### PR TITLE
fix(forms): device-tag include/exclude fields accept multiple tags

### DIFF
--- a/forward_netbox/forms.py
+++ b/forward_netbox/forms.py
@@ -10,6 +10,7 @@ from utilities.forms import get_field_value
 from utilities.forms.fields import CommentField
 from utilities.forms.rendering import FieldSet
 from utilities.forms.widgets import APISelect
+from utilities.forms.widgets import APISelectMultiple
 from utilities.forms.widgets import DateTimePicker
 from utilities.forms.widgets import HTMXSelect
 from utilities.forms.widgets import NumberWithOptions
@@ -376,7 +377,9 @@ class ForwardSourceForm(NetBoxModelForm):
         self.fields["device_tag_include_tags"] = FlexibleMultipleChoiceField(
             required=False,
             choices=(),
-            widget=APISelect(api_url="/api/plugins/forward/source/available-tags/"),
+            widget=APISelectMultiple(
+                api_url="/api/plugins/forward/source/available-tags/"
+            ),
             label="Device Tags Include",
             help_text=(
                 "Optional Forward device tags. Devices must match the selected include logic."
@@ -385,7 +388,9 @@ class ForwardSourceForm(NetBoxModelForm):
         self.fields["device_tag_exclude_tags"] = FlexibleMultipleChoiceField(
             required=False,
             choices=(),
-            widget=APISelect(api_url="/api/plugins/forward/source/available-tags/"),
+            widget=APISelectMultiple(
+                api_url="/api/plugins/forward/source/available-tags/"
+            ),
             label="Device Tags Exclude",
             help_text=(
                 "Optional Forward device tags. Devices with any selected tag are excluded."

--- a/forward_netbox/tests/test_forms.py
+++ b/forward_netbox/tests/test_forms.py
@@ -96,6 +96,28 @@ class ForwardSourceFormTest(TestCase):
             " ".join(form.non_field_errors()),
         )
 
+    def test_device_tag_fields_use_multiselect_widget(self):
+        # Regression: the include/exclude tag fields used a single-select widget
+        # (APISelect), so the browser only submitted the LAST selected tag.
+        # They must use a multiple-select widget that keeps every tag.
+        form = ForwardSourceForm()
+        for field_name in ("device_tag_include_tags", "device_tag_exclude_tags"):
+            self.assertTrue(
+                form.fields[field_name].widget.allow_multiple_selected,
+                f"{field_name} must use a multiple-select widget",
+            )
+
+    @patch("forward_netbox.forms.ForwardSource.validate_connection")
+    def test_include_tags_retain_all_submitted_values(self, _mock_validate):
+        data = self._base_form_data()
+        data["device_tag_include_tags"] = ["tag-a", "tag-b", "tag-c"]
+        form = ForwardSourceForm(data=data)
+        form.is_valid()
+        self.assertEqual(
+            list(form.cleaned_data.get("device_tag_include_tags") or []),
+            ["tag-a", "tag-b", "tag-c"],
+        )
+
 
 class ForwardSyncFormTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
Reported by an operator: the **Device Tags Include** line only kept the last tag. Root cause: the include/exclude tag fields used the single-select `APISelect` widget, so the browser submitted only one value. Fixed by switching both fields to `APISelectMultiple` (renders `<select multiple>`). Adds a regression test asserting both fields use a multi-select widget and retain all submitted tags. Targets `main` for a 1.7.x patch; 2.0 inherits it via main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)