### PR TITLE
fix: 2.0.1 — remove two 2.0.0 startup/UI regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 Generated from the README compatibility table by `scripts/gen_changelog.py`. Do not edit by hand.
 
-## v2.0.0
+## v2.0.1
+
+Patch: fixes two 2.0.0 regressions an operator hits immediately — a false `netbox_branching is not installed; syncs will fail` startup warning (the dependency check used the wrong distribution name), and a 500 on the Sync list page (`KeyError: 'available'` from a removed execution-ledger summary). No engine or data changes; drop-in upgrade from `2.0.0`
+
+## v2.0.0 — 2026-06-24
 
 Breaking 2.0 — single-branch is the only execution path. Removed the per-shard branching/fast-bootstrap/resumable executor, 10k-change budget sharding, and the execution-ledger run-history; dropped the backend/max-changes/scheduler-overlap selectors
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Forward 26.6 is the baseline for async NQE.
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.0.0` | `4.6.3` required; needs netbox-branching `1.1.0+` | Current release; Breaking 2.0 — single-branch is the only execution path. Removed the per-shard branching/fast-bootstrap/resumable executor, 10k-change budget sharding, and the execution-ledger run-history; dropped the backend/max-changes/scheduler-overlap selectors |
+| `v2.0.1` | `4.6.3` required; needs netbox-branching `1.1.0+` | Current release; Patch: fixes two 2.0.0 regressions an operator hits immediately — a false `netbox_branching is not installed; syncs will fail` startup warning (the dependency check used the wrong distribution name), and a 500 on the Sync list page (`KeyError: 'available'` from a removed execution-ledger summary). No engine or data changes; drop-in upgrade from `2.0.0` |
+| `v2.0.0` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.0.1`; Breaking 2.0 — single-branch is the only execution path. Removed the per-shard branching/fast-bootstrap/resumable executor, 10k-change budget sharding, and the execution-ledger run-history; dropped the backend/max-changes/scheduler-overlap selectors |
 | `v1.7.2` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.0.0`; Collection-gap diagnostics: per-reason backfill breakdown + staleness, growth/trend escalation, per-device collection result, ACI delete safety valve, opt-in auto-tag |
 | `v1.7.1` | `4.5.9` and `4.6.2` validated; shared branch for `4.5.x` and `4.6.x` with capability-gated 4.6 features | Superseded by `v1.7.2`; ACI BD/L3Out graduation + FHRP churn fix (replaces yanked 1.7.0 and 1.6.2) |
 | `v1.7.0` | `4.5.9` and `4.6.2` validated; shared branch for `4.5.x` and `4.6.x` with capability-gated 4.6 features | Superseded by `v1.7.1`; ACI bridge domain and L3Out NQE maps; query publish hardening |

--- a/docs/01_User_Guide/README.md
+++ b/docs/01_User_Guide/README.md
@@ -33,7 +33,8 @@ pip install forward-netbox==1.7.2
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v1.7.2` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Current release; Collection-gap diagnostics: per-reason backfill breakdown + staleness, growth/trend escalation, per-device collection result, ACI delete safety valve, opt-in auto-tag |
+| `v2.0.1` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Current release; Patch: fixes two 2.0.0 regressions an operator hits immediately — a false `netbox_branching is not installed; syncs will fail` startup warning (the dependency check used the wrong distribution name), and a 500 on the Sync list page (`KeyError: 'available'` from a removed execution-ledger summary). No engine or data changes; drop-in upgrade from `2.0.0` |
+| `v1.7.2` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.0.1`; Collection-gap diagnostics: per-reason backfill breakdown + staleness, growth/trend escalation, per-device collection result, ACI delete safety valve, opt-in auto-tag |
 | `v1.7.1` | `4.5.9` and `4.6.2` validated; shared branch for `4.5.x` and `4.6.x` with capability-gated 4.6 features | Superseded by `v1.7.2`; ACI BD/L3Out graduation + FHRP churn fix (replaces yanked 1.7.0 and 1.6.2) |
 | `v1.7.0` | `4.5.9` and `4.6.2` validated; shared branch for `4.5.x` and `4.6.x` with capability-gated 4.6 features | Superseded by `v1.7.1`; ACI bridge domain and L3Out NQE maps; query publish hardening |
 | `v1.7.0` | `4.5.9` and `4.6.2` validated; shared branch for `4.5.x` and `4.6.x` with capability-gated 4.6 features | Superseded by `v1.7.0`; ACI bridge domain and L3Out NQE maps; query publish hardening |

--- a/docs/03_Plans/active/2026-06-25-release-2.0.1.md
+++ b/docs/03_Plans/active/2026-06-25-release-2.0.1.md
@@ -1,0 +1,50 @@
+# Release 2.0.1 — Blake-facing 2.0.0 startup/UI regressions
+
+**Date:** 2026-06-25
+
+## Goal
+Ship a drop-in patch that removes the two 2.0.0 regressions an operator hits on
+upgrade, and gate it behind a real end-to-end check (clean wheel install → boot →
+render every page → POST forms → run a sync) so this class of breakage cannot
+ship again.
+
+## Constraints
+- No engine, data-model, or migration changes — patch only.
+- Must be a drop-in upgrade from 2.0.0 (no operator action beyond pip upgrade).
+- Full suite + lint + harness + sensitive gates green.
+
+## Touched Surfaces
+- `forward_netbox/__init__.py` — runtime dependency check (false "not installed" warning).
+- `forward_netbox/tables.py` — `ForwardSyncTable.render_latest_failure` (sync-list 500).
+- `pyproject.toml` — version 2.0.1.
+- `README.md` / `docs/README.md` / `docs/01_User_Guide/README.md` + `CHANGELOG.md` — release row.
+- Tests: `tests/test_runtime_dependency_check.py` (new), `tests/test_models.py` (table render guard).
+
+## Approach
+1. Dependency check: test importability of `netbox_branching` (the real "enabled"
+   signal — NetBox only loads it when listed in PLUGINS) instead of keying off a
+   single distribution name; resolve the version via the correct dist name
+   (`netboxlabs-netbox-branching`) with fallbacks. No more false warning.
+2. `render_latest_failure`: the execution-run ledger was removed in 2.0 (the
+   helpers are stubs returning `{}` / `None`); indexing `summary["available"]`
+   raised KeyError and 500'd the sync list. Re-source the cell from the
+   always-populated `ForwardIngestion.failed_change_count`.
+3. Regression tests for both; full UI page-render sweep + clean-wheel install gate.
+
+## Validation
+- Full unit suite + lint + harness + sensitive.
+- Build the 2.0.1 wheel, `pip install` into a clean NetBox, boot (no false warning),
+  GET every plugin page (empty-DB and with-data), POST sync/source add+edit forms,
+  run a scoped sync, confirm the result pages render — every step's actual result
+  recorded before release.
+
+## Rollback
+Patch is additive/defensive; reverting the two files restores 2.0.0 behaviour.
+PyPI 2.0.0 remains installable.
+
+## Decision Log
+- Root miss in 2.0.0: the engine/data path was validated exhaustively but the UI
+  pages were never rendered before release; a page-render smoke gate is now part
+  of the release check.
+- `render_latest_failure` re-sourced to `failed_change_count` (not `status` —
+  ForwardIngestion has no status field) so the column is meaningful, not a dead dash.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,8 @@ Forward 26.6 is the baseline for async NQE.
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.0.0` | `4.6.3` required; needs netbox-branching `1.1.0+` | Current release; Breaking 2.0 — single-branch is the only execution path. Removed the per-shard branching/fast-bootstrap/resumable executor, 10k-change budget sharding, and the execution-ledger run-history; dropped the backend/max-changes/scheduler-overlap selectors |
+| `v2.0.1` | `4.6.3` required; needs netbox-branching `1.1.0+` | Current release; Patch: fixes two 2.0.0 regressions an operator hits immediately — a false `netbox_branching is not installed; syncs will fail` startup warning (the dependency check used the wrong distribution name), and a 500 on the Sync list page (`KeyError: 'available'` from a removed execution-ledger summary). No engine or data changes; drop-in upgrade from `2.0.0` |
+| `v2.0.0` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.0.1`; Breaking 2.0 — single-branch is the only execution path. Removed the per-shard branching/fast-bootstrap/resumable executor, 10k-change budget sharding, and the execution-ledger run-history; dropped the backend/max-changes/scheduler-overlap selectors |
 | `v1.7.2` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.0.0`; Collection-gap diagnostics: per-reason backfill breakdown + staleness, growth/trend escalation, per-device collection result, ACI delete safety valve, opt-in auto-tag |
 | `v1.7.1` | `4.5.9` and `4.6.2` validated; shared branch for `4.5.x` and `4.6.x` with capability-gated 4.6 features | Superseded by `v1.7.2`; ACI BD/L3Out graduation + FHRP churn fix (replaces yanked 1.7.0 and 1.6.2) |
 | `v1.7.0` | `4.5.9` and `4.6.2` validated; shared branch for `4.5.x` and `4.6.x` with capability-gated 4.6 features | Superseded by `v1.7.1`; ACI bridge domain and L3Out NQE maps; query publish hardening |

--- a/forward_netbox/__init__.py
+++ b/forward_netbox/__init__.py
@@ -8,7 +8,7 @@ class NetboxForwardConfig(PluginConfig):
     name = "forward_netbox"
     verbose_name = "NetBox Forward Plugin"
     description = "Sync Forward data into NetBox using built-in NQE queries."
-    version = "2.0.0"
+    version = "2.0.1"
     base_url = "forward"
     min_version = "4.6.3"
 
@@ -20,48 +20,80 @@ class NetboxForwardConfig(PluginConfig):
 
 
 def _check_runtime_dependencies():
-    """Warn at startup about missing/dependency-version drift.
+    """Warn at startup about a missing/old ``netbox_branching`` dependency.
 
-    The resumable multi-branch executor hard-depends on the ``netbox_branching``
-    plugin; capability detection elsewhere is presence-only, so a missing or
-    surprising dependency version otherwise only surfaces mid-sync as an opaque
-    failure. This logs (never raises) so NetBox startup is unaffected, and it
-    records the resolved versions for support bundles.
+    The single-branch ingest path hard-depends on netbox-branching 1.1.0
+    internals (SquashMergeStrategy collapse/cycle-split/FK-graph, the
+    squash_dependency_graph_built signal, branch.connection_name, the
+    ObjectChange read router). A missing or pre-1.1.0 install otherwise only
+    surfaces mid-sync as an opaque failure. This logs (never raises) so NetBox
+    startup is unaffected.
+
+    "Installed and enabled" is tested by IMPORTABILITY, not the distribution
+    name: NetBox only loads the module when it is listed in PLUGINS, and the
+    PyPI distribution is ``netboxlabs-netbox-branching`` (not the import name
+    ``netbox_branching``), so keying the check off a single dist name produced a
+    false "not installed" warning on every boot even when it was active.
     """
     import logging
+
+    log = logging.getLogger("forward_netbox")
+    floor = (1, 1, 0)
+    label = "netbox_branching"
+
+    try:
+        import netbox_branching  # noqa: F401
+    except Exception:
+        log.warning(
+            "forward_netbox requires the %s plugin for branch-staged syncs, but "
+            "it is not installed/enabled; syncs will fail. Install "
+            "netboxlabs-netbox-branching (>=1.1.0), add 'netbox_branching' to "
+            "PLUGINS in configuration.py, and run migrations.",
+            label,
+        )
+        return
+
+    resolved = _resolved_branching_version()
+    if resolved is None:
+        # Installed/importable but the version could not be resolved (unusual
+        # packaging). Do not cry wolf — the import succeeded, so syncs can run.
+        log.info("forward_netbox runtime dependency %s installed", label)
+        return
+
+    log.info("forward_netbox runtime dependency %s==%s", label, resolved)
+    if _version_tuple(resolved) < floor:
+        log.warning(
+            "forward_netbox requires %s>=%s but found %s; syncs will fail (the "
+            "plugin reuses netbox-branching 1.1.0 internals). Upgrade "
+            "netboxlabs-netbox-branching.",
+            label,
+            ".".join(str(part) for part in floor),
+            resolved,
+        )
+
+
+def _resolved_branching_version():
+    """Best-effort netbox-branching version, robust to the distribution name.
+
+    The PyPI distribution is ``netboxlabs-netbox-branching``; older/forks may use
+    ``netbox-branching``. Fall back to the module's ``__version__``.
+    """
     from importlib.metadata import PackageNotFoundError
     from importlib.metadata import version
 
-    log = logging.getLogger("forward_netbox")
-    # The single-branch ingest path reuses netbox-branching 1.1.0 internals
-    # (SquashMergeStrategy collapse/cycle-split/FK-graph, the
-    # squash_dependency_graph_built signal, branch.connection_name, the ObjectChange
-    # read router). A pre-1.1.0 install would fail opaquely mid-merge, so assert the
-    # floor at startup (log-only; never blocks NetBox boot).
-    required = {"netbox-branching": (1, 1, 0)}
-    for dist, label in (("netbox-branching", "netbox_branching"),):
+    for dist in ("netboxlabs-netbox-branching", "netbox-branching"):
         try:
-            resolved = version(dist)
-            log.info("forward_netbox runtime dependency %s==%s", label, resolved)
-            floor = required.get(dist)
-            if floor and _version_tuple(resolved) < floor:
-                log.warning(
-                    "forward_netbox requires %s>=%s but found %s; syncs will fail "
-                    "(the plugin reuses netbox-branching 1.1.0 internals). Upgrade "
-                    "netbox-branching.",
-                    label,
-                    ".".join(str(part) for part in floor),
-                    resolved,
-                )
+            return version(dist)
         except PackageNotFoundError:
-            log.warning(
-                "forward_netbox requires the %s plugin for branch-staged syncs, "
-                "but it is not installed; syncs will fail. Install and enable "
-                "netbox_branching.",
-                label,
-            )
+            continue
         except Exception:  # pragma: no cover - never block startup
-            pass
+            return None
+    try:
+        import netbox_branching
+
+        return getattr(netbox_branching, "__version__", None)
+    except Exception:  # pragma: no cover - never block startup
+        return None
 
 
 def _version_tuple(value):

--- a/forward_netbox/tables.py
+++ b/forward_netbox/tables.py
@@ -16,8 +16,6 @@ from .models import ForwardNQEMap
 from .models import ForwardSource
 from .models import ForwardSync
 from .models import ForwardValidationRun
-from .utilities.execution_ledger import execution_run_failure_summary
-from .utilities.execution_ledger import latest_execution_run
 from .utilities.json_safe import json_safe_value
 
 
@@ -90,13 +88,15 @@ class ForwardSyncTable(NetBoxTable):
         return getattr(value, "name", "---") if value else "---"
 
     def render_latest_failure(self, value, record):
-        summary = execution_run_failure_summary(latest_execution_run(record))
-        if not summary["available"]:
+        # 2.0 removed the execution-run ledger; surface the latest ingestion's
+        # failed-change count (the always-populated 2.0 failure signal) instead.
+        ingestion = record.forwardingestion_set.last()
+        failed = getattr(ingestion, "failed_change_count", 0) or 0
+        if not failed:
             return "---"
         return format_html(
-            '<span title="{}">{}</span>',
-            summary["error"],
-            summary["message"],
+            '<span class="text-danger">{}</span>',
+            _("{n} failed change(s)").format(n=failed),
         )
 
     class Meta(NetBoxTable.Meta):

--- a/forward_netbox/tests/test_models.py
+++ b/forward_netbox/tests/test_models.py
@@ -1591,6 +1591,23 @@ class ForwardSyncModelTest(TestCase):
     def test_sync_table_shows_scheduled_by_default(self):
         self.assertIn("scheduled", ForwardSyncTable.Meta.default_columns)
 
+    def test_sync_table_latest_failure_renders_without_ledger(self):
+        # Regression: render_latest_failure called the removed execution-ledger
+        # stubs and indexed summary["available"] -> KeyError, 500'ing the sync
+        # list page in 2.0. It must render from the ingestion's failed-change
+        # count and never crash.
+        from forward_netbox.models import ForwardIngestion
+
+        sync = ForwardSync.objects.create(name="lf-sync", source=self.source)
+        table = ForwardSyncTable(ForwardSync.objects.filter(pk=sync.pk))
+        # No ingestion -> graceful dash.
+        self.assertEqual(table.render_latest_failure(value=None, record=sync), "---")
+        # Failed changes -> surfaced count, still no crash.
+        ForwardIngestion.objects.create(sync=sync, failed_change_count=3)
+        rendered = str(table.render_latest_failure(value=None, record=sync))
+        self.assertIn("3", rendered)
+        self.assertNotIn("available", rendered)
+
     @patch("forward_netbox.models.ForwardSource.get_client")
     @patch(
         "forward_netbox.utilities.single_branch_executor.ForwardSingleBranchExecutor"

--- a/forward_netbox/tests/test_runtime_dependency_check.py
+++ b/forward_netbox/tests/test_runtime_dependency_check.py
@@ -1,0 +1,59 @@
+import logging
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from forward_netbox import _check_runtime_dependencies
+from forward_netbox import _resolved_branching_version
+
+
+class RuntimeDependencyCheckTest(SimpleTestCase):
+    """Guards the netbox_branching startup dependency check.
+
+    Regression: the check keyed off the distribution name ``netbox-branching``,
+    but the PyPI distribution is ``netboxlabs-netbox-branching`` — so
+    importlib.metadata.version() always raised PackageNotFoundError and the
+    plugin logged a false "netbox_branching is not installed; syncs will fail"
+    warning on EVERY boot, even when branching was installed and active.
+    """
+
+    def _capture(self):
+        logger = logging.getLogger("forward_netbox")
+        with self.assertLogs(logger, level="INFO") as cm:
+            _check_runtime_dependencies()
+        return "\n".join(cm.output)
+
+    def test_resolves_version_by_correct_distribution_name(self):
+        # netbox-branching is installed as the netboxlabs-netbox-branching dist.
+        self.assertIsNotNone(_resolved_branching_version())
+
+    def test_no_false_not_installed_warning_when_installed(self):
+        out = self._capture()
+        self.assertNotIn("not installed", out)
+        self.assertNotIn("syncs will fail", out)
+
+    def test_warns_when_below_floor(self):
+        with patch("forward_netbox._resolved_branching_version", return_value="1.0.4"):
+            out = self._capture()
+        self.assertIn("netbox_branching>=1.1.0", out)
+        self.assertIn("syncs will fail", out)
+
+    def test_warns_when_not_importable(self):
+        real_import = (
+            __builtins__["__import__"]
+            if isinstance(__builtins__, dict)
+            else __builtins__.__import__
+        )
+
+        def fake_import(name, *args, **kwargs):
+            if name == "netbox_branching":
+                raise ImportError("simulated missing plugin")
+            return real_import(name, *args, **kwargs)
+
+        logger = logging.getLogger("forward_netbox")
+        with patch("builtins.__import__", side_effect=fake_import):
+            with self.assertLogs(logger, level="WARNING") as cm:
+                _check_runtime_dependencies()
+        out = "\n".join(cm.output)
+        self.assertIn("not installed/enabled", out)
+        self.assertIn("PLUGINS", out)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "forward-netbox"
-version = "2.0.0"
+version = "2.0.1"
 description = "NetBox plugin to sync Forward data into NetBox via built-in NQE queries"
 authors = ["Craig Johnson <craigjohnson@forwardnetworks.com>"]
 license = "MIT"


### PR DESCRIPTION
Two regressions an operator hits immediately on upgrading to 2.0.0:

- **False startup warning** — `netbox_branching is not installed; syncs will fail` logged on every boot. The check used `version("netbox-branching")` but the distribution is `netboxlabs-netbox-branching`, so it always raised `PackageNotFoundError` even though branching was installed + active. Now tests importability (the real enabled signal) + resolves the version via the correct dist name with fallbacks.
- **Sync list page 500** — `KeyError: 'available'`. `render_latest_failure` called the execution-run ledger helpers (2.0 stubs returning `{}`/`None`) then indexed `summary["available"]`. Re-sourced from the always-populated `ForwardIngestion.failed_change_count`.

No engine/model/migration changes — drop-in from 2.0.0. Regression tests added; full page-render sweep (with-data + empty-state) + boot check clean; suite 884 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)