### PR TITLE
fix: render brand bar without leaking its template comment

### DIFF
--- a/forward_netbox/templates/forward_netbox/inc/brand_bar.html
+++ b/forward_netbox/templates/forward_netbox/inc/brand_bar.html
@@ -1,7 +1,9 @@
 {% load static %}
 {% load i18n %}
-{# Forward Field Integration brand bar. Self-contained, theme-aware (logo wordmark
-   uses currentColor), no global NetBox style overrides. #ff3506 is Forward's accent. #}
+{% comment %}
+Forward Field Integration brand bar. Self-contained, theme-aware (logo wordmark
+uses currentColor), no global NetBox style overrides. ff3506 is Forward's accent.
+{% endcomment %}
 <style>
 .fwd-brand-bar{display:flex;align-items:center;gap:.55rem;padding:.35rem .7rem;margin-bottom:1rem;border-left:3px solid #ff3506;border-radius:4px;background:rgba(255,53,6,.05);}
 .fwd-brand-bar .fwd-logo{height:15px;width:auto;display:block;}

--- a/forward_netbox/tests/test_brand_bar.py
+++ b/forward_netbox/tests/test_brand_bar.py
@@ -1,0 +1,18 @@
+from django.template.loader import render_to_string
+from django.test import TestCase
+
+
+class BrandBarTemplateTest(TestCase):
+    """The Forward Field Integration brand bar must render the logo + label, and
+    must NOT leak its template comment as visible text (a multi-line {# #} comment
+    is not a comment in Django and rendered literally on the page)."""
+
+    def test_brand_bar_renders_without_leaking_comment(self):
+        html = render_to_string("forward_netbox/inc/brand_bar.html")
+        self.assertIn("fwd-brand-bar", html)
+        self.assertIn("Field Integration", html)
+        self.assertIn("fn-logo.svg", html)
+        # The {% comment %} block must be stripped — none of its words appear.
+        self.assertNotIn("Self-contained", html)
+        self.assertNotIn("theme-aware", html)
+        self.assertNotIn("currentColor", html)


### PR DESCRIPTION
The brand-bar include opened with a multi-line `{# ... #}` comment. Django's `{# #}` is single-line only, so it rendered as literal text above the logo on every plugin page. Replaced with `{% comment %}{% endcomment %}`.

Staged for the next release (no version bump). Regression test asserts the comment text never appears in the rendered include.

🤖 Generated with [Claude Code](https://claude.com/claude-code)