### PR TITLE
fix: 2.1.5 — Prune orphans errored on empty sites holding a VLAN/VM/prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Generated from the README compatibility table by `scripts/gen_changelog.py`. Do not edit by hand.
 
+## v2.1.5
+
+Fix Prune orphans erroring on empty sites that still hold a VLAN/VM/prefix (delete only truly-empty sites)
+
 ## v2.1.4
 
 Tag delete-eligible global IPAM (prefixes/VLANs/VRFs) for manual review

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Forward 26.6 is the baseline for async NQE.
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.1.4` | `4.6.3` required; needs netbox-branching `1.1.0+` | Current release; Tag delete-eligible global IPAM (prefixes/VLANs/VRFs) for manual review |
+| `v2.1.5` | `4.6.3` required; needs netbox-branching `1.1.0+` | Current release; Fix Prune orphans erroring on empty sites that still hold a VLAN/VM/prefix (delete only truly-empty sites) |
+| `v2.1.4` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.1.5`; Tag delete-eligible global IPAM (prefixes/VLANs/VRFs) for manual review |
 | `v2.1.3` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.1.4`; Prune empty orphan sites (zero devices + zero racks) alongside out-of-scope devices |
 | `v2.1.3` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.1.3`; Prune empty orphan sites (zero devices + zero racks) alongside out-of-scope devices |
 | `v2.1.2` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.1.3`; Feature + docs: (1) new out-of-scope orphan health signal — the sync health summary now shows how many NetBox devices match none of the included Forward tags (removable via Scope Reconciliation -> Prune orphans), mirroring the backfilled signal, via a self-healing `forward-out-of-scope` device tag and a `?tag=forward-out-of-scope` filter; (2) docs: the "no covering prefix" diagnostic now names /32 and /128 host addresses (loopbacks, anycast, some VIPs), and the Operations Guide documents backfilled (in-scope, kept) vs out-of-scope (removable) devices. Drop-in from `2.1.1`. |

--- a/docs/01_User_Guide/README.md
+++ b/docs/01_User_Guide/README.md
@@ -33,7 +33,8 @@ pip install forward-netbox==1.7.2
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.1.4` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Current release; Tag delete-eligible global IPAM (prefixes/VLANs/VRFs) for manual review |
+| `v2.1.5` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Current release; Fix Prune orphans erroring on empty sites that still hold a VLAN/VM/prefix (delete only truly-empty sites) |
+| `v2.1.4` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.1.5`; Tag delete-eligible global IPAM (prefixes/VLANs/VRFs) for manual review |
 | `v2.1.3` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.1.4`; Prune empty orphan sites (zero devices + zero racks) alongside out-of-scope devices |
 | `v2.1.3` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.1.3`; Prune empty orphan sites (zero devices + zero racks) alongside out-of-scope devices |
 | `v2.1.2` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.1.3`; Feature + docs: (1) new out-of-scope orphan health signal — the sync health summary now shows how many NetBox devices match none of the included Forward tags (removable via Scope Reconciliation -> Prune orphans), mirroring the backfilled signal, via a self-healing `forward-out-of-scope` device tag and a `?tag=forward-out-of-scope` filter; (2) docs: the "no covering prefix" diagnostic now names /32 and /128 host addresses (loopbacks, anycast, some VIPs), and the Operations Guide documents backfilled (in-scope, kept) vs out-of-scope (removable) devices. Drop-in from `2.1.1`. |

--- a/docs/03_Plans/active/2026-06-29-fix-site-prune-protected-error.md
+++ b/docs/03_Plans/active/2026-06-29-fix-site-prune-protected-error.md
@@ -1,0 +1,71 @@
+# Fix site prune ProtectedError (empty-site prune never ran)
+
+**Date:** 2026-06-29
+
+## Goal
+Make "Prune orphans" reliably delete empty orphan sites. On a real field sync it
+errored in ~2s with an empty Error field and `data: null`; the Scope
+Reconciliation preview correctly showed 152 empty orphan sites, but none were
+deleted.
+
+Root cause: `prune_orphan_sites` (shipped 2.1.3) treated a site as "empty" if it
+had zero devices AND zero racks, then deleted all candidates in one
+`transaction.atomic()` batch. But a NetBox Site is `PROTECT`-ed by more than
+devices/racks — `dcim.PowerPanel`, `ipam.VLAN`, and `virtualization.VirtualMachine`
+also PROTECT. A candidate still holding a VLAN/VM/power panel raised
+`ProtectedError`, and the single atomic block rolled the whole prune back → job
+errored, zero sites deleted, `data: null`. Separately `ipam.Prefix`,
+`dcim.Location`, `virtualization.Cluster`, `wireless.WirelessLAN`, and
+circuit/cable terminations are `CASCADE` — deleting such a site would have
+silently destroyed those children (latent data loss).
+
+## Constraints
+- Only delete a site that is **truly empty** — nothing references it via any
+  reverse relation. A site with any remaining object is kept.
+- Preview and prune must use the same emptiness rule so the count matches what is
+  deleted.
+- No deletion when the Forward scope returned 0 devices or no location data
+  (existing guards retained).
+
+## Touched Surfaces
+- `forward_netbox/utilities/scope_reconciliation.py` — `_occupied_site_ids()`;
+  preview (`compute_scope_reconciliation`) + `prune_orphan_sites` use it; per-site
+  delete with a `ProtectedError` guard.
+- `forward_netbox/jobs.py` — `prune_forward_orphans` records the exception into
+  `job.data` (`{"error", "error_type"}`) before terminating, so a failure is
+  visible in the UI instead of an empty Error + null data.
+- `forward_netbox/tests/test_scope_module_ui.py` —
+  `test_prune_keeps_sites_with_non_device_objects`.
+
+## Approach
+`_occupied_site_ids()` unions the site foreign key of every reverse relation
+(skipping many-to-many) so a site counts as occupied if anything points to it.
+The prune lists candidates not in `forward_site_slugs` and not occupied, then
+deletes them one at a time, catching `ProtectedError` (reported as `skipped`) so
+an uncovered relation can't abort the run.
+
+## Validation
+`test_scope_module_ui` (11 tests, incl. the new regression) green on NetBox
+4.6.3. The new test crashes with `ProtectedError` under the old batch code and
+passes with the fix. Lint/harness/sensitive. Prefix preservation asserted (no
+cascade delete).
+
+## Rollback
+Revert the three surfaces; `pip install forward-netbox==2.1.4`.
+
+## Decision Log
+- "Truly empty" (no references at all) over "no devices/racks": matches the
+  stated intent ("only delete if truly empty"), and avoids both the PROTECT crash
+  and the CASCADE data loss in one rule.
+- Per-site delete + `ProtectedError` catch as defense in depth: the occupancy
+  union should already exclude protected sites, but a relation added in a future
+  NetBox version (or a GenericForeignKey not in `related_objects`) must not
+  re-break the whole prune.
+
+## Bundled changes
+- Fix: "Prune orphans" now reliably removes empty orphan sites. A site is pruned
+  only when nothing references it (no devices, racks, VLANs, prefixes, VMs, power
+  panels, locations, …), so the prune no longer aborts with a NetBox
+  ProtectedError on sites that still hold a VLAN/VM/power panel, and never
+  cascade-deletes a child object. Prune-job failures are now surfaced in the
+  job's Data panel. Drop-in from `2.1.4`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,8 @@ Forward 26.6 is the baseline for async NQE.
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.1.4` | `4.6.3` required; needs netbox-branching `1.1.0+` | Current release; Tag delete-eligible global IPAM (prefixes/VLANs/VRFs) for manual review |
+| `v2.1.5` | `4.6.3` required; needs netbox-branching `1.1.0+` | Current release; Fix Prune orphans erroring on empty sites that still hold a VLAN/VM/prefix (delete only truly-empty sites) |
+| `v2.1.4` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.1.5`; Tag delete-eligible global IPAM (prefixes/VLANs/VRFs) for manual review |
 | `v2.1.3` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.1.4`; Prune empty orphan sites (zero devices + zero racks) alongside out-of-scope devices |
 | `v2.1.3` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.1.3`; Prune empty orphan sites (zero devices + zero racks) alongside out-of-scope devices |
 | `v2.1.2` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.1.3`; Feature + docs: (1) new out-of-scope orphan health signal — the sync health summary now shows how many NetBox devices match none of the included Forward tags (removable via Scope Reconciliation -> Prune orphans), mirroring the backfilled signal, via a self-healing `forward-out-of-scope` device tag and a `?tag=forward-out-of-scope` filter; (2) docs: the "no covering prefix" diagnostic now names /32 and /128 host addresses (loopbacks, anycast, some VIPs), and the Operations Guide documents backfilled (in-scope, kept) vs out-of-scope (removable) devices. Drop-in from `2.1.1`. |

--- a/forward_netbox/__init__.py
+++ b/forward_netbox/__init__.py
@@ -8,7 +8,7 @@ class NetboxForwardConfig(PluginConfig):
     name = "forward_netbox"
     verbose_name = "Forward Field Integration"
     description = "Sync Forward data into NetBox using built-in NQE queries."
-    version = "2.1.4"
+    version = "2.1.5"
     base_url = "forward"
     min_version = "4.6.3"
 

--- a/forward_netbox/jobs.py
+++ b/forward_netbox/jobs.py
@@ -311,6 +311,13 @@ def prune_forward_orphans(job, *args, **kwargs):
         job.terminate(status=JobStatusChoices.STATUS_ERRORED)
         logger.error(exc)
     except Exception as exc:
+        # Record the failure on the job so it is visible in the UI (the Data panel)
+        # instead of an empty Error field with null data.
+        job.data = {
+            "error": str(exc) or exc.__class__.__name__,
+            "error_type": exc.__class__.__name__,
+        }
+        job.save(update_fields=["data"])
         job.terminate(status=JobStatusChoices.STATUS_ERRORED)
         if type(exc) in (SyncError, JobTimeoutException):
             logger.error(exc)

--- a/forward_netbox/tests/test_scope_module_ui.py
+++ b/forward_netbox/tests/test_scope_module_ui.py
@@ -238,6 +238,41 @@ class ScopeModuleUiTest(TestCase):
         # site-u has a rack → kept despite not being in Forward locations.
         self.assertTrue(Site.objects.filter(slug="site-u").exists())
 
+    def test_prune_keeps_sites_with_non_device_objects(self):
+        # Regression: a site empty of devices+racks but still holding a VLAN
+        # (PROTECT) or a prefix (CASCADE) is NOT truly empty. Deleting it would
+        # either raise ProtectedError (aborting the whole prune) or silently
+        # cascade-delete the prefix. Such sites must be kept; only a site nothing
+        # references is pruned.
+        from ipam.models import Prefix
+        from ipam.models import VLAN
+
+        from forward_netbox.utilities.scope_reconciliation import prune_orphan_sites
+
+        Rack.objects.create(name="rack-keep", site=self.site)  # keeps setUp's site-u
+        site_vlan = Site.objects.create(name="Site Vlan", slug="site-vlan")
+        site_prefix = Site.objects.create(name="Site Prefix", slug="site-prefix")
+        Site.objects.create(name="Site Empty", slug="site-empty")
+        VLAN.objects.create(vid=10, name="v10", site=site_vlan)  # PROTECT
+        # NetBox 4.x scopes a prefix via the generic `scope` (mirrored to _site).
+        Prefix.objects.create(prefix="10.0.0.0/24", scope=site_prefix)  # CASCADE
+
+        report = {
+            "_tagged_names": {"dev-x"},
+            "_forward_site_slugs": {"site-active"},  # none of the above are in-scope
+        }
+        result = prune_orphan_sites(self.sync, report=report)
+
+        # Only the truly-empty orphan is pruned; no ProtectedError raised.
+        self.assertEqual(result["pruned_site_count"], 1)
+        self.assertFalse(Site.objects.filter(slug="site-empty").exists())
+        # VLAN-bearing and prefix-bearing sites are kept; the prefix survives.
+        self.assertTrue(Site.objects.filter(slug="site-vlan").exists())
+        self.assertTrue(Site.objects.filter(slug="site-prefix").exists())
+        self.assertTrue(Prefix.objects.filter(prefix="10.0.0.0/24").exists())
+        # site-u (rack) kept.
+        self.assertTrue(Site.objects.filter(slug="site-u").exists())
+
     def test_collection_gap_alert_command_breaches_and_tags(self):
         import json
         from io import StringIO

--- a/forward_netbox/utilities/scope_reconciliation.py
+++ b/forward_netbox/utilities/scope_reconciliation.py
@@ -180,12 +180,10 @@ def compute_scope_reconciliation(sync) -> dict:
 
     # Compute empty orphan sites for the preview (current DB state; prune re-queries
     # after device deletion so sites that become empty then are also removed).
-    from dcim.models import Rack, Site
+    from dcim.models import Site
 
     if forward_site_slugs:
-        device_site_ids = set(Device.objects.values_list("site_id", flat=True))
-        rack_site_ids = set(Rack.objects.values_list("site_id", flat=True))
-        occupied_site_ids = device_site_ids | rack_site_ids
+        occupied_site_ids = _occupied_site_ids()
         empty_orphan_sites = list(
             Site.objects.exclude(slug__in=forward_site_slugs)
             .exclude(pk__in=occupied_site_ids)
@@ -260,14 +258,52 @@ def prune_orphan_devices(sync, *, report=None) -> dict:
     }
 
 
-def prune_orphan_sites(sync, *, report=None) -> dict:
-    """Delete empty NetBox sites absent from the sync's Forward location scope.
+def _occupied_site_ids() -> set:
+    """Site PKs referenced by ANY related object (FK), across every relation.
 
-    Only removes sites with zero devices AND zero racks. Re-queries current DB
-    state so sites that became empty after device prune are also removed.
-    Safety: refuses when the Forward scope returned 0 devices or no location data.
+    A site is "truly empty" only when nothing points to it. We union the site
+    foreign keys of every reverse relation (devices, racks, prefixes, VLANs, VMs,
+    power panels, locations, clusters, wireless LANs, circuit/cable terminations,
+    …) rather than just devices+racks. This matters for two reasons NetBox's own
+    FK ``on_delete`` rules impose:
+      * PROTECT (Device, Rack, PowerPanel, VLAN, VirtualMachine) — deleting a site
+        that still has one of these raises ``ProtectedError``.
+      * CASCADE (Prefix, Location, Cluster, WirelessLAN, CircuitTermination) —
+        deleting the site would silently destroy those children.
+    Either way such a site is not "truly empty" and must be kept. Many-to-many
+    relations (e.g. ConfigContext.sites) do not pin a site and are skipped.
     """
-    from dcim.models import Rack, Site
+    from dcim.models import Site
+
+    occupied = set()
+    for rel in Site._meta.related_objects:
+        if rel.many_to_many:
+            continue
+        attname = rel.field.attname  # e.g. "site_id" / "_site_id"
+        occupied.update(
+            rel.related_model.objects.exclude(**{attname: None}).values_list(
+                attname, flat=True
+            )
+        )
+    occupied.discard(None)
+    return occupied
+
+
+def prune_orphan_sites(sync, *, report=None) -> dict:
+    """Delete truly-empty NetBox sites absent from the sync's Forward location scope.
+
+    Only removes sites that nothing references (no devices, racks, prefixes, VLANs,
+    VMs, power panels, locations, clusters, …) — see ``_occupied_site_ids``. A site
+    with any remaining object is kept, so the prune neither hits a NetBox PROTECT
+    error nor cascade-deletes child objects. Re-queries current DB state so sites
+    emptied by the device prune in the same job are also removed. Deletes one site
+    at a time and skips any that unexpectedly raise ``ProtectedError`` so a single
+    surprise relation cannot abort the whole prune. Safety: refuses when the
+    Forward scope returned 0 devices or no location data.
+    """
+    from django.db.models.deletion import ProtectedError
+
+    from dcim.models import Site
 
     if report is None:
         report = compute_scope_reconciliation(sync)
@@ -277,26 +313,32 @@ def prune_orphan_sites(sync, *, report=None) -> dict:
         )
     forward_site_slugs = report.get("_forward_site_slugs") or set()
     if not forward_site_slugs:
-        return {"pruned_site_count": 0, "pruned_site_object_count": 0}
-    device_site_ids = set(Device.objects.values_list("site_id", flat=True))
-    rack_site_ids = set(Rack.objects.values_list("site_id", flat=True))
-    occupied_site_ids = device_site_ids | rack_site_ids
+        return {"pruned_site_count": 0, "pruned_site_object_count": 0, "skipped": 0}
+    occupied_site_ids = _occupied_site_ids()
     prunable_pks = list(
         Site.objects.exclude(slug__in=forward_site_slugs)
         .exclude(pk__in=occupied_site_ids)
         .values_list("pk", flat=True)
     )
     if not prunable_pks:
-        return {"pruned_site_count": 0, "pruned_site_object_count": 0}
+        return {"pruned_site_count": 0, "pruned_site_object_count": 0, "skipped": 0}
+    pruned_sites = 0
     pruned_objects = 0
-    with transaction.atomic():
-        for start in range(0, len(prunable_pks), 500):
-            batch = prunable_pks[start : start + 500]
-            deleted, _ = Site.objects.filter(pk__in=batch).delete()
+    skipped = 0
+    for pk in prunable_pks:
+        try:
+            with transaction.atomic():
+                deleted, _ = Site.objects.filter(pk=pk).delete()
+            pruned_sites += 1
             pruned_objects += deleted
+        except ProtectedError:
+            # A relation not covered by the occupancy union still pins this site;
+            # leave it rather than fail the whole prune.
+            skipped += 1
     return {
-        "pruned_site_count": len(prunable_pks),
+        "pruned_site_count": pruned_sites,
         "pruned_site_object_count": pruned_objects,
+        "skipped": skipped,
     }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "forward-netbox"
-version = "2.1.4"
+version = "2.1.5"
 description = "NetBox plugin to sync Forward data into NetBox via built-in NQE queries"
 authors = ["Craig Johnson <craigjohnson@forwardnetworks.com>"]
 license = "MIT"


### PR DESCRIPTION
**Symptom:** On a real field sync, "Prune orphans" errored in ~2s with an empty Error field and `data: null`; the preview correctly showed 152 empty orphan sites, none deleted.

**Cause:** `prune_orphan_sites` (2.1.3) only excluded sites with devices+racks, but NetBox also PROTECTs a Site delete via `PowerPanel`, `ipam.VLAN`, and `VirtualMachine`. A candidate still holding one raised `ProtectedError`, and the single `atomic()` batch rolled back the entire prune. (CASCADE relations like `Prefix`/`Location` would also have silently cascade-deleted.)

**Fix:**
- `_occupied_site_ids()` — prune only **truly-empty** sites (nothing references them via any reverse FK); shared by preview + prune so the count matches what's deleted.
- Per-site delete with a `ProtectedError` guard so one oddball can't abort the whole prune.
- `prune_forward_orphans` records the exception into `job.data` so failures are visible in the UI.

11/11 `test_scope_module_ui` green on NetBox 4.6.3 (new regression test crashes under the old code). Drop-in from 2.1.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)