### PR TITLE
fix: 2.1.6 — devices mis-assigned the ACI platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Generated from the README compatibility table by `scripts/gen_changelog.py`. Do not edit by hand.
 
+## v2.1.6
+
+Fix devices mis-assigned the ACI platform (CUSTOM command wrongly treated as an ACI signal)
+
 ## v2.1.5
 
 Fix Prune orphans erroring on empty sites that still hold a VLAN/VM/prefix (delete only truly-empty sites)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Forward 26.6 is the baseline for async NQE.
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.1.5` | `4.6.3` required; needs netbox-branching `1.1.0+` | Current release; Fix Prune orphans erroring on empty sites that still hold a VLAN/VM/prefix (delete only truly-empty sites) |
+| `v2.1.6` | `4.6.3` required; needs netbox-branching `1.1.0+` | Current release; Fix devices mis-assigned the ACI platform (CUSTOM command wrongly treated as an ACI signal) |
+| `v2.1.5` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.1.6`; Fix Prune orphans erroring on empty sites that still hold a VLAN/VM/prefix (delete only truly-empty sites) |
 | `v2.1.4` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.1.5`; Tag delete-eligible global IPAM (prefixes/VLANs/VRFs) for manual review |
 | `v2.1.3` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.1.4`; Prune empty orphan sites (zero devices + zero racks) alongside out-of-scope devices |
 | `v2.1.3` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.1.3`; Prune empty orphan sites (zero devices + zero racks) alongside out-of-scope devices |

--- a/docs/01_User_Guide/README.md
+++ b/docs/01_User_Guide/README.md
@@ -33,7 +33,8 @@ pip install forward-netbox==1.7.2
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.1.5` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Current release; Fix Prune orphans erroring on empty sites that still hold a VLAN/VM/prefix (delete only truly-empty sites) |
+| `v2.1.6` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Current release; Fix devices mis-assigned the ACI platform (CUSTOM command wrongly treated as an ACI signal) |
+| `v2.1.5` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.1.6`; Fix Prune orphans erroring on empty sites that still hold a VLAN/VM/prefix (delete only truly-empty sites) |
 | `v2.1.4` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.1.5`; Tag delete-eligible global IPAM (prefixes/VLANs/VRFs) for manual review |
 | `v2.1.3` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.1.4`; Prune empty orphan sites (zero devices + zero racks) alongside out-of-scope devices |
 | `v2.1.3` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.1.3`; Prune empty orphan sites (zero devices + zero racks) alongside out-of-scope devices |

--- a/docs/03_Plans/active/2026-06-29-release-2.1.6-platform-aci-misclassification.md
+++ b/docs/03_Plans/active/2026-06-29-release-2.1.6-platform-aci-misclassification.md
@@ -1,0 +1,56 @@
+# Release 2.1.6 — fix platform mis-classified as ACI
+
+**Date:** 2026-06-29
+
+## Goal
+Fix nearly every device being assigned the NetBox platform "ACI". On the field
+network 5043 of 5285 devices classified ACI (Fortinet, Palo Alto, Cisco
+non-fabric all included); only 512 are genuine Cisco ACI/APIC.
+
+Root cause: `deviceHasAciCommandOutputs` in `queries/netbox_utilities.nqe`
+included `CommandType.CUSTOM` in its ACI-detection allowlist. `CUSTOM` is the
+generic catch-all command type present on almost every device (926 of 937
+Fortinet/Palo devices carry one), so any device with a custom command was
+classified ACI via `isAciDevice` → `normalizeDevicePlatformName` → "ACI". The
+other allowlist entries are all genuinely ACI-specific (`CISCO_APIC_*` /
+`CISCO_ACI_*`).
+
+## Constraints
+- Must not under-classify genuine ACI fabric. Verified live: all 512 real ACI
+  devices carry a specific `CISCO_ACI_*`/`CISCO_APIC_*` command, so they stay
+  classified after removing `CUSTOM`; 0 Fortinet/Palo remain ACI.
+- `.nqe`-only change → the bundled queries must be re-published to the Forward
+  org for the fix to take effect on existing syncs (see Validation).
+
+## Touched Surfaces
+- `forward_netbox/queries/netbox_utilities.nqe` — remove `CommandType.CUSTOM`
+  from the `deviceHasAciCommandOutputs` allowlist.
+- Version bump: `pyproject.toml`, `forward_netbox/__init__.py`, the 3 README
+  tables, `CHANGELOG.md`.
+
+## Approach
+Drop the one over-broad enum from the allowlist; the specific ACI/APIC command
+types remain and are sufficient to detect real fabric nodes.
+
+## Validation
+Live proof against the field snapshot (1329953): ACI classification drops from
+5043 → 512 devices, all 512 Cisco APIC; Fortinet/Palo still-ACI = 0. NQE smoke
+sync `forward_smoke_sync --validate-only`. Lint/harness/sensitive. After release,
+re-publish the bundled queries to the Forward org so the corrected classification
+reaches live syncs.
+
+## Rollback
+Revert the one-line allowlist change; `pip install forward-netbox==2.1.5`.
+
+## Decision Log
+- Remove `CUSTOM` rather than add negative guards: `CUSTOM` is simply not an
+  ACI-specific signal; the specific `CISCO_ACI_*`/`CISCO_APIC_*` types already
+  cover genuine fabric, confirmed live (512 Cisco APIC retain it).
+
+## Bundled changes
+- Fix: devices are no longer mis-assigned the "ACI" platform. The ACI detection
+  no longer treats the generic `CUSTOM` collection command as an ACI signal, so
+  Fortinet/Palo Alto/Cisco non-fabric devices keep their real platform; genuine
+  Cisco ACI/APIC fabric (identified by the specific ACI/APIC command types) is
+  unaffected. Re-publish the bundled queries to take effect on existing syncs.
+  Drop-in from `2.1.5`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,8 @@ Forward 26.6 is the baseline for async NQE.
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.1.5` | `4.6.3` required; needs netbox-branching `1.1.0+` | Current release; Fix Prune orphans erroring on empty sites that still hold a VLAN/VM/prefix (delete only truly-empty sites) |
+| `v2.1.6` | `4.6.3` required; needs netbox-branching `1.1.0+` | Current release; Fix devices mis-assigned the ACI platform (CUSTOM command wrongly treated as an ACI signal) |
+| `v2.1.5` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.1.6`; Fix Prune orphans erroring on empty sites that still hold a VLAN/VM/prefix (delete only truly-empty sites) |
 | `v2.1.4` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.1.5`; Tag delete-eligible global IPAM (prefixes/VLANs/VRFs) for manual review |
 | `v2.1.3` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.1.4`; Prune empty orphan sites (zero devices + zero racks) alongside out-of-scope devices |
 | `v2.1.3` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.1.3`; Prune empty orphan sites (zero devices + zero racks) alongside out-of-scope devices |

--- a/forward_netbox/__init__.py
+++ b/forward_netbox/__init__.py
@@ -8,7 +8,7 @@ class NetboxForwardConfig(PluginConfig):
     name = "forward_netbox"
     verbose_name = "Forward Field Integration"
     description = "Sync Forward data into NetBox using built-in NQE queries."
-    version = "2.1.5"
+    version = "2.1.6"
     base_url = "forward"
     min_version = "4.6.3"
 

--- a/forward_netbox/queries/netbox_utilities.nqe
+++ b/forward_netbox/queries/netbox_utilities.nqe
@@ -99,7 +99,6 @@ export deviceHasAciCommandOutputs(device: Device) =
       where command.commandType in [
         CommandType.CISCO_APIC_SWITCH,
         CommandType.CISCO_APIC_CONTROLLER_DETAIL,
-        CommandType.CUSTOM,
         CommandType.CISCO_ACI_FABRIC_NODES,
         CommandType.CISCO_ACI_FABRIC_VRFS,
         CommandType.CISCO_ACI_NODE_TYPE,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "forward-netbox"
-version = "2.1.5"
+version = "2.1.6"
 description = "NetBox plugin to sync Forward data into NetBox via built-in NQE queries"
 authors = ["Craig Johnson <craigjohnson@forwardnetworks.com>"]
 license = "MIT"


### PR DESCRIPTION
**Symptom:** Nearly every device shows NetBox platform **ACI** — Fortinet, Palo Alto, Cisco non-fabric included. Live: 5043 of 5285 devices classified ACI; only 512 are genuine.

**Cause:** `deviceHasAciCommandOutputs` ([netbox_utilities.nqe](forward_netbox/queries/netbox_utilities.nqe)) included `CommandType.CUSTOM` in its ACI-detection allowlist. `CUSTOM` is the generic catch-all command present on almost every device (926/937 Fortinet/Palo carry one), so `isAciDevice` → `normalizeDevicePlatformName` returned "ACI".

**Fix:** Remove `CUSTOM` from the allowlist. The specific `CISCO_ACI_*`/`CISCO_APIC_*` types remain — proven live to retain all 512 genuine Cisco APIC nodes while declassifying 0→Fortinet/Palo.

**Live validation (snapshot 1329953):** ACI 5043 → 512 (all Cisco APIC); Fortinet/Palo still-ACI = 0.

⚠️ `.nqe` change — bundled queries must be re-published to the Forward org to take effect on live syncs. Drop-in from 2.1.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)