### PR TITLE
fix: 2.2.2 — 504 gateway timeouts on large syncs (poll contention during long merge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Generated from the README compatibility table by `scripts/gen_changelog.py`. Do not edit by hand.
 
+## v2.2.2
+
+Fix 504 gateway timeouts on large syncs: stop recomputing change-explainability on every poll during a long merge + back off poll to 15s
+
 ## v2.2.1
 
 Add read-only forward_apply_identity_audit diagnostic to pinpoint 1-created/1-deleted idempotency churn

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Forward 26.6 is the baseline for async NQE.
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.2.1` | `4.6.3` required; needs netbox-branching `1.1.0+` | Current release; Add read-only forward_apply_identity_audit diagnostic to pinpoint 1-created/1-deleted idempotency churn |
+| `v2.2.2` | `4.6.3` required; needs netbox-branching `1.1.0+` | Current release; Fix 504 gateway timeouts on large syncs: stop recomputing change-explainability on every poll during a long merge + back off poll to 15s |
+| `v2.2.1` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.2.2`; Add read-only forward_apply_identity_audit diagnostic to pinpoint 1-created/1-deleted idempotency churn |
 | `v2.2.0` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.2.1`; Fix devices mis-assigned the ACI platform; link Palo vsys / Fortinet vdom firewalls to their physical chassis |
 | `v2.1.5` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.2.0`; Fix Prune orphans erroring on empty sites that still hold a VLAN/VM/prefix (delete only truly-empty sites) |
 | `v2.1.4` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.1.5`; Tag delete-eligible global IPAM (prefixes/VLANs/VRFs) for manual review |

--- a/docs/01_User_Guide/README.md
+++ b/docs/01_User_Guide/README.md
@@ -33,7 +33,8 @@ pip install forward-netbox==1.7.2
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.2.1` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Current release; Add read-only forward_apply_identity_audit diagnostic to pinpoint 1-created/1-deleted idempotency churn |
+| `v2.2.2` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Current release; Fix 504 gateway timeouts on large syncs: stop recomputing change-explainability on every poll during a long merge + back off poll to 15s |
+| `v2.2.1` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.2.2`; Add read-only forward_apply_identity_audit diagnostic to pinpoint 1-created/1-deleted idempotency churn |
 | `v2.2.0` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.2.1`; Fix devices mis-assigned the ACI platform; link Palo vsys / Fortinet vdom firewalls to their physical chassis |
 | `v2.1.5` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.2.0`; Fix Prune orphans erroring on empty sites that still hold a VLAN/VM/prefix (delete only truly-empty sites) |
 | `v2.1.4` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.1.5`; Tag delete-eligible global IPAM (prefixes/VLANs/VRFs) for manual review |

--- a/docs/03_Plans/active/2026-06-30-release-2.2.2-sync-504.md
+++ b/docs/03_Plans/active/2026-06-30-release-2.2.2-sync-504.md
@@ -1,0 +1,84 @@
+# Release 2.2.2 — fix 504 gateway timeouts during large settling syncs
+
+**Date:** 2026-06-30
+
+## Goal
+Stop the "504 gateway timeout on every sync after upgrading to 2.2" a customer
+hit. The 504 is front-end worker contention, not a slow handler and not the new
+custom field.
+
+Root cause (multi-agent + adversarially verified): the RQ sync job has a 48h
+timeout, so the *job* never times out — the 504 is gateway-side. After the 2.2
+ACI-platform fix (`netbox_utilities.nqe`) was republished, the settling sync
+reassigns ~2800 device platforms in one change set; the netbox_branching
+`Branch.merge()` runs that as one long `MERGING` transaction (minutes). During
+that window the ingestion page's htmx poll fires **every 5s** and, on every
+poll, recomputes `change_explainability_summary` (a `.count()` + `list[:5000]`
+over the branch ChangeDiffs). Those polls pile DB load onto the web workers (and
+read the ChangeDiff rows the merge transaction is touching), so a request
+exceeds the HTTP gateway timeout → 504. Ruled out by measurement: the object
+custom field (no N+1, bare PK in JSON), the vsys auto-link (opt-in/off), and a
+re-loop (staging is compare-before-write, so it settles in one sync).
+
+## Constraints
+- Plugin-side only. No schema migration, no change to the `forward_parent_device`
+  custom field, no change to the vsys/vdom parenting feature, no data migration.
+- Do not alter merge semantics (batching the netbox_branching merge is a separate,
+  scale-tested follow-up — too risky for a patch).
+
+## Touched Surfaces
+- `forward_netbox/views.py` — `ForwardIngestionLogView.get` and
+  `ForwardIngestionView.get_extra_context`: defer `change_explainability_summary`
+  while the job is running (it is only meaningful once staging/merge completes).
+- `forward_netbox/templates/forward_netbox/forwardingestion.html` +
+  `partials/ingestion_all.html` — htmx poll cadence 5s → 15s while running.
+- `forward_netbox/tests/test_log_export.py` — poll defers explainability while
+  running; still computes it when done.
+- Version bump: `pyproject.toml`, `forward_netbox/__init__.py`, 3 README tables,
+  `CHANGELOG.md`.
+
+## Approach
+Cut the per-poll DB pressure during the long merge window: (1) skip the
+explainability recompute while the job runs, removing the heaviest poll query and
+the ChangeDiff read that contends with the merge; (2) back the poll off to 15s
+(3x fewer requests). Both are additive and reversible. The settling merge itself
+is one-time and completes in the RQ worker regardless of the browser.
+
+## Validation
+Unit: `test_poll_defers_change_explainability_while_running` (running → not
+recomputed), `test_poll_computes_change_explainability_when_done` (done →
+recomputed); existing `test_ingestion_poll_refreshes_change_explainability` still
+green (no regression to the completed-state UI). Full suite on NetBox 4.6.3.
+Lint/harness/sensitive. (Diagnosis: 6-agent workflow measured every per-request
+and per-merge path; object-CF render +2.6x CPU only, explainability 52–868 ms,
+branching diff/merge linear with 0 CF-driven SELECTs, RQ timeout 48h — so the
+504 is gateway-side worker contention.)
+
+## Rollback
+Revert the three surfaces; `pip install forward-netbox==2.2.1`.
+
+## Decision Log
+- Fix the poll contention (safe, targeted, removes the recurring trigger) rather
+  than batch the netbox_branching merge (architectural, can't be scale-validated
+  in a patch, risks merge semantics). The long settling merge is one-time.
+- Defer explainability rather than cache it: mid-run it is not meaningful (changes
+  still staging/merging), so deferral is also semantically correct.
+
+## Bundled changes
+- Fix: large syncs no longer cause 504 gateway timeouts. The ingestion page no
+  longer recomputes the change-explainability breakdown on every poll while a
+  sync/merge is running (it is shown once the run completes), and the poll backs
+  off from 5s to 15s — removing the web-worker contention that produced 504s
+  during a long platform-reclassification merge. No change to the sync, the
+  vsys/vdom custom field, or any data. Drop-in from `2.2.1`.
+
+## Customer note (Blake)
+- The first sync after republishing the ACI fix legitimately reclassifies ~2800
+  device platforms — a large but **one-time** change set; subsequent syncs are
+  small. While that settling sync merges (a few minutes), it completes in the
+  background worker (48h timeout) even if the browser shows a 504 — leave the
+  page or let it finish. After 2.2.2, the poll no longer contends, so the 504
+  stops. Optional infra: raise gunicorn `--timeout` / reverse-proxy
+  `proxy_read_timeout` and/or add a worker to ride the one big merge.
+- A follow-up will batch the settling merge so even the one big window can't hold
+  a long transaction; it needs scale validation before shipping.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,8 @@ Forward 26.6 is the baseline for async NQE.
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.2.1` | `4.6.3` required; needs netbox-branching `1.1.0+` | Current release; Add read-only forward_apply_identity_audit diagnostic to pinpoint 1-created/1-deleted idempotency churn |
+| `v2.2.2` | `4.6.3` required; needs netbox-branching `1.1.0+` | Current release; Fix 504 gateway timeouts on large syncs: stop recomputing change-explainability on every poll during a long merge + back off poll to 15s |
+| `v2.2.1` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.2.2`; Add read-only forward_apply_identity_audit diagnostic to pinpoint 1-created/1-deleted idempotency churn |
 | `v2.2.0` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.2.1`; Fix devices mis-assigned the ACI platform; link Palo vsys / Fortinet vdom firewalls to their physical chassis |
 | `v2.1.5` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.2.0`; Fix Prune orphans erroring on empty sites that still hold a VLAN/VM/prefix (delete only truly-empty sites) |
 | `v2.1.4` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.1.5`; Tag delete-eligible global IPAM (prefixes/VLANs/VRFs) for manual review |

--- a/forward_netbox/__init__.py
+++ b/forward_netbox/__init__.py
@@ -8,7 +8,7 @@ class NetboxForwardConfig(PluginConfig):
     name = "forward_netbox"
     verbose_name = "Forward Field Integration"
     description = "Sync Forward data into NetBox using built-in NQE queries."
-    version = "2.2.1"
+    version = "2.2.2"
     base_url = "forward"
     min_version = "4.6.3"
 

--- a/forward_netbox/templates/forward_netbox/forwardingestion.html
+++ b/forward_netbox/templates/forward_netbox/forwardingestion.html
@@ -167,7 +167,7 @@
     <div id="ingestion_poll"
          class="col col-md-12"
          hx-get="{% url 'plugins:forward_netbox:forwardingestion_logs' pk=object.pk %}?stage={{ active_stage|default:'sync' }}"
-         hx-trigger="{% if job_running %}every 5s{% else %}none{% endif %}"
+         hx-trigger="{% if job_running %}every 15s{% else %}none{% endif %}"
          hx-target="#ingestion_logs"
          hx-select="#ingestion_logs"
          hx-select-oob="#ingestion_status:innerHTML,#ingestion_progress:innerHTML,#ingestion_statistics:innerHTML,#change_explainability:innerHTML,#object_tabs:innerHTML,#ingestion_merge_button:innerHTML"

--- a/forward_netbox/templates/forward_netbox/partials/ingestion_all.html
+++ b/forward_netbox/templates/forward_netbox/partials/ingestion_all.html
@@ -22,7 +22,7 @@
      hx-swap-oob="true"
      class="col col-md-12"
      hx-get="{{ logs_url }}?stage={{ active_stage }}"
-     hx-trigger="{% if polling_done %}none{% else %}every 5s{% endif %}"
+     hx-trigger="{% if polling_done %}none{% else %}every 15s{% endif %}"
      hx-target="#ingestion_logs"
      hx-select="#ingestion_logs"
      hx-select-oob="#ingestion_status:innerHTML,#ingestion_progress:innerHTML,#ingestion_statistics:innerHTML,#change_explainability:innerHTML,#object_tabs:innerHTML,#ingestion_merge_button:innerHTML"

--- a/forward_netbox/tests/test_log_export.py
+++ b/forward_netbox/tests/test_log_export.py
@@ -338,6 +338,66 @@ class ForwardIngestionLogExportViewTest(TestCase):
         self.assertContains(response, "ipam.prefix 1")
         self.assertContains(response, "vrf 1")
 
+    def test_poll_defers_change_explainability_while_running(self):
+        # Regression (504 fix): while the job is running, the 5s/15s poll must
+        # NOT recompute change_explainability — doing so on every poll piles DB
+        # load onto the web workers during a long settling merge, which is what
+        # produces the gateway 504s on large platform-reclassification syncs.
+        running_sync = ForwardSync.objects.create(
+            name="sync-running-poll",
+            source=self.source,
+            parameters={"snapshot_id": "latestProcessed"},
+        )
+        running_ing = ForwardIngestion.objects.create(
+            sync=running_sync,
+            snapshot_selector="latestProcessed",
+            snapshot_id="snap-running",
+        )
+        now = timezone.now()
+        running_job = Job.objects.create(
+            object_type=ContentType.objects.get_for_model(ForwardIngestion),
+            object_id=running_ing.pk,
+            name="running-ingestion-job",
+            user=None,
+            status=JobStatusChoices.STATUS_RUNNING,
+            job_id="333e4567-e89b-12d3-a456-426614174002",
+            created=now,
+            started=now,
+            completed=None,
+            data={},
+        )
+        running_ing.job = running_job
+        running_ing.save(update_fields=["job"])
+
+        self.client.force_login(self.user)
+        with patch("forward_netbox.views.change_explainability_summary") as mock_ce:
+            response = self.client.get(
+                reverse(
+                    "plugins:forward_netbox:forwardingestion_logs",
+                    kwargs={"pk": running_ing.pk},
+                ),
+                headers={"HX-Request": "true"},
+            )
+        self.assertEqual(response.status_code, 200)
+        mock_ce.assert_not_called()
+
+    def test_poll_computes_change_explainability_when_done(self):
+        # The completed ingestion still computes it (the deferral is only while
+        # the job runs), so the operator sees the breakdown once it finishes.
+        self.client.force_login(self.user)
+        with patch(
+            "forward_netbox.views.change_explainability_summary",
+            return_value={"available": False},
+        ) as mock_ce:
+            self.client.get(
+                reverse(
+                    "plugins:forward_netbox:forwardingestion_logs",
+                    kwargs={"pk": self.ingestion.pk},
+                ),
+                headers={"HX-Request": "true"},
+            )
+        mock_ce.assert_called_once()
+
     def test_export_logs_compacts_large_execution_plan_items(self):
         sync = ForwardSync.objects.create(
             name="sync-log-export-plan-items",

--- a/forward_netbox/views.py
+++ b/forward_netbox/views.py
@@ -1374,19 +1374,27 @@ class ForwardIngestionLogView(LoginRequiredMixin, View):
         data["execution_state"] = _compact_execution_state_payload(
             json_safe_value(get_execution_display_state(ingestion.sync))
         )
-        data["change_explainability"] = change_explainability_summary(ingestion)
+        sync_running = ingestion.job and not ingestion.job.completed
+        merge_running = ingestion.merge_job and not ingestion.merge_job.completed
+        job_running = bool(sync_running or merge_running)
+        # Defer the change-explainability recompute while the job is running: it
+        # is only meaningful once staging/merge completes, and recomputing it on
+        # every poll piles DB load onto the web workers during a long settling
+        # merge (a large platform reclassification can run for minutes) — that
+        # contention is what produces the 504 gateway timeouts the customer sees.
+        data["change_explainability"] = (
+            {"available": False, "reason": "deferred_while_running"}
+            if job_running
+            else change_explainability_summary(ingestion)
+        )
         data["export_logs_url"] = reverse(
             "plugins:forward_netbox:forwardingestion_export_logs",
             kwargs={"pk": ingestion.pk},
         )
 
         if request.htmx:
-            sync_running = ingestion.job and not ingestion.job.completed
-            merge_running = ingestion.merge_job and not ingestion.merge_job.completed
             anything_ever_ran = ingestion.job or ingestion.merge_job
-            data["polling_done"] = (
-                bool(anything_ever_ran) and not sync_running and not merge_running
-            )
+            data["polling_done"] = bool(anything_ever_ran) and not job_running
         return render(request, self.template_name, data)
 
 
@@ -1447,7 +1455,13 @@ class ForwardIngestionView(generic.ObjectView):
         data["execution_state"] = _compact_execution_state_payload(
             json_safe_value(get_execution_display_state(instance.sync))
         )
-        data["change_explainability"] = change_explainability_summary(instance)
+        # Defer change-explainability while the job is running (see
+        # ForwardIngestionLogView): avoids recomputing it under merge contention.
+        data["change_explainability"] = (
+            {"available": False, "reason": "deferred_while_running"}
+            if data["job_running"]
+            else change_explainability_summary(instance)
+        )
         data["export_logs_url"] = reverse(
             "plugins:forward_netbox:forwardingestion_export_logs",
             kwargs={"pk": instance.pk},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "forward-netbox"
-version = "2.2.1"
+version = "2.2.2"
 description = "NetBox plugin to sync Forward data into NetBox via built-in NQE queries"
 authors = ["Craig Johnson <craigjohnson@forwardnetworks.com>"]
 license = "MIT"


### PR DESCRIPTION
**Symptom:** After upgrading to 2.2, every sync returns a 504 gateway timeout.

**Root cause (multi-agent + adversarially verified):** The 504 is *gateway-side*, not the job — the RQ sync/merge job has a 48h timeout (`RQ_PARAMS['DEFAULT_TIMEOUT']=172800`), so it never times out. After the 2.2 ACI-platform fix is republished, the settling sync reassigns ~2800 device platforms in one `netbox_branching` `MERGING` transaction (minutes). Meanwhile the ingestion page's htmx poll fires **every 5s** and recomputes `change_explainability_summary` (`.count()` + `list[:5000]` over branch ChangeDiffs) on every poll → web-worker contention + reads the ChangeDiff rows the merge is touching → a request exceeds the HTTP gateway timeout → **504**.

**Ruled out by measurement:** the `forward_parent_device` object CF (no N+1, bulk-cached, bare PK in JSON, +2.6x CPU only), the vsys auto-link (opt-in/off), a re-loop (staging is compare-before-write → settles in one sync).

**Fix (plugin-side, no migration, no CF/vsys/data change):**
- `views.py` `ForwardIngestionLogView` + `ForwardIngestionView`: defer `change_explainability_summary` while the job is running (only meaningful once complete).
- Templates: htmx poll 5s → 15s.

919 Django tests green on 4.6.3, incl. new `test_poll_defers_change_explainability_while_running` / `test_poll_computes_change_explainability_when_done`; existing poll test still green. Drop-in from 2.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)