### PR TITLE
fix: 2.2.4 — device-analysis NQE (bare foreach) broke refresh + surface job errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Generated from the README compatibility table by `scripts/gen_changelog.py`. Do not edit by hand.
 
+## v2.2.4
+
+Hotfix: device-analysis NQE (bare foreach) errored refresh + CVE list; surface job errors into job.data
+
 ## v2.2.3
 
 Field-feedback fixes: delete-count labeling, vsys/vdom auto-link, skip empty VRFs, per-device CVE list, churn pinpoint, query-ID status clarify

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Forward 26.6 is the baseline for async NQE.
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.2.3` | `4.6.3` required; needs netbox-branching `1.1.0+` | Current release; Field-feedback fixes: delete-count labeling, vsys/vdom auto-link, skip empty VRFs, per-device CVE list, churn pinpoint, query-ID status clarify |
+| `v2.2.4` | `4.6.3` required; needs netbox-branching `1.1.0+` | Current release; Hotfix: device-analysis NQE (bare foreach) errored refresh + CVE list; surface job errors into job.data |
+| `v2.2.3` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.2.4`; Field-feedback fixes: delete-count labeling, vsys/vdom auto-link, skip empty VRFs, per-device CVE list, churn pinpoint, query-ID status clarify |
 | `v2.2.2` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.2.3`; Fix 504 gateway timeouts on large syncs: stop recomputing change-explainability on every poll during a long merge + back off poll to 15s |
 | `v2.2.1` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.2.2`; Add read-only forward_apply_identity_audit diagnostic to pinpoint 1-created/1-deleted idempotency churn |
 | `v2.2.0` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.2.1`; Fix devices mis-assigned the ACI platform; link Palo vsys / Fortinet vdom firewalls to their physical chassis |

--- a/docs/01_User_Guide/README.md
+++ b/docs/01_User_Guide/README.md
@@ -33,7 +33,8 @@ pip install forward-netbox==1.7.2
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.2.3` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Current release; Field-feedback fixes: delete-count labeling, vsys/vdom auto-link, skip empty VRFs, per-device CVE list, churn pinpoint, query-ID status clarify |
+| `v2.2.4` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Current release; Hotfix: device-analysis NQE (bare foreach) errored refresh + CVE list; surface job errors into job.data |
+| `v2.2.3` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.2.4`; Field-feedback fixes: delete-count labeling, vsys/vdom auto-link, skip empty VRFs, per-device CVE list, churn pinpoint, query-ID status clarify |
 | `v2.2.2` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.2.3`; Fix 504 gateway timeouts on large syncs: stop recomputing change-explainability on every poll during a long merge + back off poll to 15s |
 | `v2.2.1` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.2.2`; Add read-only forward_apply_identity_audit diagnostic to pinpoint 1-created/1-deleted idempotency churn |
 | `v2.2.0` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.2.1`; Fix devices mis-assigned the ACI platform; link Palo vsys / Fortinet vdom firewalls to their physical chassis |

--- a/docs/03_Plans/active/2026-07-02-release-2.2.4-device-analysis-hotfix.md
+++ b/docs/03_Plans/active/2026-07-02-release-2.2.4-device-analysis-hotfix.md
@@ -1,0 +1,61 @@
+# Release 2.2.4 — hotfix device-analysis query + surface job errors
+
+**Date:** 2026-07-02
+
+## Goal
+Fix the 2.2.3 regression where "Refresh device analysis" (and the CVE list it
+feeds) errored on every run, and stop sync jobs from hiding their errors.
+
+Root cause (live-verified): `forward_device_analysis.nqe` assigned a BARE
+`foreach` comprehension to a `let` (`let cveIds = foreach ... select ...`) — an
+NQE that the live engine rejects with HTTP 400 (`extraneous input 'foreach'`).
+The local NQE linter reported 0 errors, so it shipped. A `foreach` used as a
+value must be parenthesized. The refresh job runs this NQE first, so it errored
+before touching the DB; and because the job never wrote the exception into
+`job.data`, the UI showed Status=Errored, Error="—", Data=null.
+
+## Constraints
+- Hotfix scope: the query fix + error-visibility only. No schema change.
+- `.nqe` change → re-publish is NOT needed (device-analysis runs inline via the
+  nqe-executions API; the fix ships in the package and takes effect on upgrade).
+
+## Touched Surfaces
+- `forward_netbox/queries/forward_device_analysis.nqe` — parenthesize the
+  `cveIds` comprehension.
+- `forward_netbox/jobs.py` — record `{error, error_type}` into `job.data` before
+  `terminate(ERRORED)` in all 5 jobs that were swallowing it
+  (refresh_forward_device_analysis, forward_dependency_preview,
+  tag_forward_backfilled_devices, tag_forward_delete_eligible_ipam,
+  create_forward_module_bays), mirroring `prune_forward_orphans`.
+- `forward_netbox/tests/test_device_analysis_query.py` — source-level guard that
+  the `cveIds` comprehension stays parenthesized (the linter can't).
+
+## Approach
+Wrap the comprehension in parens. Add the error-surfacing to every offending job
+so no failure is ever hidden again. Guard the query shape with a hermetic test.
+
+## Validation
+Live-run of the fixed query against the field network: 5313 rows, 4755 with
+`cve_ids`, real CVE IDs. Audit of ALL bundled `.nqe` for the bare-foreach-in-let
+pattern: 0 others. Full suite on NetBox 4.6.3. Lint/harness/sensitive.
+
+## Rollback
+Revert the surfaces; `pip install forward-netbox==2.2.3` (device-analysis stays
+broken there).
+
+## Decision Log
+- Source-level regression test (not a live NQE test): the linter is blind to this
+  class, and a network round-trip in the suite is undesirable; asserting the
+  parenthesization in the query source pins the exact regression cheaply.
+- device-analysis is inline (not an org-bound query) → no ADP republish needed
+  for the CVE fix, unlike the 2.2.3 VRF change.
+
+## Bundled changes
+- Fix: "Refresh device analysis" no longer errors — the device-analysis query had
+  an invalid NQE construct (a bare `foreach` used as a value) that the live engine
+  rejected, so the CVE list never populated. Now it runs and the per-device CVE
+  IDs appear. Re-run Refresh device analysis after upgrading.
+- Fix: sync jobs that fail now record the actual error in the job's Data panel
+  (refresh device analysis, dependency preview, tag backfilled, tag
+  delete-eligible IPAM, create module bays) instead of a blank Error / null Data.
+  Drop-in from `2.2.3`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,8 @@ Forward 26.6 is the baseline for async NQE.
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.2.3` | `4.6.3` required; needs netbox-branching `1.1.0+` | Current release; Field-feedback fixes: delete-count labeling, vsys/vdom auto-link, skip empty VRFs, per-device CVE list, churn pinpoint, query-ID status clarify |
+| `v2.2.4` | `4.6.3` required; needs netbox-branching `1.1.0+` | Current release; Hotfix: device-analysis NQE (bare foreach) errored refresh + CVE list; surface job errors into job.data |
+| `v2.2.3` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.2.4`; Field-feedback fixes: delete-count labeling, vsys/vdom auto-link, skip empty VRFs, per-device CVE list, churn pinpoint, query-ID status clarify |
 | `v2.2.2` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.2.3`; Fix 504 gateway timeouts on large syncs: stop recomputing change-explainability on every poll during a long merge + back off poll to 15s |
 | `v2.2.1` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.2.2`; Add read-only forward_apply_identity_audit diagnostic to pinpoint 1-created/1-deleted idempotency churn |
 | `v2.2.0` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.2.1`; Fix devices mis-assigned the ACI platform; link Palo vsys / Fortinet vdom firewalls to their physical chassis |

--- a/forward_netbox/__init__.py
+++ b/forward_netbox/__init__.py
@@ -8,7 +8,7 @@ class NetboxForwardConfig(PluginConfig):
     name = "forward_netbox"
     verbose_name = "Forward Field Integration"
     description = "Sync Forward data into NetBox using built-in NQE queries."
-    version = "2.2.3"
+    version = "2.2.4"
     base_url = "forward"
     min_version = "4.6.3"
 

--- a/forward_netbox/jobs.py
+++ b/forward_netbox/jobs.py
@@ -385,6 +385,13 @@ def refresh_forward_device_analysis(job, *args, **kwargs):
         job.save(update_fields=["data"])
         job.terminate()
     except Exception as exc:
+        # Record the failure on the job so it is visible in the UI (the Data
+        # panel) instead of an empty Error field with null data.
+        job.data = {
+            "error": str(exc) or exc.__class__.__name__,
+            "error_type": exc.__class__.__name__,
+        }
+        job.save(update_fields=["data"])
         job.terminate(status=JobStatusChoices.STATUS_ERRORED)
         if type(exc) in (SyncError, JobTimeoutException):
             logger.error(exc)
@@ -408,6 +415,13 @@ def tag_forward_backfilled_devices(job, *args, **kwargs):
         job.save(update_fields=["data"])
         job.terminate()
     except Exception as exc:
+        # Record the failure on the job so it is visible in the UI (the Data
+        # panel) instead of an empty Error field with null data.
+        job.data = {
+            "error": str(exc) or exc.__class__.__name__,
+            "error_type": exc.__class__.__name__,
+        }
+        job.save(update_fields=["data"])
         job.terminate(status=JobStatusChoices.STATUS_ERRORED)
         if type(exc) in (SyncError, JobTimeoutException):
             logger.error(exc)
@@ -464,6 +478,13 @@ def tag_forward_delete_eligible_ipam(job, *args, **kwargs):
         job.save(update_fields=["data"])
         job.terminate()
     except Exception as exc:
+        # Record the failure on the job so it is visible in the UI (the Data
+        # panel) instead of an empty Error field with null data.
+        job.data = {
+            "error": str(exc) or exc.__class__.__name__,
+            "error_type": exc.__class__.__name__,
+        }
+        job.save(update_fields=["data"])
         job.terminate(status=JobStatusChoices.STATUS_ERRORED)
         if type(exc) in (SyncError, JobTimeoutException):
             logger.error(exc)
@@ -485,6 +506,13 @@ def create_forward_module_bays(job, *args, **kwargs):
         job.save(update_fields=["data"])
         job.terminate()
     except Exception as exc:
+        # Record the failure on the job so it is visible in the UI (the Data
+        # panel) instead of an empty Error field with null data.
+        job.data = {
+            "error": str(exc) or exc.__class__.__name__,
+            "error_type": exc.__class__.__name__,
+        }
+        job.save(update_fields=["data"])
         job.terminate(status=JobStatusChoices.STATUS_ERRORED)
         if type(exc) in (SyncError, JobTimeoutException):
             logger.error(exc)
@@ -511,6 +539,13 @@ def forward_dependency_preview(job, *args, **kwargs):
         job.save(update_fields=["data"])
         job.terminate()
     except Exception as exc:
+        # Record the failure on the job so it is visible in the UI (the Data
+        # panel) instead of an empty Error field with null data.
+        job.data = {
+            "error": str(exc) or exc.__class__.__name__,
+            "error_type": exc.__class__.__name__,
+        }
+        job.save(update_fields=["data"])
         job.terminate(status=JobStatusChoices.STATUS_ERRORED)
         if type(exc) in (SyncError, JobTimeoutException):
             logger.error(exc)

--- a/forward_netbox/queries/forward_device_analysis.nqe
+++ b/forward_netbox/queries/forward_device_analysis.nqe
@@ -31,9 +31,9 @@ let physicalLinks =
          foreach l in i.links
          select l)
 let cveIds =
-  foreach c in device.cveFindings
-  where c.isVulnerable
-  select c.cveId
+  (foreach c in device.cveFindings
+   where c.isVulnerable
+   select c.cveId)
 select {
   name: device.name,
   reachable: device.snapshotInfo.result == DeviceSnapshotResult.completed,

--- a/forward_netbox/tests/test_device_analysis_query.py
+++ b/forward_netbox/tests/test_device_analysis_query.py
@@ -1,0 +1,26 @@
+import re
+
+from django.test import SimpleTestCase
+
+from forward_netbox.utilities.query_registry import read_builtin_query_source
+
+
+class DeviceAnalysisQueryTest(SimpleTestCase):
+    """Guard the device-analysis NQE against the 2.2.3 regression: a bare
+    ``let x = foreach ... select ...`` is INVALID NQE — the live Forward engine
+    returns HTTP 400 (``extraneous input 'foreach'``) and the whole
+    refresh-device-analysis job errors. The local NQE linter does NOT catch this
+    (it reported 0 errors on the broken query), so this source-level test is the
+    real guard. A ``foreach`` used as a value must be wrapped in parens / a call.
+    """
+
+    def test_cve_ids_comprehension_is_parenthesized(self):
+        source = read_builtin_query_source("forward_device_analysis.nqe")
+        self.assertIn("(foreach c in device.cveFindings", source)
+
+    def test_no_bare_foreach_in_let_binding(self):
+        source = read_builtin_query_source("forward_device_analysis.nqe")
+        # A `let <name> =` immediately followed by a bare `foreach` is the invalid
+        # pattern; wrapped forms (`(foreach`, `length(foreach`) are fine.
+        bare = re.findall(r"let\s+\w+\s*=\s*\n\s*foreach\b", source)
+        self.assertEqual(bare, [], f"bare foreach in a let binding: {bare}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "forward-netbox"
-version = "2.2.3"
+version = "2.2.4"
 description = "NetBox plugin to sync Forward data into NetBox via built-in NQE queries"
 authors = ["Craig Johnson <craigjohnson@forwardnetworks.com>"]
 license = "MIT"


### PR DESCRIPTION
**Regression in 2.2.3.** "Refresh device analysis" errored on every run (Status=Errored, Error="—", Data=null), so the new CVE list never populated.

**Root cause (live-verified):** `forward_device_analysis.nqe` assigned a **bare `foreach` comprehension to a `let`** (`let cveIds = foreach ... select c.cveId`) — invalid NQE; the live Forward engine returns HTTP 400 `NQE_RUNTIME_ERROR: extraneous input 'foreach'`. The local NQE linter reported **0 errors**, so it shipped. A `foreach` used as a value must be parenthesized.

**Fix:** wrap it — `let cveIds = (foreach ... select c.cveId)`. Live-verified: 5313 rows, 4755 with `cve_ids`, real CVE IDs. Audited all bundled `.nqe`: no other bare-foreach-in-let.

**Also:** the job hid the error. All 5 jobs that terminated ERRORED without recording it (refresh device analysis, dependency preview, tag backfilled, tag delete-eligible IPAM, create module bays) now write `{error, error_type}` into `job.data` (mirrors `prune_forward_orphans`). New source-level test guards the query shape (the linter can't).

927 Django tests green on 4.6.3; lint/harness/sensitive pass. `.nqe` runs inline → **no org republish needed**. Drop-in from 2.2.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)