### PR TITLE
Scrub internal name from test comments; fix release SBOM flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,9 @@ jobs:
       - name: Generate CycloneDX SBOM
         # Software Bill of Materials over the declared runtime deps, kept OUT of
         # dist/ (uploaded to PyPI) and published as its own artifact for
-        # supply-chain review.
+        # supply-chain review. Non-blocking: the SBOM is supplementary and must
+        # never fail the publish (a cyclonedx-py CLI change once did — v2.3.1).
+        continue-on-error: true
         run: |
           python -m pip install cyclonedx-bom
           mkdir -p sbom
@@ -45,7 +47,7 @@ jobs:
           echo 'netboxlabs-netbox-branching>=1.1.0' >> sbom-reqs.txt
           echo pyzipper >> sbom-reqs.txt
           cyclonedx-py requirements sbom-reqs.txt \
-            --output-format JSON --outfile sbom/forward-netbox-sbom.json
+            --output-format JSON --output-file sbom/forward-netbox-sbom.json
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/docs/03_Plans/active/2026-07-06-scrub-internal-name-sbom-flag.md
+++ b/docs/03_Plans/active/2026-07-06-scrub-internal-name-sbom-flag.md
@@ -1,0 +1,39 @@
+# Scrub internal name from test comments; fix release SBOM flag
+
+**Date:** 2026-07-06
+
+## Goal
+Post-2.3.1 hygiene: (1) remove an internal name that was reintroduced in two
+test comments (`# Regression (<name> 2.3.0)`); (2) fix the release workflow's
+CycloneDX SBOM step, which broke the tag-triggered publish.
+
+## Constraints
+- No functional/behaviour change; comment + workflow only.
+- No version bump (2.3.1 accepted as-is; this only cleans main going forward).
+
+## Touched Surfaces
+- `forward_netbox/tests/test_sync.py`, `forward_netbox/tests/test_health.py` —
+  reword the two regression comments to drop the name.
+- `.github/workflows/release.yml` — SBOM step: `cyclonedx-py … --outfile` →
+  `--output-file` (the CLI flag was renamed; the old flag failed the build job,
+  which skipped the publish job on the v2.3.1 tag) + `continue-on-error: true`
+  so a supplementary SBOM can never gate a publish again.
+
+## Approach
+Mechanical edits verified by the full gate; the release workflow is validated on
+the next real tag (its publish job uses Trusted Publishing).
+
+## Validation
+`invoke harness-check`; `yamllint` / pre-commit on the workflow; the two
+regression tests still pass (`test_sync` / `test_health`).
+
+## Rollback
+Revert the three edits. No release artifact depends on this.
+
+## Decision Log
+- SBOM step made non-blocking: it is supplementary supply-chain metadata, not a
+  release gate — a `cyclonedx-py` CLI change should never block publishing.
+- No 2.3.2 for this: the reintroduced name is an internal first name and the
+  functional 2.3.1 fixes are already published; main is cleaned forward instead.
+- The recurrence guard is the `FORWARD_SENSITIVE_PATTERNS` CI secret (still to be
+  set by the maintainer) — the content-scan is toothless until it is populated.

--- a/forward_netbox/tests/test_health.py
+++ b/forward_netbox/tests/test_health.py
@@ -1115,7 +1115,7 @@ class ForwardSyncHealthTest(TestCase):
         )
 
     def test_drift_report_flags_stale_when_sync_ran_after_preview(self):
-        # Regression (Blake 2.3.0): the drift report is built from the cached
+        # Regression (2.3.0 field report): the drift report is built from the cached
         # preview payload, so a sync run AFTER the preview leaves stale
         # "everything to create" numbers. Flag it.
         preview_at = timezone.now() - timezone.timedelta(hours=2)

--- a/forward_netbox/tests/test_sync.py
+++ b/forward_netbox/tests/test_sync.py
@@ -3606,7 +3606,7 @@ class ForwardSyncRunnerTest(TestCase):
     def test_apply_extras_taggeditem_reuses_existing_tag_by_name_when_slug_differs(
         self,
     ):
-        # Regression (Blake 2.3.0): a NetBox tag with the same NAME but a
+        # Regression (2.3.0 field report): a NetBox tag with the same NAME but a
         # different SLUG must be REUSED, not re-created — the slug-only match
         # missed it and the create failed the unique-name constraint
         # ("Tag with this Name already exists.").


### PR DESCRIPTION
Post-2.3.1 hygiene. (1) Reword two `# Regression (<name> 2.3.0)` test comments to drop an internal name. (2) Fix `release.yml` SBOM step: `cyclonedx-py --outfile` → `--output-file` (the renamed flag failed the build job and skipped the publish on the v2.3.1 tag) + `continue-on-error` so the SBOM never gates a publish. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)