### PR TITLE
docs: collapse release tables in docs READMEs

### DIFF
--- a/docs/01_User_Guide/README.md
+++ b/docs/01_User_Guide/README.md
@@ -32,6 +32,11 @@ pip install forward-netbox==2.3.1
 
 ## Release Compatibility
 
+Latest release requires NetBox `4.6.4` and `netbox-branching` `1.1.0+`. Expand for the full per-release history and notes.
+
+<details>
+<summary>Release compatibility history</summary>
+
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
 | `v2.3.1` | `4.6.4` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Current release;  |
@@ -130,7 +135,12 @@ pip install forward-netbox==2.3.1
 | `v0.3.0.1` | `4.5.8` validated; `4.5.x` only | Superseded by `v0.3.1` |
 | `v0.3.0` | `4.5.8` validated; `4.5.x` only | Superseded by `v0.3.0.1` |
 
+</details>
+
 ## Version History
+
+<details>
+<summary>Per-release summaries</summary>
 
 | Release | Summary |
 | --- | --- |
@@ -209,6 +219,8 @@ pip install forward-netbox==2.3.1
 | `v0.1.2` | Improved ingestion safety, diagnostics, and compatibility with existing NetBox objects. |
 | `v0.1.1` | Added NQE pagination, shared helper composition, and release/doc cleanup. |
 | `v0.1.0` | Initial unsupported release of the plugin. |
+
+</details>
 
 ## Support Disclaimer
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,11 @@ Forward 26.6 is the baseline for async NQE.
 
 ## Release Compatibility
 
+Latest release requires NetBox `4.6.4` and `netbox-branching` `1.1.0+`. Expand for the full per-release history and notes.
+
+<details>
+<summary>Release compatibility history</summary>
+
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
 | `v2.3.1` | `4.6.4` required; needs netbox-branching `1.1.0+` | Current release;  |
@@ -105,7 +110,12 @@ Forward 26.6 is the baseline for async NQE.
 | `v0.3.0.1` | `4.5.8` validated; `4.5.x` only | Superseded by `v0.3.1` |
 | `v0.3.0` | `4.5.8` validated; `4.5.x` only | Superseded by `v0.3.0.1` |
 
+</details>
+
 ## Version History
+
+<details>
+<summary>Per-release summaries</summary>
 
 | Release | Summary |
 | --- | --- |
@@ -182,6 +192,8 @@ Forward 26.6 is the baseline for async NQE.
 | `v0.1.2` | Improved ingestion safety, diagnostics, and compatibility with existing NetBox data. |
 | `v0.1.1` | Added NQE pagination, shared helper composition, and release hygiene updates. |
 | `v0.1.0` | Initial unsupported release of the Forward-to-NetBox sync plugin. |
+
+</details>
 
 ## Support
 


### PR DESCRIPTION
Follow-up to the root README cleanup — apply the same `<details>` collapse to the two docs READMEs (`docs/README.md`, `docs/01_User_Guide/README.md`) so the rendered docs site matches. Rows are unchanged (wrapper lines only); not read by `gen_changelog` (root README only); single `Current release;` marker preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)