### PR TITLE
Reframe as a field integration (drop 'officially maintained')

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@
 
 ## Status
 
-Officially maintained. Requires **NetBox `4.6.4`** and **`netbox-branching` `1.1.0+`**;
-Forward **26.6** is the baseline for async NQE. See
-[Release Compatibility](#release-compatibility) for the full matrix.
+- **Support model:** field integration reference — **not** an officially
+  supported Forward Networks product.
+- **Requires:** NetBox `4.6.4`, `netbox-branching` `1.1.0+`; Forward `26.6`
+  baseline for async NQE (full matrix in
+  [Release Compatibility](#release-compatibility)).
+- **Distribution:** PyPI (`forward-netbox`) + GitHub releases.
 
 ## What It Does
 
@@ -164,9 +167,10 @@ Latest release requires NetBox `4.6.4` and `netbox-branching` `1.1.0+`. Expand f
 
 ## Support
 
-Forward Integration for NetBox is an officially maintained Forward Networks integration
-for NetBox. Supported NetBox and `netbox-branching` versions are listed in the
-Release Compatibility table above; support targets the latest released version.
+This is a **field integration** maintained by a Forward Networks SE — a reference
+integration, **not an officially supported Forward Networks product**, provided
+as-is with no SLA. Supported NetBox and `netbox-branching` versions are listed in
+the Release Compatibility table above; fixes target the latest released version.
 
 - **Bugs / feature requests:** open a GitHub issue using the provided templates.
 - **Security vulnerabilities:** report privately per [SECURITY.md](SECURITY.md) —

--- a/docs/03_Plans/active/2026-07-06-field-integration-framing.md
+++ b/docs/03_Plans/active/2026-07-06-field-integration-framing.md
@@ -1,0 +1,44 @@
+# Reframe as a field integration (drop "officially maintained")
+
+**Date:** 2026-07-06
+
+## Goal
+Correct the support posture: this is a **field integration** built by a Forward
+Networks SE, not an officially supported Forward product. Remove the
+"officially maintained" / "Production/Stable" claims, matching the sibling
+Dynatrace repo's honest "field integration reference" framing.
+
+## Constraints
+- Do not touch the Release Compatibility table rows.
+- Keep the descriptive product/PyPI name "Forward Integration for NetBox".
+
+## Touched Surfaces
+- `README.md` — Status + Support sections reworded to "field integration …
+  not an officially supported Forward Networks product, provided as-is, no SLA".
+- `docs/README.md` — Support paragraph, same reword.
+- `pyproject.toml` — `Development Status :: 5 - Production/Stable` →
+  `4 - Beta` (a field integration should not advertise Production/Stable).
+
+## Approach
+Straight wording edits + one classifier change; mirrors the Dynatrace repo's
+`Support model: field integration reference, not an officially supported
+Forward product integration`.
+
+## Validation
+`gen_changelog.py --check` (compat rows untouched); sensitive + harness;
+`grep -i official` shows only the unrelated `forward-backfilled` tag rows.
+
+## Rollback
+Revert the wording + classifier edits.
+
+## Decision Log
+- Maintainer (Forward SE) explicitly rejected the "official" framing: it is a
+  field/reference integration, provided as-is. Prior GA/"supported product"
+  posture (2.3.0) is superseded by this.
+- Beta not Production/Stable: aligns the PyPI maturity signal with the
+  as-is/no-SLA support model.
+
+## Bundled changes
+Reframed the plugin as a field integration (not an officially supported Forward
+product); dropped the "officially maintained" wording and the Production/Stable
+classifier.

--- a/docs/README.md
+++ b/docs/README.md
@@ -114,7 +114,7 @@ Latest release requires NetBox `4.6.4` and `netbox-branching` `1.1.0+`. Expand f
 
 ## Support
 
-Forward Integration for NetBox is an officially maintained Forward Networks integration for NetBox; support targets the latest released version (see the Release Compatibility table). Report bugs via GitHub issues and security vulnerabilities privately per `SECURITY.md`. Review the deployment security notes in `SECURITY.md` before production use.
+Forward Integration for NetBox is a **field integration** maintained by a Forward Networks SE — a reference integration, not an officially supported Forward Networks product, provided as-is with no SLA. Fixes target the latest released version (see the Release Compatibility table). Report bugs via GitHub issues and security vulnerabilities privately per `SECURITY.md`. Review the deployment security notes in `SECURITY.md` before production use.
 
 ## What This Plugin Provides
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 keywords = ["netbox", "forward", "plugin", "sync", "nqe"]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
+    "Development Status :: 4 - Beta",
     "Framework :: Django",
     "Intended Audience :: System Administrators",
     "Intended Audience :: Information Technology",


### PR DESCRIPTION
Per maintainer: this is a **field integration**, not an officially supported Forward product. Reworded README Status + Support and docs/README to 'field integration reference … as-is, no SLA' (matches the Dynatrace repo), and dropped the `Development Status :: Production/Stable` classifier to `Beta`. Compat table untouched (CHANGELOG gate green).