### PR TITLE
feat: import Forward SNMP endpoints as NetBox devices (2.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Generated from the README compatibility table by `scripts/gen_changelog.py`. Do not edit by hand.
 
+## v2.3.2
+
+Feature: optional import of Forward SNMP endpoints (e.g. Avocent console servers) as NetBox devices — off by default (`sync_endpoints`), enabled per source and scoped by the same device tags.
+
 ## v2.3.1
 
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ Latest release requires NetBox `4.6.4` and `netbox-branching` `1.1.0+`. Expand f
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.3.1` | `4.6.4` required; needs netbox-branching `1.1.0+` | Current release;  |
+| `v2.3.2` | `4.6.4` required; needs netbox-branching `1.1.0+` | Current release; Feature: optional import of Forward SNMP endpoints (e.g. Avocent console servers) as NetBox devices — off by default (`sync_endpoints`), enabled per source and scoped by the same device tags. |
+| `v2.3.1` | `4.6.4` required; needs netbox-branching `1.1.0+` | Superseded by `v2.3.2`;  |
 | `v2.3.0` | `4.6.4` required; needs netbox-branching `1.1.0+` | Superseded by `v2.3.1`; GA/enterprise hardening: encrypted Forward credential at rest, PyPI Trusted Publishing + SBOM, Prometheus metrics + stuck-job alert, populated-DB upgrade test, dead-code removal (multi_branch/density-learning), reliability fixes (jittered/Retry-After backoff, SaaS rate clamp, PK-anchored device prune), and supported-product framing. Drop-in from 2.2.5 — stored credentials auto-encrypt on save; rotating SECRET_KEY requires re-entering them. |
 | `v2.2.5` | `4.6.4` required; needs netbox-branching `1.1.0+` | Superseded by `v2.3.0`; Feature: operator-selectable **Sync Device Tags** — pick which Forward device tags (e.g. `Mgmt_*`) become NetBox device tags (replaces the hardcoded feature-tag set); Fix dependency-preview AttributeError + vsys job pile-up guard (hung pending); test/require NetBox 4.6.4 |
 | `v2.2.4` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.2.5`; Hotfix: device-analysis NQE (bare foreach) errored refresh + CVE list; surface job errors into job.data |

--- a/docs/01_User_Guide/README.md
+++ b/docs/01_User_Guide/README.md
@@ -20,14 +20,14 @@ pip install forward-netbox
 Alternatively, install a specific wheel or source archive from GitHub Releases:
 
 ```bash
-pip install /path/to/forward_netbox-2.3.1-py3-none-any.whl
-pip install /path/to/forward_netbox-2.3.1.tar.gz
+pip install /path/to/forward_netbox-2.3.2-py3-none-any.whl
+pip install /path/to/forward_netbox-2.3.2.tar.gz
 ```
 
 If you mirror the package into a private Python index, pin the same release version:
 
 ```bash
-pip install forward-netbox==2.3.1
+pip install forward-netbox==2.3.2
 ```
 
 ## Release Compatibility
@@ -39,7 +39,8 @@ Latest release requires NetBox `4.6.4` and `netbox-branching` `1.1.0+`. Expand f
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.3.1` | `4.6.4` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Current release;  |
+| `v2.3.2` | `4.6.4` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Current release; Feature: optional import of Forward SNMP endpoints (e.g. Avocent console servers) as NetBox devices — off by default (`sync_endpoints`), enabled per source and scoped by the same device tags. |
+| `v2.3.1` | `4.6.4` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.3.2`;  |
 | `v2.3.0` | `4.6.4` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.3.1`; GA/enterprise hardening: encrypted Forward credential at rest, PyPI Trusted Publishing + SBOM, Prometheus metrics + stuck-job alert, populated-DB upgrade test, dead-code removal (multi_branch/density-learning), reliability fixes (jittered/Retry-After backoff, SaaS rate clamp, PK-anchored device prune), and supported-product framing. Drop-in from 2.2.5 — stored credentials auto-encrypt on save; rotating SECRET_KEY requires re-entering them. |
 | `v2.2.5` | `4.6.4` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.3.0`; Feature: operator-selectable **Sync Device Tags** — pick which Forward device tags (e.g. `Mgmt_*`) become NetBox device tags (replaces the hardcoded feature-tag set); Fix dependency-preview AttributeError + vsys job pile-up guard (hung pending); test/require NetBox 4.6.4 |
 | `v2.2.4` | `4.6.3` required (4.5.x dropped); needs netbox-branching `1.1.0+` | Superseded by `v2.2.5`; Hotfix: device-analysis NQE (bare foreach) errored refresh + CVE list; surface job errors into job.data |

--- a/docs/03_Plans/active/2026-07-06-snmp-endpoint-import.md
+++ b/docs/03_Plans/active/2026-07-06-snmp-endpoint-import.md
@@ -1,0 +1,63 @@
+# Import Forward SNMP endpoints as NetBox devices
+
+**Date:** 2026-07-06
+
+## Goal
+Let operators import Forward **endpoints** — generic SSH/SNMP devices Forward
+collects but does not model as first-class `network.devices` (e.g. Avocent
+console servers, which carry the same device tags) — into NetBox as devices.
+Reported by the design partner: N.Patel-tagged Avocents were not syncing.
+
+## Constraints
+- Opt-in (default off); zero change to existing device sync when off.
+- Reuse the existing dcim.device pipeline + device-tag scope (endpoints carry
+  `tagNames`, so the same include/exclude/match applies).
+- No new customer data committed; validated against the ADP demo org only.
+
+## Touched Surfaces
+- `forward_netbox/queries/forward_devices.nqe` — union a `network.endpoints`
+  branch onto the device query, gated by a `sync_endpoints` param + the standard
+  `device_tag_*` scope params. Generic identity from MIB-2 (sysName/sysDescr/
+  sysObjectId); per-vendor overlay (Avocent, enterprise OID 10418). Device
+  branch output is byte-identical (verified live: `model` is already a String,
+  `deviceType` serializes without the enum prefix).
+- `forward_netbox/utilities/query_registry.py` — `SYNC_ENDPOINTS_PARAMETER_*`;
+  `forward_devices.nqe` added to `DEVICE_TAG_PARAMETER_QUERY_FILES`; seed the
+  `sync_endpoints` default (False).
+- `forward_netbox/utilities/query_fetch_execution.py` — `ForwardQueryContext`
+  `sync_endpoints` field; read from source parameters; inject into any query
+  declaring `sync_endpoints` (mirrors `sync_device_tags`).
+- `forward_netbox/forms.py` — `sync_endpoints` BooleanField + persistence.
+- `forward_netbox/utilities/model_validation.py` — allowlist + bool type check.
+- `forward_netbox/tests/test_endpoints_import.py` — new.
+- `pyproject.toml`, `forward_netbox/__init__.py`, the three README compatibility
+  tables, `CHANGELOG.md` — version bump to 2.3.2 (shipped as a patch: additive,
+  off by default).
+
+## Approach
+The endpoint branch is a second `foreach` unioned into the device query with
+`+`; `where sync_endpoints` makes it emit nothing when off (NQE has no empty-list
+literal). SNMP scalars are read with `max(foreach o … where requestedOid == …
+select max(foreach e in o.rawOidEntries select e.rawValue))`. The whole query
+was validated live against the ADP org (155541): 5123 rows = all devices + 121
+Avocent endpoints (manufacturer "Avocent", model "Avocent ACS 8000"/"Cyclades
+ACS 6000", role "Console Server", tag-scoped).
+
+## Validation
+Live NQE run against ADP; `test_endpoints_import`; `test_query_registry`,
+`test_query_binding`, `test_forms` green; full Django suite; harness + sensitive.
+
+## Rollback
+Revert the query + wiring. When off (default) behaviour is unchanged, so the
+risk to existing syncs is nil.
+
+## Decision Log
+- Union into the device query rather than a separate model: endpoints ARE
+  devices in NetBox, and this reuses types/roles/scoping with no new contract.
+- MIB-2 generic core + per-vendor overlay: works for any SNMP endpoint out of
+  the box; Avocent is the first overlay, Infoblox/Palo are a few lines later.
+- Opt-in: endpoints are noisy and not every deployment wants them.
+
+## Bundled changes
+Optional import of Forward SNMP endpoints (e.g. Avocent console servers) as
+NetBox devices, off by default, enabled per source and scoped by device tags.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,8 @@ Latest release requires NetBox `4.6.4` and `netbox-branching` `1.1.0+`. Expand f
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.3.1` | `4.6.4` required; needs netbox-branching `1.1.0+` | Current release;  |
+| `v2.3.2` | `4.6.4` required; needs netbox-branching `1.1.0+` | Current release; Feature: optional import of Forward SNMP endpoints (e.g. Avocent console servers) as NetBox devices — off by default (`sync_endpoints`), enabled per source and scoped by the same device tags. |
+| `v2.3.1` | `4.6.4` required; needs netbox-branching `1.1.0+` | Superseded by `v2.3.2`;  |
 | `v2.3.0` | `4.6.4` required; needs netbox-branching `1.1.0+` | Superseded by `v2.3.1`; GA/enterprise hardening: encrypted Forward credential at rest, PyPI Trusted Publishing + SBOM, Prometheus metrics + stuck-job alert, populated-DB upgrade test, dead-code removal (multi_branch/density-learning), reliability fixes (jittered/Retry-After backoff, SaaS rate clamp, PK-anchored device prune), and supported-product framing. Drop-in from 2.2.5 — stored credentials auto-encrypt on save; rotating SECRET_KEY requires re-entering them. |
 | `v2.2.5` | `4.6.4` required; needs netbox-branching `1.1.0+` | Superseded by `v2.3.0`; Feature: operator-selectable **Sync Device Tags** — pick which Forward device tags (e.g. `Mgmt_*`) become NetBox device tags (replaces the hardcoded feature-tag set); Fix dependency-preview AttributeError + vsys job pile-up guard (hung pending); test/require NetBox 4.6.4 |
 | `v2.2.4` | `4.6.3` required; needs netbox-branching `1.1.0+` | Superseded by `v2.2.5`; Hotfix: device-analysis NQE (bare foreach) errored refresh + CVE list; surface job errors into job.data |

--- a/forward_netbox/__init__.py
+++ b/forward_netbox/__init__.py
@@ -8,7 +8,7 @@ class NetboxForwardConfig(PluginConfig):
     name = "forward_netbox"
     verbose_name = "Forward"
     description = "Sync Forward data into NetBox using built-in NQE queries."
-    version = "2.3.1"
+    version = "2.3.2"
     base_url = "forward"
     min_version = "4.6.4"
 

--- a/forward_netbox/forms.py
+++ b/forward_netbox/forms.py
@@ -436,6 +436,16 @@ class ForwardSourceForm(NetBoxModelForm):
                 "filtered in NetBox."
             ),
         )
+        self.fields["sync_endpoints"] = forms.BooleanField(
+            required=False,
+            label="Import SNMP Endpoints as Devices",
+            help_text=(
+                "Also import Forward SNMP endpoints (generic SSH/SNMP devices "
+                "Forward collects but does not model as first-class devices, "
+                "e.g. Avocent console servers) as NetBox devices, scoped by the "
+                "same device tags."
+            ),
+        )
         self.fields["sync_device_tags"] = FlexibleMultipleChoiceField(
             required=False,
             choices=(),
@@ -605,6 +615,7 @@ class ForwardSourceForm(NetBoxModelForm):
         self.fields["device_tag_include_tags"].initial = include_initial
         self.fields["device_tag_exclude_tags"].initial = exclude_initial
         self.fields["sync_device_tags"].initial = sync_tags_initial
+        self.fields["sync_endpoints"].initial = bool(parameters.get("sync_endpoints"))
         self.fields["device_tag_include_tags"].choices = [
             (tag, tag) for tag in include_initial
         ]
@@ -840,6 +851,7 @@ class ForwardSourceForm(NetBoxModelForm):
             ),
             "apply_device_scope_tags": bool(cleaned.get("apply_device_scope_tags")),
             "sync_device_tags": sync_device_tags,
+            "sync_endpoints": bool(cleaned.get("sync_endpoints")),
         }
         self.instance.type = source_type
         self.instance.url = (
@@ -1033,6 +1045,7 @@ class ForwardSourceForm(NetBoxModelForm):
                 self.cleaned_data.get("apply_device_scope_tags")
             ),
             "sync_device_tags": sync_device_tags,
+            "sync_endpoints": bool(self.cleaned_data.get("sync_endpoints")),
         }
         self.instance.status = ForwardSourceStatusChoices.NEW
         return super().save(*args, **kwargs)

--- a/forward_netbox/queries/forward_devices.nqe
+++ b/forward_netbox/queries/forward_devices.nqe
@@ -1,41 +1,82 @@
 /**
- * @intent Devices collected by Forward
- * @description It provides a list of devices collected by Forward to be added or
- * updated in NetBox using POST and PATCH requests to the /api/dcim/devices/ REST API endpoint.
+ * @intent Devices collected by Forward (plus optional SNMP endpoints)
+ * @description Devices to add or update in NetBox via POST/PATCH to
+ * /api/dcim/devices/. When sync_endpoints is true, generic SNMP endpoints that
+ * Forward collects but does not model as first-class devices (e.g. Avocent
+ * console servers) are also emitted as device rows, identified from standard
+ * MIB-2 (sysName/sysDescr/sysObjectId) with per-vendor overlays, and scoped by
+ * the same device tags.
  */
 
 import "netbox_utilities";
 
 @query
-f(forward_netbox_shard_keys: List<String>) =
-foreach device in network.devices
-where device.snapshotInfo.result == DeviceSnapshotResult.completed
-where device.platform.vendor != Vendor.FORWARD_CUSTOM
-where isEmpty(forward_netbox_shard_keys) || device.name in forward_netbox_shard_keys
-let location = device.locationName
-let model = device.platform.model
-let device_type = device.platform.deviceType
-let site_name = if isPresent(location) then toLowerCase(location) else "unknown"
-let site_slug = slugify(site_name)
-let role_name = replace(toString(device_type), "DeviceType.", "")
-let role_slug = slugify(role_name)
-let platform_name = normalizeDevicePlatformName(device)
-let platform_slug = slugify(platform_name)
-let device_type_slug = slugifyNetboxModel(toString(model))
-let manufacturer_name = canonicalManufacturerName(device.platform.vendor)
-let manufacturer_slug = slugify(manufacturer_name)
-select {
-  name: device.name,
-  manufacturer: manufacturer_name,
-  device_type: model,
-  device_type_slug: device_type_slug,
-  site: site_name,
-  site_slug: site_slug,
-  role: device_type,
-  role_slug: role_slug,
-  role_color: "9e9e9e",
-  platform: platform_name,
-  platform_slug: platform_slug,
-  status: "active",
-  manufacturer_slug: manufacturer_slug
-};
+f(forward_netbox_shard_keys: List<String>, sync_endpoints: Bool, device_tag_include_tags: List<String>, device_tag_include_match: String, device_tag_exclude_tags: List<String>) =
+foreach row in (
+  (
+    foreach device in network.devices
+    where device.snapshotInfo.result == DeviceSnapshotResult.completed
+    where device.platform.vendor != Vendor.FORWARD_CUSTOM
+    where isEmpty(forward_netbox_shard_keys) || device.name in forward_netbox_shard_keys
+    let model = toString(device.platform.model)
+    let role_name = replace(toString(device.platform.deviceType), "DeviceType.", "")
+    let site_name = if isPresent(device.locationName) then toLowerCase(device.locationName) else "unknown"
+    let platform_name = normalizeDevicePlatformName(device)
+    let manufacturer_name = canonicalManufacturerName(device.platform.vendor)
+    let manufacturer_slug = slugify(manufacturer_name)
+    select {
+      name: device.name,
+      manufacturer: manufacturer_name,
+      device_type: model,
+      device_type_slug: slugifyNetboxModel(model),
+      site: site_name,
+      site_slug: slugify(site_name),
+      role: role_name,
+      role_slug: slugify(role_name),
+      role_color: "9e9e9e",
+      platform: platform_name,
+      platform_slug: slugify(platform_name),
+      status: "active",
+      manufacturer_slug: manufacturer_slug
+    }
+  )
+  +
+  (
+    // SNMP endpoints (opt-in): generic SSH/SNMP devices Forward collects but
+    // does not model. Generic identity from MIB-2; Avocent overlay by enterprise
+    // OID 10418. Scoped by the same device tags (endpoints carry tagNames).
+    foreach endpoint in network.endpoints
+    where sync_endpoints
+    where !isEmpty(endpoint.snmpOutputs)
+    where isEmpty(device_tag_include_tags)
+      || (device_tag_include_match == "all"
+        && all(foreach tag in device_tag_include_tags select tag in endpoint.tagNames))
+      || (device_tag_include_match != "all"
+        && any(foreach tag in device_tag_include_tags select tag in endpoint.tagNames))
+    where isEmpty(device_tag_exclude_tags)
+      || !any(foreach tag in device_tag_exclude_tags select tag in endpoint.tagNames)
+    let sysDescrOpt = max(foreach o in endpoint.snmpOutputs where o.requestedOid == "1.3.6.1.2.1.1.1" select max(foreach e in o.rawOidEntries select e.rawValue))
+    let sysObjIdOpt = max(foreach o in endpoint.snmpOutputs where o.requestedOid == "1.3.6.1.2.1.1.2" select max(foreach e in o.rawOidEntries select e.rawValue))
+    let sysDescr = if isPresent(sysDescrOpt) then sysDescrOpt else "SNMP Endpoint"
+    let isAvocent = matches(if isPresent(sysObjIdOpt) then sysObjIdOpt else "", "*10418*")
+    let ep_manuf = if isAvocent then "Avocent" else replaceRegexMatches(sysDescr, re` .*`, "")
+    let ep_role = if isAvocent then "Console Server" else "SNMP Endpoint"
+    let ep_site = if isPresent(endpoint.locationName) then toLowerCase(endpoint.locationName) else "unknown"
+    select {
+      name: endpoint.name,
+      manufacturer: ep_manuf,
+      device_type: sysDescr,
+      device_type_slug: slugifyNetboxModel(sysDescr),
+      site: ep_site,
+      site_slug: slugify(ep_site),
+      role: ep_role,
+      role_slug: slugify(ep_role),
+      role_color: "9e9e9e",
+      platform: ep_manuf,
+      platform_slug: slugify(ep_manuf),
+      status: "active",
+      manufacturer_slug: slugify(ep_manuf)
+    }
+  )
+)
+select row;

--- a/forward_netbox/tests/test_endpoints_import.py
+++ b/forward_netbox/tests/test_endpoints_import.py
@@ -1,0 +1,51 @@
+from django.test import SimpleTestCase
+
+from forward_netbox.utilities.query_registry import _default_query_parameters
+from forward_netbox.utilities.query_registry import _read_query
+
+
+class EndpointImportWiringTest(SimpleTestCase):
+    """The device query gains an opt-in SNMP-endpoint branch (Avocent etc.)."""
+
+    def test_device_query_declares_sync_endpoints_default_off(self):
+        params = _default_query_parameters("forward_devices.nqe")
+        self.assertIn("sync_endpoints", params)
+        self.assertIs(params["sync_endpoints"], False)
+
+    def test_device_query_declares_device_tag_scope_params(self):
+        params = _default_query_parameters("forward_devices.nqe")
+        for key in (
+            "forward_netbox_shard_keys",
+            "device_tag_include_tags",
+            "device_tag_include_match",
+            "device_tag_exclude_tags",
+        ):
+            self.assertIn(key, params)
+
+    def test_device_query_source_has_endpoint_branch(self):
+        src = _read_query("forward_devices.nqe")
+        # Opt-in gate + endpoint source + MIB-2 identity + Avocent overlay.
+        self.assertIn("sync_endpoints: Bool", src)
+        self.assertIn("network.endpoints", src)
+        self.assertIn("where sync_endpoints", src)
+        self.assertIn("1.3.6.1.2.1.1.1", src)  # sysDescr
+        self.assertIn("1.3.6.1.2.1.1.2", src)  # sysObjectId
+        self.assertIn("10418", src)  # Avocent enterprise OID overlay
+        # Endpoints are scoped by the same device tags (they carry tagNames).
+        self.assertIn("endpoint.tagNames", src)
+
+    def test_device_query_still_emits_all_required_device_fields(self):
+        src = _read_query("forward_devices.nqe")
+        for field in (
+            "manufacturer:",
+            "device_type:",
+            "device_type_slug:",
+            "site:",
+            "site_slug:",
+            "role:",
+            "role_slug:",
+            "role_color:",
+            "status:",
+            "manufacturer_slug:",
+        ):
+            self.assertIn(field, src)

--- a/forward_netbox/utilities/model_validation.py
+++ b/forward_netbox/utilities/model_validation.py
@@ -60,6 +60,7 @@ def clean_forward_source(source):
             "device_tag_prune_out_of_scope",
             "apply_device_scope_tags",
             "sync_device_tags",
+            "sync_endpoints",
         }
     )
     if invalid:
@@ -75,6 +76,8 @@ def clean_forward_source(source):
         raise ValidationError(_("Provide a Forward username and password."))
     if not isinstance(parameters.get("verify", True), bool):
         raise ValidationError(_("`verify` must be a boolean."))
+    if not isinstance(parameters.get("sync_endpoints", False), bool):
+        raise ValidationError(_("`sync_endpoints` must be a boolean."))
     if parameters.get("network_id") is not None and not isinstance(
         parameters.get("network_id"), str
     ):

--- a/forward_netbox/utilities/query_fetch_execution.py
+++ b/forward_netbox/utilities/query_fetch_execution.py
@@ -181,6 +181,8 @@ class ForwardQueryContext:
     # Forward tags the operator selected to sync as NetBox device tags (feeds the
     # sync_device_tags query parameter of the device-tag sync query).
     sync_device_tags: list[str] = field(default_factory=list)
+    # Opt-in: import Forward SNMP endpoints (e.g. Avocent) as NetBox devices.
+    sync_endpoints: bool = False
     scoped_device_names: set[str] = field(default_factory=set)
     scoped_site_names: set[str] = field(default_factory=set)
     scoped_matched_tags: dict[str, list[str]] = field(default_factory=dict)
@@ -381,6 +383,7 @@ class ForwardQueryFetcher:
         sync_device_tags = sorted(
             {str(tag).strip() for tag in sync_device_tags if str(tag).strip()}
         )
+        sync_endpoints = bool(source_parameters.get("sync_endpoints"))
         context_cache_key = (
             network_id,
             snapshot_selector,
@@ -463,6 +466,7 @@ class ForwardQueryFetcher:
             device_tag_include_match=include_match,
             device_tag_prune_out_of_scope=prune_out_of_scope,
             sync_device_tags=sync_device_tags,
+            sync_endpoints=sync_endpoints,
             scoped_device_names=scoped_device_names,
             scoped_site_names=scoped_site_names,
             scoped_matched_tags=scoped_matched_tags,
@@ -2122,6 +2126,10 @@ class ForwardQueryFetcher:
         if "sync_device_tags" in spec_parameters:
             sanitized_parameters["sync_device_tags"] = sorted(
                 getattr(context, "sync_device_tags", None) or []
+            )
+        if "sync_endpoints" in spec_parameters:
+            sanitized_parameters["sync_endpoints"] = bool(
+                getattr(context, "sync_endpoints", False)
             )
         if not accepts_device_tag_parameters:
             return sanitized_parameters

--- a/forward_netbox/utilities/query_registry.py
+++ b/forward_netbox/utilities/query_registry.py
@@ -106,12 +106,18 @@ SHARD_QUERY_PARAMETER_DEFAULT = {SHARD_QUERY_PARAMETER_NAME: []}
 # resolved selection is injected in _prepare_query_parameters.
 SYNC_DEVICE_TAGS_PARAMETER_NAME = "sync_device_tags"
 SYNC_DEVICE_TAGS_PARAMETER_DEFAULT = {SYNC_DEVICE_TAGS_PARAMETER_NAME: []}
+# Opt-in: also import Forward SNMP endpoints (generic SSH/SNMP devices Forward
+# collects but does not model as first-class devices, e.g. Avocent console
+# servers) as NetBox devices. Declared by the device query; default off.
+SYNC_ENDPOINTS_PARAMETER_NAME = "sync_endpoints"
+SYNC_ENDPOINTS_PARAMETER_DEFAULT = {SYNC_ENDPOINTS_PARAMETER_NAME: False}
 DEVICE_TAG_QUERY_PARAMETER_DEFAULTS = {
     "device_tag_include_tags": [],
     "device_tag_include_match": "any",
     "device_tag_exclude_tags": [],
 }
 DEVICE_TAG_PARAMETER_QUERY_FILES = {
+    "forward_devices.nqe",
     "forward_hsrp_groups.nqe",
     "forward_locations.nqe",
     "forward_prefixes_ipv4.nqe",
@@ -138,6 +144,8 @@ def _default_query_parameters(filename: str) -> dict[str, Any]:
         parameters.update(SHARD_QUERY_PARAMETER_DEFAULT)
     if SYNC_DEVICE_TAGS_PARAMETER_NAME in source:
         parameters.update(SYNC_DEVICE_TAGS_PARAMETER_DEFAULT)
+    if SYNC_ENDPOINTS_PARAMETER_NAME in source:
+        parameters.update(SYNC_ENDPOINTS_PARAMETER_DEFAULT)
     return parameters
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "forward-netbox"
-version = "2.3.1"
+version = "2.3.2"
 description = "NetBox plugin to sync Forward data into NetBox via built-in NQE queries"
 authors = ["Craig Johnson <craigjohnson@forwardnetworks.com>"]
 license = "MIT"


### PR DESCRIPTION
Fixes the design-partner report: N.Patel-tagged **Avocent** console servers weren't syncing because Forward files them as **endpoints** (generic SSH/SNMP), not modeled `network.devices`.

**What:** `forward_devices.nqe` gains an **opt-in** `network.endpoints` branch (unioned into the device query), gated by a `sync_endpoints` param and scoped by the same device tags (endpoints carry `tagNames`). Identity from standard MIB-2 (sysName/sysDescr/sysObjectId) + a per-vendor overlay (Avocent = enterprise OID 10418); Infoblox/Palo overlays are a few lines later.

**Safety:** off by default; device-branch output is byte-identical (verified live — `model` is already a String, `deviceType` serializes without the enum prefix). Wired through registry/context/form/validation exactly like `sync_device_tags`.

**Validated:** live NQE against the ADP org (5123 rows = all devices + 121 Avocent endpoints, manufacturer "Avocent", model "Avocent ACS 8000"/"Cyclades ACS 6000", role "Console Server"); full Django suite 964 green; new `test_endpoints_import`.