### PR TITLE
docs: reflect core/integrations editions split

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ On top of the import it adds scope control (sync only devices carrying chosen Fo
 - **It is not a source of truth for Forward configuration or intent** — it
   populates NetBox from Forward's collected snapshot, nothing more.
 - **It does not require** the optional `netbox-routing` / `netbox-peering-manager`
-  / `netbox-dlm` plugins unless you enable the beta BGP/OSPF or device-lifecycle
-  maps.
+  / `netbox-cisco-aci` / `netbox-dlm` plugins — the **core** edition ships without
+  them. Install `forward-netbox[integrations]` and enable the relevant maps to use
+  the beta BGP/OSPF, Cisco ACI, or device-lifecycle surfaces.
 
 ## Screenshots
 
@@ -234,18 +235,23 @@ use.
 
 ## Quickstart
 
-1. Install the plugin into the same Python environment as NetBox:
+1. Install the plugin into the same Python environment as NetBox. `forward-netbox`
+   ships two profiles — **core** (NetBox-builtin models only) and **integrations**
+   (adds the optional `netbox-dlm` / `netbox-routing` / `netbox-cisco-aci` /
+   `netbox-peering-manager` maps). See
+   [Editions](docs/01_User_Guide/README.md#editions-core-vs-integrations).
 
 Install the latest release from PyPI:
 
 ```bash
-pip install forward-netbox
+pip install forward-netbox                # core
+pip install forward-netbox[integrations]  # + optional plugin maps
 ```
 
 Or install a specific wheel or source archive from GitHub Releases:
 
 ```bash
-pip install /path/to/forward_netbox-2.2.5-py3-none-any.whl
+pip install /path/to/forward_netbox-2.5.3-py3-none-any.whl
 ```
 
 2. Enable both plugins in the NetBox configuration:

--- a/docs/01_User_Guide/upgrade.md
+++ b/docs/01_User_Guide/upgrade.md
@@ -20,10 +20,13 @@ Run these in the NetBox Python environment (and inside every worker container in
 containerized deployment):
 
 ```bash
-# 1. Install the target version.
-pip install --upgrade forward-netbox            # latest
+# 1. Install the target version. Keep the [integrations] extra if you run the
+#    optional plugin maps (netbox-dlm / netbox-routing / netbox-cisco-aci /
+#    netbox-peering-manager); plain forward-netbox is the core edition.
+pip install --upgrade forward-netbox                 # core
+pip install --upgrade "forward-netbox[integrations]" # keep optional plugin maps
 # or pin explicitly:
-# pip install forward-netbox==<version>
+# pip install "forward-netbox[integrations]==<version>"
 
 # 2. Apply database migrations.
 cd /opt/netbox/netbox && python manage.py migrate

--- a/docs/02_Reference/built-in-nqe-maps.md
+++ b/docs/02_Reference/built-in-nqe-maps.md
@@ -2,6 +2,8 @@
 
 This reference lists the built-in NQE maps that ship with `forward_netbox`.
 
+Maps targeting `netbox_routing.*`, `netbox_peering_manager.*`, `netbox_cisco_aci.*`, or `netbox_dlm.*` require the matching optional plugin, shipped in the **integrations** edition (`pip install forward-netbox[integrations]`, or a single extra like `[dlm]`). The **core** edition (`pip install forward-netbox`) ships only the NetBox-builtin maps. See [Editions](../01_User_Guide/README.md#editions-core-vs-integrations).
+
 Each entry includes:
 
 - the map name

--- a/docs/02_Reference/model-mapping-matrix.md
+++ b/docs/02_Reference/model-mapping-matrix.md
@@ -2,6 +2,8 @@
 
 This matrix summarizes how the shipped Forward NQE maps populate each NetBox model.
 
+Maps for `netbox_routing.*`, `netbox_peering_manager.*`, `netbox_cisco_aci.*`, and `netbox_dlm.*` require the matching optional plugin — install the **integrations** edition (`pip install forward-netbox[integrations]`, or a single extra like `[dlm]`) and enable the map. The **core** edition (`pip install forward-netbox`) ships only the NetBox-builtin models below. See [Editions](../01_User_Guide/README.md#editions-core-vs-integrations).
+
 `Exact` means the Forward data maps cleanly to the NetBox object without a major semantic compromise. `Best-fit` means the plugin intentionally approximates the Forward concept to the closest useful NetBox model.
 
 | NetBox Model | Built-In Query | Forward Source Shape | Mapping Style | Notes |

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 `forward_netbox` connects NetBox directly to Forward, executes NQE against a selected Forward snapshot, and stages the resulting changes in a NetBox branch for review and merge by default. Large trusted baselines can optionally use fast bootstrap direct writes before returning to the Branching workflow.
 
+It installs in two profiles: **core** (`pip install forward-netbox`, NetBox-builtin models only) and **integrations** (`pip install forward-netbox[integrations]`, which adds the optional `netbox-dlm` / `netbox-routing` / `netbox-cisco-aci` / `netbox-peering-manager` maps). See [Editions](01_User_Guide/README.md#editions-core-vs-integrations).
+
 Forward 26.6 is the baseline for async NQE.
 
 ## Release Compatibility


### PR DESCRIPTION
Docs-only follow-up to 2.5.3 — make the core-vs-integrations editions split consistent everywhere install/plugins are described (the User Guide **Editions** section already shipped in 2.5.3; this fills the gaps):

- **README** Quickstart: `pip install forward-netbox` (core) vs `forward-netbox[integrations]`; fixed a stale `forward_netbox-2.2.5` wheel example → `2.5.3`; the "does not require" bullet now points at the extra (+ includes `netbox-cisco-aci`).
- **docs/README** intro: editions line + link.
- **User Guide `upgrade.md`**: keep the `[integrations]` extra on upgrade so plugin maps carry over.
- **Reference** (`model-mapping-matrix.md`, `built-in-nqe-maps.md`): top note that `netbox_routing.*` / `netbox_peering_manager.*` / `netbox_cisco_aci.*` / `netbox_dlm.*` maps require the integrations edition.

No code, no version bump. Cross-links match existing `.md#anchor` patterns that already pass `mkdocs --strict`.