### PR TITLE
release: authorize v2.6.0

### DIFF
--- a/docs/03_Plans/active/2026-07-18-release-2.6.0-scope-convergence.md
+++ b/docs/03_Plans/active/2026-07-18-release-2.6.0-scope-convergence.md
@@ -735,24 +735,15 @@ The local finalizer and release workflow reject the release while any required i
 is unchecked or lacks concrete evidence. These entries are updated only from the
 same final tree that will be tagged.
 
-- Evidence base commit: `pending`
+- Evidence base commit: `9e14697dc6c5917ea345da9c64a0693d8d12b857`
 
-- [ ] `final-tree-full-gate` - Full harness, lint, check, scenario, Django,
-  documentation, sensitive-content, and CI-equivalent gates must pass.
-- [ ] `exact-runtime-artifact` - The wheel must pass clean installation,
-  migration, system-check, migration-drift, metadata, and installed-runtime SBOM
-  validation on NetBox 4.6.5, Branching 1.1.1, and Python 3.14.
-- [ ] `scale-and-failure` - Scale, collision, rollback, partial retry,
-  stale-generation, concurrency, and recovery tests must pass.
-- [ ] `ui-validation` - Desktop and mobile Playwright validation must pass with
-  no overlap, overflow, blank state, or broken action.
-- [ ] `ownership-audit` - Strict ownership audit must report no inconsistent
-  state and no open branches on the release testbed.
-- [ ] `customer-equivalent-acceptance` - Affected-environment-equivalent preview, sync,
-  post-sync overlays, issue assertions, support evidence, and same-snapshot
-  repeat convergence must pass.
-- [ ] `independent-review` - Independent final-tree reviews must report no
-  concrete release blocker.
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 FORWARD_NETBOX_HOST_PORT=8080 NETBOX_URL=http://127.0.0.1:8080 invoke ci` completed green: harness, lint, checks, scenario, Django, docs, sensitive-content, and CI-equivalent gates passed with 0 failures.
+- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke artifact-test` passed clean installation, migration, system checks, metadata, and installed-runtime SBOM validation on NetBox 4.6.5, Branching 1.1.1, and Python 3.14.
+- [x] `scale-and-failure` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-upgrade26 FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke scale-soak --runs 3 --max-changes-per-staging-item 10000 --pause-seconds 0`, `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke scenario-test`, and `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke bulk-merge-retry-scale-test` passed scale, collision, rollback, partial retry, stale-generation, concurrency, and recovery coverage with 0 errors.
+- [x] `ui-validation` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 FORWARD_NETBOX_HOST_PORT=8080 NETBOX_URL=http://127.0.0.1:8080 invoke playwright-test` passed desktop and mobile validation with 14 checks and 0 overlap, overflow, blank-state, or broken-action findings.
+- [x] `ownership-audit` - `rtk docker compose --project-name forward-netbox-release-gate --project-directory development exec -T netbox python manage.py forward_ownership_audit --fail-on-inconsistent --require-no-open-branches` reported consistent=true, release_ready=true, 0 inconsistent records, and 0 open branches.
+- [x] `customer-equivalent-acceptance` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-upgrade26 FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke sync-release-gate --sync-ids 51 --max-polls 6 --interval-seconds 10` passed sync id 51 preview, sync, overlays, issue assertions, support evidence, and same-snapshot repeat convergence with 0 warnings and 0 blocking issues.
+- [x] `independent-review` - Independent review passed with 0 blockers and 0 findings after `rtk git diff --check`, the security hardening, query publication repair, and dependency-summary corrections.
 
 ## Rollback
 


### PR DESCRIPTION
Release Evidence PR for v2.6.0. Required CI, CodeQL, and the trusted sensitive-content status must pass before squash merge.