### PR TITLE
fix: correct release provenance bridge

### DIFF
--- a/docs/03_Plans/active/2026-07-22-release-provenance-repair.md
+++ b/docs/03_Plans/active/2026-07-22-release-provenance-repair.md
@@ -1,18 +1,43 @@
 # Release Provenance Repair
 
-## Scope
+## Goal
+
+Allow the validated 2.6.0 protected-main tag to pass provenance validation and
+publish identical GitHub and PyPI artifacts.
+
+## Constraints
+
+Keep the repair limited to release provenance metadata and preserve protected
+branch, tag, and trusted-publishing controls.
+
+## Touched Surfaces
+
+- `scripts/verify_release_provenance.py`
+- This release repair plan
+
+## Approach
 
 Correct the prior-release documentation bridge used by tagged-release
 provenance validation. The previous commit identifier was not present in the
 repository history, so the 2.6.0 publication workflow rejected an otherwise
 valid protected-main release.
 
-## Evidence
+## Validation
 
 - The actual post-2.5.11 documentation bridge is `f9a8420a8bcc2d3afe338d0435a17df9e2bc01d0`.
 - The change is limited to the provenance validator constant.
 - Required CI, CodeQL, sensitive-content scanning, and tagged release
   validation must pass before retrying publication.
+
+## Rollback
+
+If validation fails, do not publish or recreate the release tag; revert the
+repair commit through the protected PR flow.
+
+## Decision Log
+
+- Use the actual first-parent bridge commit rather than weakening provenance
+  validation or bypassing the release workflow.
 
 ## Completion
 

--- a/docs/03_Plans/active/2026-07-22-release-provenance-repair.md
+++ b/docs/03_Plans/active/2026-07-22-release-provenance-repair.md
@@ -1,0 +1,20 @@
+# Release Provenance Repair
+
+## Scope
+
+Correct the prior-release documentation bridge used by tagged-release
+provenance validation. The previous commit identifier was not present in the
+repository history, so the 2.6.0 publication workflow rejected an otherwise
+valid protected-main release.
+
+## Evidence
+
+- The actual post-2.5.11 documentation bridge is `f9a8420a8bcc2d3afe338d0435a17df9e2bc01d0`.
+- The change is limited to the provenance validator constant.
+- Required CI, CodeQL, sensitive-content scanning, and tagged release
+  validation must pass before retrying publication.
+
+## Completion
+
+After the protected PR merges, recreate the failed `v2.6.0` tag from the
+validated main commit and verify identical GitHub and PyPI artifacts.

--- a/scripts/verify_release_provenance.py
+++ b/scripts/verify_release_provenance.py
@@ -18,7 +18,7 @@ TRUSTED_STATUS_CONTEXT = "Trusted sensitive-content scan"
 TRUSTED_STATUS_CREATOR = "github-actions[bot]"
 TRUSTED_SCANNER_WORKFLOW = ".github/workflows/trusted-sensitive-pr.yml"
 PRIOR_RELEASE_TAG = "v2.5.11"
-PRIOR_POST_RELEASE_DOC_COMMIT = "df85f2e94b91f5afe3a419c3121aeb189f2b2737"
+PRIOR_POST_RELEASE_DOC_COMMIT = "f9a8420a8bcc2d3afe338d0435a17df9e2bc01d0"
 BOOTSTRAP_REQUIRED_FILES = (
     TRUSTED_SCANNER_WORKFLOW,
     "scripts/check_sensitive_content.py",


### PR DESCRIPTION
Correct the post-2.5.11 documentation bridge used by tagged release provenance validation. The prior hash does not exist in repository history; use the actual bridge commit f9a8420a8bcc2d3afe338d0435a17df9e2bc01d0.