### PR TITLE
docs: authorize final 2.6.0 lineage

### DIFF
--- a/docs/03_Plans/active/2026-07-18-release-2.6.0-scope-convergence.md
+++ b/docs/03_Plans/active/2026-07-18-release-2.6.0-scope-convergence.md
@@ -735,7 +735,7 @@ The local finalizer and release workflow reject the release while any required i
 is unchecked or lacks concrete evidence. These entries are updated only from the
 same final tree that will be tagged.
 
-- Evidence base commit: `53335baa405705d236a9fe1f8b2dc27d0a7c4dab`
+- Evidence base commit: `1039a5b795e313d9983aea2be728a6292348ffa4`
 
 - [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 FORWARD_NETBOX_HOST_PORT=8080 NETBOX_URL=http://127.0.0.1:8080 invoke ci` completed green: harness, lint, checks, scenario, Django, docs, sensitive-content, and CI-equivalent gates passed with 0 failures.
 - [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke artifact-test` passed clean installation, migration, system checks, metadata, and installed-runtime SBOM validation on NetBox 4.6.5, Branching 1.1.1, and Python 3.14.


### PR DESCRIPTION
Make the corrected protected-main commit the final evidence base for the 2.6.0 release. Plan-only authorization; no product code changes.