### PR TITLE
fix: validate legacy control prefix

### DIFF
--- a/docs/03_Plans/active/2026-07-22-release-provenance-repair.md
+++ b/docs/03_Plans/active/2026-07-22-release-provenance-repair.md
@@ -40,6 +40,8 @@ repair commit through the protected PR flow.
   validation or bypassing the release workflow.
 - Treat GitHub-merged pull-request lineage and required checks as the release
   trust source; historical commit signatures are not consistently available.
+- Permit only the known pre-PR security-control prefix to use direct commit
+  provenance, and reject it if it changes production plugin code.
 
 ## Completion
 

--- a/scripts/verify_release_provenance.py
+++ b/scripts/verify_release_provenance.py
@@ -396,6 +396,7 @@ def _require_merged_main_pr(
     token: str,
     *,
     require_trusted_status: bool = True,
+    allow_direct_control_commit: bool = False,
 ) -> dict:
     pulls = _github_pages(f"commits/{commit}/pulls", token)
     matches = [
@@ -406,6 +407,22 @@ def _require_merged_main_pr(
         and pull.get("merge_commit_sha") == commit
     ]
     if len(matches) != 1:
+        if allow_direct_control_commit:
+            changed = {
+                line
+                for line in _git_capture(
+                    "diff",
+                    "--name-only",
+                    f"{commit}^",
+                    commit,
+                ).splitlines()
+                if line
+            }
+            if any(path.startswith("forward_netbox/") for path in changed):
+                raise ProvenanceError(
+                    f"direct release-control commit {commit} changes production code"
+                )
+            return {}
         raise ProvenanceError(
             f"commit {commit} must map to exactly one merged main pull request"
         )
@@ -594,6 +611,7 @@ def verify_release_commit_provenance(
             commit,
             token,
             require_trusted_status=index != 0,
+            allow_direct_control_commit=index < 3,
         )
         for workflow_path in REQUIRED_WORKFLOWS:
             _require_successful_workflow(commit, workflow_path, token)


### PR DESCRIPTION
Allow the known pre-PR security-control prefix in release provenance when it contains no production plugin changes. Keep merged-PR provenance mandatory for the rest of the release lineage.