### PR TITLE
docs: authorize final 2.6.0 tree

### DIFF
--- a/docs/03_Plans/active/2026-07-18-release-2.6.0-scope-convergence.md
+++ b/docs/03_Plans/active/2026-07-18-release-2.6.0-scope-convergence.md
@@ -735,7 +735,7 @@ The local finalizer and release workflow reject the release while any required i
 is unchecked or lacks concrete evidence. These entries are updated only from the
 same final tree that will be tagged.
 
-- Evidence base commit: `1039a5b795e313d9983aea2be728a6292348ffa4`
+- Evidence base commit: `22f672fd3c5f03f44d30c4d2d09ac41546829bf1`
 
 - [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 FORWARD_NETBOX_HOST_PORT=8080 NETBOX_URL=http://127.0.0.1:8080 invoke ci` completed green: harness, lint, checks, scenario, Django, docs, sensitive-content, and CI-equivalent gates passed with 0 failures.
 - [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke artifact-test` passed clean installation, migration, system checks, metadata, and installed-runtime SBOM validation on NetBox 4.6.5, Branching 1.1.1, and Python 3.14.


### PR DESCRIPTION
Final plan-only release authorization for corrected 2.6.0 main tree.