### PR TITLE
release: authorize v2.6.0

### DIFF
--- a/docs/03_Plans/active/2026-07-18-release-2.6.0-scope-convergence.md
+++ b/docs/03_Plans/active/2026-07-18-release-2.6.0-scope-convergence.md
@@ -735,7 +735,7 @@ The local finalizer and release workflow reject the release while any required i
 is unchecked or lacks concrete evidence. These entries are updated only from the
 same final tree that will be tagged.
 
-- Evidence base commit: `22f672fd3c5f03f44d30c4d2d09ac41546829bf1`
+- Evidence base commit: `01d4deb7a04de8f6d8f61283a37d291b425f8b23`
 
 - [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 FORWARD_NETBOX_HOST_PORT=8080 NETBOX_URL=http://127.0.0.1:8080 invoke ci` completed green: harness, lint, checks, scenario, Django, docs, sensitive-content, and CI-equivalent gates passed with 0 failures.
 - [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke artifact-test` passed clean installation, migration, system checks, metadata, and installed-runtime SBOM validation on NetBox 4.6.5, Branching 1.1.1, and Python 3.14.
@@ -832,3 +832,8 @@ as one tested unit. Do not run an older plugin against 2.6 ownership state.
 11. Current architecture, code, tests, and documentation contain no known
     technical debt, architecture gap, beta path, or deferred release work.
 12. No tag or release is created until the operator explicitly authorizes it.
+
+## Final Evidence Binding
+
+The final release-evidence commit contains this plan only and binds the
+validated protected-main tree to the `v2.6.0` publication gate.


### PR DESCRIPTION
Release evidence PR for v2.6.0. The final evidence commit changes only the release plan and binds the validated main tree. Required CI, CodeQL, trusted scanning, and release authorization must pass before merge.