### PR TITLE
fix: allow audited test-only control paths

### DIFF
--- a/docs/03_Plans/active/2026-07-22-release-provenance-repair.md
+++ b/docs/03_Plans/active/2026-07-22-release-provenance-repair.md
@@ -45,6 +45,8 @@ repair commit through the protected PR flow.
 - Skip unavailable historical workflow-run lookups only for that same
   security-control prefix; all pull-request-backed commits still require the
   complete required-workflow success set.
+- Classify test-only paths under `forward_netbox/tests/` as control evidence;
+  runtime plugin modules remain rejected for direct historical commits.
 
 ## Completion
 

--- a/scripts/tests/test_verify_release_provenance.py
+++ b/scripts/tests/test_verify_release_provenance.py
@@ -347,6 +347,24 @@ class ReleaseProvenanceTest(unittest.TestCase):
                 )
             )
 
+    def test_direct_control_commit_rejects_runtime_plugin_code(self):
+        commit = "f" * 40
+
+        with (
+            patch.object(provenance, "_github_pages", return_value=[]),
+            patch.object(
+                provenance,
+                "_git_capture",
+                return_value="forward_netbox/models.py",
+            ),
+        ):
+            with self.assertRaises(provenance.ProvenanceError):
+                provenance._require_merged_main_pr(
+                    commit,
+                    "token",
+                    allow_direct_control_commit=True,
+                )
+
     def test_rejects_tagged_release_diverged_from_main(self):
         advanced_main = "e" * 40
 

--- a/scripts/verify_release_provenance.py
+++ b/scripts/verify_release_provenance.py
@@ -418,7 +418,13 @@ def _require_merged_main_pr(
                 ).splitlines()
                 if line
             }
-            if any(path.startswith("forward_netbox/") for path in changed):
+            runtime_paths = {
+                path
+                for path in changed
+                if path.startswith("forward_netbox/")
+                and not path.startswith("forward_netbox/tests/")
+            }
+            if runtime_paths:
                 raise ProvenanceError(
                     f"direct release-control commit {commit} changes production code"
                 )


### PR DESCRIPTION
Treat test-only paths in the audited historical security-control prefix as control evidence while continuing to reject runtime plugin changes.\n\nValidation: focused provenance tests and invoke harness-check.