### PR TITLE
fix: validate merged trusted scan coverage

### DIFF
--- a/docs/03_Plans/active/2026-07-22-release-provenance-repair.md
+++ b/docs/03_Plans/active/2026-07-22-release-provenance-repair.md
@@ -47,6 +47,8 @@ repair commit through the protected PR flow.
   complete required-workflow success set.
 - Classify test-only paths under `forward_netbox/tests/` as control evidence;
   runtime plugin modules remain rejected for direct historical commits.
+- Resolve trusted scanner coverage against the exact merged PR when GitHub no
+  longer includes the PR in the completed run payload.
 
 ## Completion
 

--- a/scripts/tests/test_verify_release_provenance.py
+++ b/scripts/tests/test_verify_release_provenance.py
@@ -167,6 +167,7 @@ class ReleaseProvenanceTest(unittest.TestCase):
                     "number": number,
                     "merged_at": merged_at[number],
                     "head": {"sha": candidate},
+                    "base": {"ref": "main"},
                 }
 
         status_runs = {
@@ -208,13 +209,7 @@ class ReleaseProvenanceTest(unittest.TestCase):
                     "event": "pull_request_target",
                     "status": "completed",
                     "conclusion": "success",
-                    "pull_requests": [
-                        {
-                            "number": pull_number,
-                            "head": {"sha": candidate},
-                            "base": {"ref": "main"},
-                        }
-                    ],
+                    "pull_requests": [],
                 }
 
         workflow_paths = dict(enumerate(provenance.REQUIRED_WORKFLOWS, 1))
@@ -478,7 +473,13 @@ class ReleaseProvenanceTest(unittest.TestCase):
         def github(path, token):
             payload = self._github(path, token)
             if path == "actions/runs/202":
-                payload["pull_requests"][0]["number"] = 999
+                payload["pull_requests"] = [
+                    {
+                        "number": 999,
+                        "head": {"sha": self.evidence_candidate},
+                        "base": {"ref": "main"},
+                    }
+                ]
             return payload
 
         with self.assertRaisesRegex(provenance.ProvenanceError, "exact pull"):

--- a/scripts/verify_release_provenance.py
+++ b/scripts/verify_release_provenance.py
@@ -385,6 +385,15 @@ def _require_trusted_candidate_status(
         and (pull.get("head") or {}).get("sha") == candidate
         and (pull.get("base") or {}).get("ref") == "main"
     ]
+    if not pull_matches and not run.get("pull_requests"):
+        pull = _github_json(f"pulls/{pull_number}", token)
+        if (
+            isinstance(pull, dict)
+            and pull.get("number") == pull_number
+            and (pull.get("head") or {}).get("sha") == candidate
+            and (pull.get("base") or {}).get("ref") == "main"
+        ):
+            pull_matches = [pull]
     if len(pull_matches) != 1:
         raise ProvenanceError(
             "trusted scanner run does not cover the exact pull request candidate"


### PR DESCRIPTION
Use the exact merged PR lookup when GitHub's completed trusted-scan run no longer includes pull_requests. Preserve candidate SHA, main base, trusted workflow identity, and successful status checks.\n\nValidation: focused provenance tests and invoke harness-check.