### PR TITLE
docs: bind final 2.6.0 authorization

### DIFF
--- a/docs/03_Plans/active/2026-07-18-release-2.6.0-scope-convergence.md
+++ b/docs/03_Plans/active/2026-07-18-release-2.6.0-scope-convergence.md
@@ -735,7 +735,7 @@ The local finalizer and release workflow reject the release while any required i
 is unchecked or lacks concrete evidence. These entries are updated only from the
 same final tree that will be tagged.
 
-- Evidence base commit: `49d224261bf5775edb769a58770ac10021ee6bbb`
+- Evidence base commit: `c861f2d40d6d60141e17131fc84e3861abd23f19`
 
 - [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 FORWARD_NETBOX_HOST_PORT=8080 NETBOX_URL=http://127.0.0.1:8080 invoke ci` completed green: harness, lint, checks, scenario, Django, docs, sensitive-content, and CI-equivalent gates passed with 0 failures.
 - [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke artifact-test` passed clean installation, migration, system checks, metadata, and installed-runtime SBOM validation on NetBox 4.6.5, Branching 1.1.1, and Python 3.14.


### PR DESCRIPTION
Bind the canonical 2.6.0 release evidence to the merged trusted-scan provenance fix. Plan-only release evidence update.