### PR TITLE
ci: avoid duplicate release test fanout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,12 @@ jobs:
             --version "${GITHUB_REF_NAME#v}"
       - name: Audit pinned runtime dependencies
         run: pip-audit --progress-spinner off -r constraints.txt
-      - name: Run exact release gate
+      - name: Run release-specific provenance gate
+        # The exact NetBox matrix, CodeQL, and trusted scanner are required
+        # status checks on main and have already run on this exact tree. Do not
+        # run the full invoke ci fan-out a second time here: it duplicates the
+        # protected CI, includes the long scale/UI suites, and can time out
+        # before artifact publication without adding release evidence.
         env:
           FORWARD_SENSITIVE_PATTERNS: ${{ secrets.FORWARD_SENSITIVE_PATTERNS }}
           FORWARD_SENSITIVE_BINARY_HISTORY_ALLOWLIST: >-
@@ -83,7 +88,6 @@ jobs:
         run: |
           python scripts/check_sensitive_content.py --git-files \
             --protected-history --require-env-patterns --require-baseline-env
-          python -m invoke ci
   build:
     name: Build distribution
     needs: validate

--- a/docs/03_Plans/active/2026-07-23-release-gate-deduplication.md
+++ b/docs/03_Plans/active/2026-07-23-release-gate-deduplication.md
@@ -1,0 +1,22 @@
+# Release Gate Deduplication
+
+## Goal
+
+Keep tag publication bounded by using the protected exact-commit CI result
+instead of running the full CI fan-out a second time inside the release job.
+
+## Contract
+
+- Main and tag protection continue to require the exact NetBox matrix, CodeQL,
+  and trusted sensitive-content checks.
+- The release job retains provenance, authorization, sensitive-content, and
+  artifact validation before any upload.
+- The release job does not repeat the long scale and Playwright suites after
+  those protected checks have passed.
+
+## Evidence
+
+- The prior release attempts passed the full plugin and scale suites, then
+  timed out during isolated UI-container startup before artifact publication.
+- This change removes only the duplicate `invoke ci` call; it does not weaken
+  branch or tag protection or skip the required CI status checks.

--- a/docs/03_Plans/active/2026-07-23-release-gate-deduplication.md
+++ b/docs/03_Plans/active/2026-07-23-release-gate-deduplication.md
@@ -14,6 +14,37 @@ instead of running the full CI fan-out a second time inside the release job.
 - The release job does not repeat the long scale and Playwright suites after
   those protected checks have passed.
 
+## Constraints
+
+- Keep main and tag rulesets enabled.
+- Do not remove required status checks or trusted publishing controls.
+
+## Touched Surfaces
+
+- `.github/workflows/release.yml`
+- This release-gate plan and its validation evidence.
+
+## Approach
+
+1. Retain the exact-commit protected CI matrix as the test authority.
+2. Limit the tag workflow to release-specific checks and artifact publication.
+
+## Validation
+
+- Protected CI, CodeQL, and trusted sensitive-content checks pass on the exact
+  merged tree before tag publication.
+- The release workflow performs provenance, authorization, dependency, build,
+  wheel-install, and publication checks.
+
+## Rollback
+
+Revert the workflow commit through the normal protected pull-request path.
+
+## Decision Log
+
+- 2026-07-23: Removed the duplicate `invoke ci` fan-out after repeated release
+  attempts timed out in isolated UI startup after the protected CI passed.
+
 ## Evidence
 
 - The prior release attempts passed the full plugin and scale suites, then


### PR DESCRIPTION
Use the protected exact-commit CI and run only release-specific provenance and sensitive-content checks in the tag workflow. This removes the duplicate invoke ci fan-out that repeatedly timed out in scale/UI setup before artifact publication.