### PR TITLE
release: authorize v2.6.1

### DIFF
--- a/docs/03_Plans/active/2026-07-23-release-2.6.1-python-compatibility.md
+++ b/docs/03_Plans/active/2026-07-23-release-2.6.1-python-compatibility.md
@@ -41,3 +41,18 @@ Revert the patch through the normal protected pull-request path. The existing
 - 2026-07-23: `2.6.0` was found to require Python `>=3.14,<3.15`; restore the
   previously supported lower bound in a patch release rather than rewriting
   immutable PyPI metadata.
+
+## Release Authorization
+
+The compatibility patch changes packaging metadata and documentation only; the
+runtime behavior covered by the existing release evidence is unchanged.
+
+- Evidence base commit: `3b639d93e4a15d54ef493212892c92584fd6187a`
+
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 FORWARD_NETBOX_HOST_PORT=8080 NETBOX_URL=http://127.0.0.1:8080 invoke ci` completed green: protected CI, harness, lint, checks, scenario, Django, docs, and sensitive-content gates passed with 0 failures.
+- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke artifact-test` passed clean installation, migration, system checks, metadata, and installed-runtime SBOM validation on NetBox 4.6.5, Branching 1.1.1, and Python 3.14.
+- [x] `scale-and-failure` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-upgrade26 FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke scale-soak --runs 3 --max-changes-per-staging-item 10000 --pause-seconds 0`, `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke scenario-test`, and `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke bulk-merge-retry-scale-test` passed scale, collision, rollback, partial retry, stale-generation, concurrency, and recovery coverage with 0 errors.
+- [x] `ui-validation` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 FORWARD_NETBOX_HOST_PORT=8080 NETBOX_URL=http://127.0.0.1:8080 invoke playwright-test` passed desktop and mobile validation with 14 checks and 0 overlap, overflow, blank-state, or broken-action findings.
+- [x] `ownership-audit` - `rtk docker compose --project-name forward-netbox-release-gate --project-directory development exec -T netbox python manage.py forward_ownership_audit --fail-on-inconsistent --require-no-open-branches` reported consistent=true, release_ready=true, 0 inconsistent records, and 0 open branches.
+- [x] `customer-equivalent-acceptance` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-upgrade26 FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke sync-release-gate --sync-ids 51 --max-polls 6 --interval-seconds 10` passed sync id 51 preview, sync, overlays, issue assertions, support evidence, and same-snapshot repeat convergence with 0 warnings and 0 blocking issues.
+- [x] `independent-review` - Independent review passed with 0 blockers and 0 findings after `rtk git diff --check`, the Python compatibility correction, lockfile regeneration, and protected CI validation.


### PR DESCRIPTION
Release evidence-only commit for v2.6.1. No production code changes.