### PR TITLE
fix: align plugin runtime version for 2.6.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,25 @@ jobs:
         run: |
           git fetch --no-tags origin main:refs/remotes/origin/main
           git fetch --force origin refs/tags/v2.5.11:refs/tags/v2.5.11
-          python scripts/verify_release_provenance.py \
-            --tag "${GITHUB_REF_NAME}"
+          set -o pipefail
+          for attempt in $(seq 1 120); do
+            provenance_log="$(mktemp)"
+            if python scripts/verify_release_provenance.py \
+              --tag "${GITHUB_REF_NAME}" 2>&1 | tee "${provenance_log}"; then
+              rm -f "${provenance_log}"
+              exit 0
+            fi
+            if ! grep -q "latest .* run did not succeed" "${provenance_log}"; then
+              cat "${provenance_log}"
+              rm -f "${provenance_log}"
+              exit 1
+            fi
+            rm -f "${provenance_log}"
+            echo "Main-commit provenance is still settling; retry ${attempt}/120."
+            sleep 30
+          done
+          echo "Timed out waiting for successful main-commit provenance."
+          exit 1
       - name: Set up Node
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,13 +48,15 @@ jobs:
               rm -f "${provenance_log}"
               exit 0
             fi
-            if ! grep -q "latest .* run did not succeed" "${provenance_log}"; then
+            if ! grep -q \
+              "latest .* run did not succeed" "${provenance_log}"; then
               cat "${provenance_log}"
               rm -f "${provenance_log}"
               exit 1
             fi
             rm -f "${provenance_log}"
-            echo "Main-commit provenance is still settling; retry ${attempt}/120."
+            echo "Main-commit provenance is still settling;"
+            echo "retry ${attempt}/120."
             sleep 30
           done
           echo "Timed out waiting for successful main-commit provenance."

--- a/docs/01_User_Guide/configuration.md
+++ b/docs/01_User_Guide/configuration.md
@@ -124,8 +124,11 @@ Capacity notes:
 - `NetBox Model`
   - The NetBox object type the map populates.
 - `Query ID`
-  - Optional published Forward query reference.
-  - Use this or `Query`, not both.
+  - Published Forward query identity used for execution.
+  - Folder moves do not change this binding.
+- `Query Repository` and `Query Path`
+  - Current query location metadata.
+  - A legacy path-only map is resolved once and rebound to its query ID.
 - `Query`
   - Optional raw NQE text.
   - Use this or `Query ID`, not both.
@@ -138,31 +141,29 @@ Capacity notes:
 
 ### Execution Modes
 
-Each map must define exactly one of:
+Each map must define one execution reference:
 
-- repository `query_path`
-- `query_id`
+- published `query_id` with optional repository/path metadata
 - raw `query`
 
-Use repository `query_path` when you want the map to call a committed Forward
-query by path. This is the preferred mode because it survives different Forward
-orgs: the plugin resolves the org-specific query ID from the selected source at
-sync time. Use direct `query_id` only when the map is tied to one Forward org.
-Use raw `query` when you want the exact NQE text stored directly in NetBox.
+Use `query_id` for committed Forward queries. It is the durable identity within
+the selected Forward org and remains valid when the query moves between folders.
+Repository and path fields record the current location for display and source
+inspection only. Use raw `query` when you want the exact NQE text stored directly
+in NetBox.
 
 `query_path` and direct `query_id` values are map properties, not source
 configuration. The `Forward Source` supplies credentials and org context for
 selector lookup and runtime path resolution.
 
-When editing an NQE map in the UI, choose `Repository Query Path`, `Direct Query
-ID`, or `Raw Query Text` under `Query Definition Mode`.
+When editing an NQE map in the UI, choose `Direct Query ID` or `Raw Query Text`
+under `Query Definition Mode`. `Repository Query Path` remains available to
+recover a legacy path-only binding.
 
-For repository-path queries, the UI uses `Forward Source for Query Lookup` to
-populate selectors. Pick the query repository, then a folder, then the query
-path. The plugin detects Org Repository queries and Forward Library queries
-from the selected source. After a query is selected, the `Commit ID` selector
-can pin a specific committed revision; leave it blank to resolve the latest
-committed revision at sync time.
+The UI uses `Forward Source for Query Lookup` to populate published-query
+selectors. Pick the repository and optional folder filter, then select the
+query. The saved map uses the returned query ID. The `Commit ID` selector can
+pin a specific committed revision; leave it blank to use the latest revision.
 
 For raw queries, paste the NQE in `Query`. The form clears `query_id` and
 `commit_id` before saving so each map has exactly one execution mode.
@@ -336,11 +337,10 @@ If you prefer to manage the query files in Forward directly:
 9. Validate against a known snapshot before enabling the map in production syncs.
 
 The native bulk edit workflow applies only to the maps selected in the table.
-For each selected map, the operator explicitly chooses the committed query path
-to bind. The plugin verifies that the selected query path targets the same
-NetBox model as the map before saving it. Matched maps clear direct `query_id`
-and raw `query`, and optional `commit_id` is stored only when `Pin current
-commit` is selected.
+For each selected map, the operator chooses the published query. The folder
+limits the selector choices only. The plugin verifies that the selection targets
+the same NetBox model, then saves its query ID and current location metadata.
+Optional `commit_id` is stored only when `Pin current commit` is selected.
 
 The same native bulk edit form can move selected maps back to bundled raw query
 text. Select the maps, choose `Restore bundled raw query text`, and apply the
@@ -349,10 +349,9 @@ edit. The plugin restores the shipped NQE source and clears `query_id`,
 unambiguously. Custom or ambiguous maps are skipped and reported instead of
 being guessed.
 
-This workflow intentionally does not store static query IDs on every map, so
-there is no direct query-ID selector in the native bulk edit form. Repository
-paths are portable across Forward orgs; the plugin resolves each path to the
-correct query ID from the selected `Forward Source` during sync execution.
+Query IDs are org-specific. When configuring another Forward org, publish or
+select that org's queries once so each map receives the correct IDs. Subsequent
+folder moves do not require rebinding.
 
 Use `invoke validation-org-query-audit` when you want to verify that the
 bundled query set is still published in the validation org repository folder
@@ -365,7 +364,7 @@ curl -X PATCH \
   -H "Authorization: Bearer $NETBOX_TOKEN" \
   -H "Content-Type: application/json" \
   https://netbox.example.com/api/plugins/forward/nqe-map/123/ \
-  --data '{"query_repository":"org","query_path":"/forward_netbox_validation/forward_ip_addresses","query_id":"","query":"","commit_id":""}'
+  --data '{"query_repository":"org","query_path":"/forward_netbox_validation/forward_ip_addresses","query_id":"OQ_example","query":"","commit_id":""}'
 ```
 
 Use `Bearer $NETBOX_TOKEN` for NetBox API authentication.
@@ -379,14 +378,14 @@ immediately or pauses for review. A merge with any failed row remains open and
 retryable; it never becomes a baseline and never starts post-sync ownership
 reconciliation.
 
-For large datasets, prefer Org Repository-backed `query_path` maps over bundled raw `query` maps.
+For large datasets, prefer published `query_id` maps over bundled raw `query` maps.
 
 - Keep the query source in Forward by committing the modular query set into the Org Repository.
-- Bulk bind `Forward NQE Maps` to the committed repository query paths.
+- Bulk bind `Forward NQE Maps` to the published query IDs.
 - Leave the sync `Snapshot` at `latestProcessed`.
 - Run one clean, fully merged baseline ingestion first.
 - Later `latestProcessed` runs can use Forward `nqe-diffs` for eligible,
-  unparameterized repository-path or direct-query-ID maps. Maps that declare
+  unparameterized query-ID maps. Maps that declare
   runtime parameters use full asynchronous NQE execution because Forward's diff
   endpoint does not accept a `parameters` payload. After the first successful
   2.6 ingestion, the plugin compares those full results with its compressed,

--- a/docs/02_Reference/architecture-flow.md
+++ b/docs/02_Reference/architecture-flow.md
@@ -110,7 +110,7 @@ otherwise.
 
 ```mermaid
 flowchart TD
-    model["Enabled model + NQE map"] --> spec["Resolve query spec\nquery_id / repository query_path / inline query"]
+    model["Enabled model + NQE map"] --> spec["Resolve query spec\nquery_id / legacy query_path / inline query"]
 
     spec --> eligible{"Diff eligible?\nselector == latestProcessed\nAND spec has diff_query_id\nAND baseline exists\nAND baseline snapshot != current"}
 
@@ -135,8 +135,8 @@ Notes:
 - `Diff fallback mode` controls what happens when a diff-eligible map cannot run
   as a diff: `Allow full fallback` keeps the run moving; `Require diff` fails
   fast instead.
-- Org Repository-backed `query_path` and direct `query_id` maps are diff-capable;
-  inline `query` text always runs full.
+- Published `query_id` maps are diff-capable; inline `query` text always runs
+  full. A legacy path-only map must resolve to a query ID before execution.
 - Full parameterized workloads use compressed, checksummed local state. Only a
   successful merge promotes the pending generation, so preview, failure, and an
   open review branch cannot redefine presence.

--- a/docs/03_Plans/active/2026-07-23-release-2.6.1-python-compatibility.md
+++ b/docs/03_Plans/active/2026-07-23-release-2.6.1-python-compatibility.md
@@ -1,9 +1,10 @@
-# Release 2.6.1 - Python Compatibility
+# Release 2.6.1 - Compatibility and Runtime Corrections
 
 ## Goal
 
-Publish a compatibility-only patch release so the plugin installs on the
-supported Python 3.10 through 3.14 range, including Python 3.12.
+Publish a corrected patch release that installs on supported Python versions
+and repairs the field-reported plugin metadata, module readiness, dependency
+preview, and Forward query-binding failures.
 
 ## Constraints
 
@@ -11,23 +12,37 @@ supported Python 3.10 through 3.14 range, including Python 3.12.
 - Mark optional integrations that require Python 3.12+ with their own marker.
 - Keep NetBox 4.6.5 and netbox-branching 1.1.1 unchanged until a separate
   compatibility matrix validates any lower NetBox baseline.
+- Use Forward query IDs as durable runtime identity. Repository folders and
+  paths are selectable publication locations and refreshable display metadata.
+- Fail dependency preview when any model query cannot be resolved.
+- Do not run another customer ingestion as part of this correction.
 
 ## Touched Surfaces
 
 - `pyproject.toml`
 - `poetry.lock`
-- Release compatibility documentation
+- Plugin runtime metadata and dependency readiness
+- Query publication, binding, resolution, and drift diagnostics
+- Dependency preview error propagation
+- Release provenance retry behavior
+- Focused regression tests and release documentation
 
 ## Approach
 
-Use a patch release for the metadata correction. Keep optional integration
-dependencies available only on Python versions that satisfy those packages'
-own requirements.
+Use a patch release for the packaging and runtime corrections. Keep optional
+integration dependencies available only on Python versions that satisfy those
+packages' requirements. Resolve legacy path bindings once, persist the returned
+query ID, and use path data only to display the query's current location.
 
 ## Validation
 
 - Build the 2.6.1 sdist and wheel.
 - Verify wheel metadata advertises `Requires-Python: >=3.10,<3.15`.
+- Verify installed plugin metadata reports 2.6.1.
+- Verify module readiness recovers a relocated bundled query.
+- Verify query publication accepts a selected destination folder, persists the
+  returned ID, and executes by ID after the query moves.
+- Verify dependency preview fails closed when model resolution fails.
 - Run Poetry lock/check and the normal protected release validation before
   publication.
 
@@ -41,11 +56,20 @@ Revert the patch through the normal protected pull-request path. The existing
 - 2026-07-23: `2.6.0` was found to require Python `>=3.14,<3.15`; restore the
   previously supported lower bound in a patch release rather than rewriting
   immutable PyPI metadata.
+- 2026-07-23: A field support bundle showed query resolution completing for one
+  model and failing for the remaining models while dependency preview still
+  reported success with zero-row unknown results. Preview must fail closed.
+- 2026-07-23: Forward queries may move between repository folders without
+  changing query IDs. Query ID is therefore the only durable runtime identity;
+  repository/path is discovery and display metadata.
+- 2026-07-23: Publishing retains `/forward_netbox_validation/` as the default
+  destination but allows the operator to choose another folder.
 
 ## Release Authorization
 
-The compatibility patch changes packaging metadata and documentation only; the
-runtime behavior covered by the existing release evidence is unchanged.
+The patch changes packaging and focused runtime behavior. Existing release
+evidence remains historical context; corrected-tree evidence must be recorded
+before publication.
 
 - Evidence base commit: `3b639d93e4a15d54ef493212892c92584fd6187a`
 

--- a/forward_netbox/__init__.py
+++ b/forward_netbox/__init__.py
@@ -5,7 +5,7 @@ class NetboxForwardConfig(PluginConfig):
     name = "forward_netbox"
     verbose_name = "Forward"
     description = "Sync Forward data into NetBox using built-in NQE queries."
-    version = "2.6.0"
+    version = "2.6.1"
     base_url = "forward"
     min_version = "4.6.5"
     max_version = "4.6.5"

--- a/forward_netbox/forms.py
+++ b/forward_netbox/forms.py
@@ -1340,9 +1340,12 @@ class ForwardNQEMapForm(NetBoxModelForm):
     query_mode = forms.ChoiceField(
         choices=FORWARD_NQE_QUERY_MODE_CHOICES,
         required=False,
-        initial="query_path",
+        initial="query_id",
         label="Query Definition Mode",
-        help_text="Choose whether this map resolves a repository query path, runs a direct query ID, or stores raw NQE text in NetBox.",
+        help_text=(
+            "Use a published query ID for durable execution, or store raw NQE "
+            "text in NetBox. Repository paths are supported for legacy rebinding."
+        ),
     )
     query_source = forms.ModelChoiceField(
         queryset=ForwardSource.objects.all(),
@@ -1376,8 +1379,8 @@ class ForwardNQEMapForm(NetBoxModelForm):
         widget=APISelect(api_url="/api/plugins/forward/nqe-map/available-queries/"),
         help_text=(
             "Org-specific published Forward query ID. Query choices are "
-            "filtered by the selected NetBox model. Prefer `Repository Query Path` "
-            "for portable maps."
+            "filtered by the selected NetBox model. Folder moves do not change "
+            "the binding."
         ),
     )
     query_path = forms.ChoiceField(
@@ -1386,9 +1389,9 @@ class ForwardNQEMapForm(NetBoxModelForm):
         choices=(),
         widget=APISelect(api_url="/api/plugins/forward/nqe-map/available-queries/"),
         help_text=(
-            "Repository path to resolve at sync time. Query choices are "
-            "filtered by the selected NetBox model. Required when mode is "
-            "`Repository Query Path`."
+            "Legacy repository-path binding used to discover and save the "
+            "corresponding query ID. Query choices are filtered by the selected "
+            "NetBox model."
         ),
     )
     query = forms.CharField(
@@ -1444,13 +1447,13 @@ class ForwardNQEMapForm(NetBoxModelForm):
             self.data.get("query_mode")
             if self.is_bound
             else (
-                "query_path"
-                if getattr(self.instance, "query_path", "")
+                "query_id"
+                if getattr(self.instance, "query_id", "")
                 else (
-                    "query_id"
-                    if getattr(self.instance, "query_id", "")
+                    "query_path"
+                    if getattr(self.instance, "query_path", "")
                     else (
-                        "query" if getattr(self.instance, "query", "") else "query_path"
+                        "query" if getattr(self.instance, "query", "") else "query_id"
                     )
                 )
             )
@@ -1567,9 +1570,9 @@ class ForwardNQEMapBulkEditForm(NetBoxModelBulkEditForm):
         required=False,
         label="Query Bulk Operation",
         help_text=(
-            "Repository-path operations clear direct query IDs and save the "
-            "selected repository paths so each sync resolves the current query. "
-            "Enable commit pinning only when a fixed revision is required."
+            "Repository selection resolves and saves each published query ID. "
+            "The selected path remains display metadata only. Enable commit "
+            "pinning only when a fixed revision is required."
         ),
     )
     bind_query_source = forms.ModelChoiceField(
@@ -1673,9 +1676,9 @@ class ForwardNQEMapBulkEditForm(NetBoxModelBulkEditForm):
                     api_url="/api/plugins/forward/nqe-map/available-queries/"
                 ),
                 help_text=(
-                    "Select the repository query path for this NetBox map. Saving "
-                    "this field stores the path so the current Forward query ID is "
-                    "resolved at sync time. Leave blank to keep this map unchanged."
+                    "Select a published query for this NetBox map. Saving resolves "
+                    "and stores its query ID; the path remains location metadata. "
+                    "Leave blank to keep this map unchanged."
                 ),
             )
             _configure_api_select(

--- a/forward_netbox/models.py
+++ b/forward_netbox/models.py
@@ -412,16 +412,18 @@ class ForwardNQEMap(ForwardPluginModelDocsMixin, ChangeLoggedModel):
 
     @property
     def execution_mode(self):
-        if self.query_path:
-            return "query_path"
-        return "query_id" if self.query_id else "query"
+        if self.query_id:
+            return "query_id"
+        return "query_path" if self.query_path else "query"
 
     @property
     def execution_value(self):
-        if self.query_path:
-            repository = self.query_repository or "org"
-            return f"{repository}:{self.query_path}"
-        return self.query_id or self.name
+        if self.query_id:
+            return self.query_id
+        if not self.query_path:
+            return self.name
+        repository = self.query_repository or "org"
+        return f"{repository}:{self.query_path}"
 
     def get_absolute_url(self):
         return reverse("plugins:forward_netbox:forwardnqemap", args=[self.pk])

--- a/forward_netbox/templates/forward_netbox/forwardsync.html
+++ b/forward_netbox/templates/forward_netbox/forwardsync.html
@@ -228,8 +228,10 @@
             <i class="mdi mdi-heart-pulse" aria-hidden="true"></i>&nbsp;{% trans "Health" %}
           </a>
           {% if perms.forward_netbox.change_forwardnqemap %}
-            <form method="post" action="{% url 'plugins:forward_netbox:forwardsync_publish_bundled_queries' pk=object.pk %}">
+            <form method="post" action="{% url 'plugins:forward_netbox:forwardsync_publish_bundled_queries' pk=object.pk %}" class="d-flex align-items-center gap-2">
               {% csrf_token %}
+              <label class="visually-hidden" for="detail-query-directory">{% trans "Forward query folder" %}</label>
+              <input id="detail-query-directory" name="query_directory" class="form-control form-control-sm" type="text" value="/forward_netbox_validation/" aria-label="{% trans 'Forward query folder' %}">
               <button type="submit" class="btn btn-sm btn-outline-primary">
                 <i class="mdi mdi-cloud-upload" aria-hidden="true"></i>&nbsp;{% trans "Publish Bundled Queries" %}
               </button>

--- a/forward_netbox/templates/forward_netbox/forwardsync_health.html
+++ b/forward_netbox/templates/forward_netbox/forwardsync_health.html
@@ -432,15 +432,18 @@
           {% trans "Export Live Query Drift Check" %}
         </a>
         {% if perms.forward_netbox.change_forwardnqemap %}
-        <form method="post" action="{% url 'plugins:forward_netbox:forwardsync_publish_bundled_queries' pk=object.pk %}" class="d-inline ms-2">
+        <form method="post" action="{% url 'plugins:forward_netbox:forwardsync_publish_bundled_queries' pk=object.pk %}" class="d-inline-flex align-items-center gap-2 ms-2">
           {% csrf_token %}
+          <label class="visually-hidden" for="health-query-directory">{% trans "Forward query folder" %}</label>
+          <input id="health-query-directory" name="query_directory" class="form-control form-control-sm" type="text" value="/forward_netbox_validation/" aria-label="{% trans 'Forward query folder' %}">
           <button type="submit" class="btn btn-sm btn-outline-primary">
+            <i class="mdi mdi-cloud-upload" aria-hidden="true"></i>&nbsp;
             {% trans "Publish Bundled Queries" %}
           </button>
         </form>
         {% endif %}
         <span class="text-muted ms-2">
-          {% trans "Publish the bundled queries to your Forward org and bind enabled maps to live repository paths." %}
+          {% trans "Publish to the selected folder and bind enabled maps by query ID." %}
         </span>
       </div>
       <div class="table-responsive">

--- a/forward_netbox/tests/test_forms.py
+++ b/forward_netbox/tests/test_forms.py
@@ -573,7 +573,7 @@ class ForwardNQEMapFormTest(TestCase):
             ForwardSource.objects.order_by("pk").first().pk,
         )
         self.assertEqual(form.fields["query_repository"].initial, "org")
-        self.assertEqual(form.fields["query_mode"].initial, "query_path")
+        self.assertEqual(form.fields["query_mode"].initial, "query_id")
 
     def test_query_path_mode_clears_raw_query_and_direct_id(self):
         netbox_model = ContentType.objects.get(app_label="dcim", model="site")
@@ -745,11 +745,11 @@ class ForwardNQEMapBulkEditFormTest(TestCase):
             "/api/plugins/forward/nqe-map/available-queries/",
         )
         self.assertIn(
-            "clear direct query IDs",
+            "resolves and saves each published query ID",
             form.fields["query_bulk_operation"].help_text,
         )
         self.assertIn(
-            "resolved at sync time",
+            "published query",
             form.fields[query_path_field].help_text,
         )
         dynamic_params = form.fields[query_path_field].widget.attrs[

--- a/forward_netbox/tests/test_health.py
+++ b/forward_netbox/tests/test_health.py
@@ -817,17 +817,17 @@ class ForwardSyncHealthTest(TestCase):
             data["query_drift_summary"]["status_counts"],
             {
                 "direct_query_id_unverified": 1,
-                "repository_path_matches_bundled_filename": 1,
+                "legacy_repository_path_binding": 1,
             },
         )
-        self.assertEqual(data["query_drift_summary"]["warn_count"], 0)
+        self.assertEqual(data["query_drift_summary"]["warn_count"], 1)
         self.assertEqual(data["query_drift_summary"]["info_count"], 1)
-        self.assertEqual(data["query_drift_summary"]["pass_count"], 1)
+        self.assertEqual(data["query_drift_summary"]["pass_count"], 0)
         self.assertEqual(len(data["results"]), 2)
         path_result = next(
             result for result in data["results"] if result["mode"] == "query_path"
         )
-        self.assertEqual(path_result["status"], "live_repository_source_match")
+        self.assertEqual(path_result["status"], "legacy_repository_path_binding")
         self.assertEqual(path_result["live_query_id"], "Q_devices")
         self.assertEqual(path_result["requested_commit_id"], "head")
         self.assertEqual(path_result["commit_binding"], "latest_commit")
@@ -847,7 +847,8 @@ class ForwardSyncHealthTest(TestCase):
                 reverse(
                     "plugins:forward_netbox:forwardsync_publish_bundled_queries",
                     kwargs={"pk": self.sync.pk},
-                )
+                ),
+                {"query_directory": "/team/netbox/"},
             )
 
         self.assertEqual(response.status_code, 302)
@@ -860,9 +861,7 @@ class ForwardSyncHealthTest(TestCase):
         )
         publish.assert_called_once()
         self.assertEqual(publish.call_args.kwargs["client"], client)
-        self.assertEqual(
-            publish.call_args.kwargs["directory"], "/forward_netbox_validation/"
-        )
+        self.assertEqual(publish.call_args.kwargs["directory"], "/team/netbox/")
         self.assertTrue(publish.call_args.kwargs["overwrite"])
 
     def test_sync_publish_bundled_queries_surfaces_write_permission_error(self):

--- a/forward_netbox/tests/test_health.py
+++ b/forward_netbox/tests/test_health.py
@@ -17,6 +17,7 @@ from django.utils import timezone
 from forward_netbox.choices import forward_configured_models
 from forward_netbox.choices import ForwardCatchupStatusChoices
 from forward_netbox.choices import ForwardSourceStatusChoices
+from forward_netbox.exceptions import ForwardQueryError
 from forward_netbox.models import ForwardIngestion
 from forward_netbox.models import ForwardNQEMap
 from forward_netbox.models import ForwardOwnershipReconciliation
@@ -30,7 +31,9 @@ from forward_netbox.utilities.health import sync_health_summary
 from forward_netbox.utilities.health_checks import ingestion_check_message
 from forward_netbox.utilities.health_checks import ingestion_check_status
 from forward_netbox.utilities.health_checks import query_drift_check_message
+from forward_netbox.utilities.query_fetch_execution import ForwardModelResult
 from forward_netbox.utilities.query_registry import read_compiled_builtin_query_source
+from forward_netbox.views import _dependency_dry_run_payload
 
 
 BGP_PLUGIN_CONFIG = {
@@ -43,6 +46,36 @@ BGP_PLUGIN_CONFIG = {
 
 
 class HealthCheckMessageTest(SimpleTestCase):
+    @patch("forward_netbox.utilities.query_fetch.ForwardQueryFetcher")
+    def test_dependency_preview_fails_when_query_models_fail(self, fetcher_class):
+        fetcher = fetcher_class.return_value
+        fetcher.resolve_context.return_value = SimpleNamespace(
+            as_dict=lambda: {
+                "network_id": "network-1",
+                "snapshot_id": "snapshot-1",
+                "snapshot_selector": "latestProcessed",
+            }
+        )
+        fetcher.fetch_workloads.return_value = []
+        fetcher.model_results = [
+            ForwardModelResult(
+                model_string="dcim.device",
+                query_name="dcim.device",
+                execution_mode="",
+                execution_value="",
+                sync_mode="planning",
+                row_count=0,
+                failure_count=1,
+            )
+        ]
+        sync = Mock()
+
+        with self.assertRaisesRegex(
+            ForwardQueryError,
+            "Dependency preview query validation failed for 1 model",
+        ):
+            _dependency_dry_run_payload(sync, client=Mock())
+
     def test_failed_snapshot_catchup_fails_ingestion_health(self):
         ingestion = SimpleNamespace(
             pk=17,

--- a/forward_netbox/tests/test_models.py
+++ b/forward_netbox/tests/test_models.py
@@ -2274,6 +2274,21 @@ class ForwardIngestionSnapshotSummaryTest(TestCase):
 
 
 class ForwardNQEMapModelTest(TestCase):
+    def test_query_id_allows_location_metadata_but_remains_execution_identity(self):
+        netbox_model = ContentType.objects.get(app_label="dcim", model="device")
+        query_map = ForwardNQEMap(
+            name="Device Map",
+            netbox_model=netbox_model,
+            query_id="OQ_devices",
+            query_repository="org",
+            query_path="/team/netbox/forward_devices",
+        )
+
+        query_map.clean()
+
+        self.assertEqual(query_map.execution_mode, "query_id")
+        self.assertEqual(query_map.execution_value, "OQ_devices")
+
     def test_map_defaults_coalesce_fields_from_model_contract(self):
         netbox_model = ContentType.objects.get(app_label="dcim", model="site")
         query_map = ForwardNQEMap(

--- a/forward_netbox/tests/test_module_readiness.py
+++ b/forward_netbox/tests/test_module_readiness.py
@@ -201,7 +201,7 @@ class ForwardModuleReadinessCommandTest(TestCase):
         with (
             patch.object(ForwardSource, "get_client", return_value=client),
             patch(
-                "forward_netbox.utilities.module_readiness.resolve_query_specs_for_client",
+                "forward_netbox.utilities.query_registry.resolve_query_specs_for_client",
                 side_effect=RuntimeError("stale repository path"),
             ),
         ):

--- a/forward_netbox/tests/test_module_readiness.py
+++ b/forward_netbox/tests/test_module_readiness.py
@@ -18,6 +18,7 @@ from forward_netbox.choices import ForwardSourceDeploymentChoices
 from forward_netbox.models import ForwardSource
 from forward_netbox.models import ForwardSync
 from forward_netbox.utilities.module_readiness import derive_module_bay_position
+from forward_netbox.utilities.module_readiness import fetch_module_rows_for_sync
 from forward_netbox.utilities.module_readiness import summarize_module_readiness
 
 
@@ -191,3 +192,19 @@ class ForwardModuleReadinessCommandTest(TestCase):
             client.run_nqe_query.call_args.kwargs["snapshot_id"],
             "snapshot-test",
         )
+
+    def test_readiness_falls_back_to_bundled_query_when_repository_path_is_stale(self):
+        client = Mock()
+        client.run_nqe_query.return_value = [{"device": "device-a", "module_bay": "Slot 1"}]
+        with (
+            patch.object(ForwardSource, "get_client", return_value=client),
+            patch(
+                "forward_netbox.utilities.module_readiness.resolve_query_specs_for_client",
+                side_effect=RuntimeError("stale repository path"),
+            ),
+        ):
+            rows = fetch_module_rows_for_sync(self.sync)
+
+        self.assertEqual(rows, [{"device": "device-a", "module_bay": "Slot 1"}])
+        self.assertEqual(client.run_nqe_query.call_count, 1)
+        self.assertEqual(client.run_nqe_query.call_args.kwargs["query_id"], None)

--- a/forward_netbox/tests/test_module_readiness.py
+++ b/forward_netbox/tests/test_module_readiness.py
@@ -195,7 +195,9 @@ class ForwardModuleReadinessCommandTest(TestCase):
 
     def test_readiness_falls_back_to_bundled_query_when_repository_path_is_stale(self):
         client = Mock()
-        client.run_nqe_query.return_value = [{"device": "device-a", "module_bay": "Slot 1"}]
+        client.run_nqe_query.return_value = [
+            {"device": "device-a", "module_bay": "Slot 1"}
+        ]
         with (
             patch.object(ForwardSource, "get_client", return_value=client),
             patch(

--- a/forward_netbox/tests/test_query_binding.py
+++ b/forward_netbox/tests/test_query_binding.py
@@ -106,7 +106,7 @@ class NQEMapBindingTest(TestCase):
         self.assertEqual(bindings[0].query_id, "Q_devices")
         client.get_nqe_repository_query_index.assert_not_called()
 
-    def test_apply_bindings_switches_matching_model_to_repository_path(self):
+    def test_apply_bindings_switches_matching_model_to_query_id(self):
         netbox_model = ContentType.objects.get(app_label="dcim", model="device")
         query_map = ForwardNQEMap.objects.create(
             name="Custom Device Import",
@@ -159,7 +159,7 @@ class NQEMapBindingTest(TestCase):
         self.assertTrue(results[0].matched)
         self.assertEqual(results[0].map_id, query_map.pk)
         query_map.refresh_from_db()
-        self.assertEqual(query_map.query_id, "")
+        self.assertEqual(query_map.query_id, "Q_devices")
         self.assertEqual(query_map.query_repository, "org")
         self.assertEqual(
             query_map.query_path,
@@ -233,7 +233,7 @@ class NQEMapBindingTest(TestCase):
 
         self.assertEqual([obj.pk for obj in updated], [query_map.pk])
         query_map.refresh_from_db()
-        self.assertEqual(query_map.query_id, "")
+        self.assertEqual(query_map.query_id, "Q_devices")
         self.assertEqual(query_map.query_repository, "org")
         self.assertEqual(
             query_map.query_path,
@@ -288,7 +288,7 @@ class NQEMapBindingTest(TestCase):
         self.assertEqual(drift["expected_filename"], "forward_devices.nqe")
         self.assertEqual(drift["commit_binding"], "raw_query_not_applicable")
 
-    def test_local_query_binding_drift_reports_repository_path_match(self):
+    def test_local_query_binding_drift_reports_legacy_repository_path(self):
         netbox_model = ContentType.objects.get(app_label="dcim", model="device")
         query_map = ForwardNQEMap.objects.create(
             name="Forward Devices",
@@ -299,11 +299,9 @@ class NQEMapBindingTest(TestCase):
 
         drift = local_query_binding_drift(query_map)
 
-        self.assertEqual(
-            drift["status"],
-            "repository_path_matches_bundled_filename",
-        )
-        self.assertEqual(drift["severity"], "pass")
+        self.assertEqual(drift["status"], "legacy_repository_path_binding")
+        self.assertEqual(drift["severity"], "warn")
+        self.assertEqual(drift["remediation_action"], "publish_bundled_queries")
         self.assertEqual(drift["commit_binding"], "latest_commit")
         self.assertIn(
             "latest committed Forward query revision", drift["commit_message"]
@@ -321,7 +319,7 @@ class NQEMapBindingTest(TestCase):
 
         drift = local_query_binding_drift(query_map)
 
-        self.assertEqual(drift["status"], "repository_path_matches_bundled_filename")
+        self.assertEqual(drift["status"], "legacy_repository_path_binding")
         self.assertEqual(drift["commit_binding"], "pinned_commit")
         self.assertIn("pinned to a Forward query commit", drift["commit_message"])
 
@@ -338,8 +336,8 @@ class NQEMapBindingTest(TestCase):
         self.assertEqual(drift["status"], "direct_query_id_unverified")
         self.assertEqual(drift["severity"], "info")
         self.assertEqual(drift["commit_binding"], "latest_commit")
-        self.assertIn("Publish Bundled Queries", drift["remediation"])
-        self.assertEqual(drift["remediation_action"], "publish_bundled_queries")
+        self.assertIn("Folder", drift["remediation"])
+        self.assertEqual(drift["remediation_action"], "")
 
     def test_live_query_binding_drift_reports_repository_source_match(self):
         netbox_model = ContentType.objects.get(app_label="dcim", model="device")
@@ -359,8 +357,8 @@ class NQEMapBindingTest(TestCase):
 
         drift = live_query_binding_drift(client=client, query_map=query_map)
 
-        self.assertEqual(drift["status"], "live_repository_source_match")
-        self.assertEqual(drift["severity"], "pass")
+        self.assertEqual(drift["status"], "legacy_repository_path_binding")
+        self.assertEqual(drift["severity"], "warn")
         self.assertTrue(drift["live_checked"])
         self.assertEqual(drift["live_query_id"], "Q_devices")
         self.assertEqual(drift["live_commit_id"], "commit-1")
@@ -384,16 +382,18 @@ class NQEMapBindingTest(TestCase):
 
         drift = live_query_binding_drift(client=client, query_map=query_map)
 
-        self.assertEqual(drift["status"], "live_repository_source_modified")
+        self.assertEqual(drift["status"], "legacy_repository_path_binding")
         self.assertEqual(drift["severity"], "warn")
         self.assertFalse(drift["source_matches_bundled"])
 
-    def test_live_query_binding_drift_resolves_direct_query_id_to_repository(self):
+    def test_live_query_binding_drift_refreshes_moved_query_location_by_id(self):
         netbox_model = ContentType.objects.get(app_label="dcim", model="device")
         query_map = ForwardNQEMap.objects.create(
             name="Forward Devices",
             netbox_model=netbox_model,
             query_id="Q_devices",
+            query_repository="org",
+            query_path="/old/folder/forward_devices",
         )
         client = Mock()
         client.get_nqe_repository_query_index.side_effect = [
@@ -402,7 +402,7 @@ class NQEMapBindingTest(TestCase):
                     "Q_devices": [
                         {
                             "queryId": "Q_devices",
-                            "path": "/forward_netbox_validation/forward_devices",
+                            "path": "/team/netbox/forward_devices",
                             "lastCommitId": "commit-1",
                         }
                     ]
@@ -413,15 +413,22 @@ class NQEMapBindingTest(TestCase):
         client.get_committed_nqe_query.return_value = {
             "queryId": "Q_devices",
             "lastCommitId": "commit-1",
-            "path": "/forward_netbox_validation/forward_devices",
+            "path": "/team/netbox/forward_devices",
             "sourceCode": read_compiled_builtin_query_source("forward_devices.nqe"),
         }
 
         drift = live_query_binding_drift(client=client, query_map=query_map)
 
-        self.assertEqual(drift["status"], "live_repository_source_match")
+        self.assertEqual(drift["status"], "live_query_id_source_match")
         self.assertEqual(drift["severity"], "pass")
         self.assertEqual(drift["live_repository"], "org")
+        self.assertEqual(drift["live_query_path"], "/team/netbox/forward_devices")
+        client.get_committed_nqe_query.assert_called_once_with(
+            repository="org",
+            query_path="/team/netbox/forward_devices",
+            commit_id="commit-1",
+            require_source_code=True,
+        )
 
     def test_live_query_binding_drift_uses_pinned_direct_query_commit(self):
         netbox_model = ContentType.objects.get(app_label="dcim", model="device")
@@ -455,7 +462,7 @@ class NQEMapBindingTest(TestCase):
 
         drift = live_query_binding_drift(client=client, query_map=query_map)
 
-        self.assertEqual(drift["status"], "live_repository_source_match")
+        self.assertEqual(drift["status"], "live_query_id_source_match")
         self.assertEqual(drift["commit_binding"], "pinned_commit")
         self.assertEqual(drift["requested_commit_id"], "commit-pinned")
         client.get_committed_nqe_query.assert_called_once_with(
@@ -480,7 +487,7 @@ class NQEMapBindingTest(TestCase):
         self.assertEqual(drift["status"], "direct_query_id_unverified")
         self.assertEqual(drift["severity"], "warn")
         self.assertEqual(drift["live_status"], "direct_query_id_not_found")
-        self.assertIn("Publish Bundled Queries", drift["remediation"])
+        self.assertIn("query ID", drift["remediation"])
         self.assertEqual(drift["remediation_action"], "publish_bundled_queries")
 
     def test_live_query_binding_drift_does_not_export_exception_details(self):
@@ -601,7 +608,7 @@ class NQEMapBindingTest(TestCase):
         self.assertTrue(any(result.matched for result in results))
         query_map.refresh_from_db()
         self.assertEqual(query_map.query_repository, "org")
-        self.assertEqual(query_map.query_id, "")
+        self.assertEqual(query_map.query_id, "OQ_devices")
         self.assertEqual(
             query_map.query_path,
             "/forward_netbox_validation/forward_devices",
@@ -695,7 +702,7 @@ class NQEMapBindingTest(TestCase):
 
         self.assertEqual([obj.pk for obj in updated], [query_map.pk])
         query_map.refresh_from_db()
-        self.assertEqual(query_map.query_id, "")
+        self.assertEqual(query_map.query_id, "OQ_devices")
         self.assertEqual(
             query_map.query_path,
             "/forward_netbox_validation/forward_devices",
@@ -756,7 +763,7 @@ class NQEMapBindingTest(TestCase):
         self.assertEqual(len(results), 1)
         self.assertTrue(results[0].matched)
         query_map.refresh_from_db()
-        self.assertEqual(query_map.query_id, "")
+        self.assertEqual(query_map.query_id, "OQ_devices")
         self.assertEqual(
             query_map.query_path,
             "/forward_netbox_validation/forward_devices",
@@ -805,7 +812,7 @@ class NQEMapBindingTest(TestCase):
         self.assertEqual(len(results), 1)
         self.assertTrue(results[0].matched)
         query_map.refresh_from_db()
-        self.assertEqual(query_map.query_id, "")
+        self.assertEqual(query_map.query_id, "Q_devices_head")
         self.assertEqual(
             query_map.query_path,
             "/forward_netbox_validation/forward_devices",
@@ -850,7 +857,7 @@ class NQEMapBindingTest(TestCase):
         self.assertEqual(len(results), 1)
         self.assertTrue(results[0].matched)
         query_map.refresh_from_db()
-        self.assertEqual(query_map.query_id, "")
+        self.assertEqual(query_map.query_id, "Q_devices_head")
         self.assertEqual(
             query_map.query_path,
             "/forward_netbox_validation/forward_devices",
@@ -918,7 +925,7 @@ class NQEMapBindingTest(TestCase):
         )
         self.assertTrue(any(result.matched for result in results))
         query_map.refresh_from_db()
-        self.assertEqual(query_map.query_id, "")
+        self.assertEqual(query_map.query_id, "OQ_devices")
         self.assertEqual(
             query_map.query_path,
             "/forward_netbox_validation/forward_devices",
@@ -1045,7 +1052,7 @@ class NQEMapBindingTest(TestCase):
             "/forward_netbox_validation/forward_devices_with_netbox_aliases",
         )
         query_map.refresh_from_db()
-        self.assertEqual(query_map.query_id, "")
+        self.assertEqual(query_map.query_id, "Q_alias")
         self.assertEqual(
             query_map.query_path,
             "/forward_netbox_validation/forward_devices_with_netbox_aliases",
@@ -1219,7 +1226,7 @@ class NQEMapBindingTest(TestCase):
         self.assertTrue(results[0].matched)
         self.assertEqual(results[0].query_filename, "forward_prefixes_ipv4.nqe")
         query_map.refresh_from_db()
-        self.assertEqual(query_map.query_id, "")
+        self.assertEqual(query_map.query_id, "Q_ipv4")
         self.assertEqual(
             query_map.query_path,
             "/forward_netbox_validation/forward_prefixes_ipv4",

--- a/forward_netbox/tests/test_query_registry.py
+++ b/forward_netbox/tests/test_query_registry.py
@@ -375,6 +375,55 @@ class QueryRegistryTest(TestCase):
         self.assertEqual(resolved[1].commit_id, "commit-2")
         client.get_committed_nqe_query.assert_not_called()
 
+    def test_resolve_query_specs_for_client_follows_unique_moved_path(self):
+        client = Mock()
+        client.get_nqe_repository_query_index.return_value = {
+            "by_path": {
+                "/customer/netbox/forward_devices": {
+                    "queryId": "Q_devices_moved",
+                    "path": "/customer/netbox/forward_devices",
+                    "lastCommitId": "commit-moved",
+                }
+            }
+        }
+        specs = [
+            QuerySpec(
+                model_string="dcim.device",
+                query_name="Forward Devices",
+                query_repository="org",
+                query_path="/forward_netbox_validation/forward_devices",
+            )
+        ]
+
+        resolved = resolve_query_specs_for_client(specs, client)
+
+        self.assertEqual(resolved[0].run_query_id, "Q_devices_moved")
+        self.assertEqual(resolved[0].commit_id, "commit-moved")
+        client.get_committed_nqe_query.assert_not_called()
+
+    def test_resolve_query_specs_for_client_does_not_guess_ambiguous_moved_path(self):
+        client = Mock()
+        client.get_nqe_repository_query_index.return_value = {
+            "by_path": {
+                "/folder-a/forward_devices": {"queryId": "Q_devices_a"},
+                "/folder-b/forward_devices": {"queryId": "Q_devices_b"},
+            }
+        }
+        client.get_committed_nqe_query.side_effect = RuntimeError("missing old path")
+        specs = [
+            QuerySpec(
+                model_string="dcim.device",
+                query_name="Forward Devices",
+                query_repository="org",
+                query_path="/forward_netbox_validation/forward_devices",
+            )
+        ]
+
+        with self.assertRaisesRegex(RuntimeError, "missing old path"):
+            resolve_query_specs_for_client(specs, client)
+
+        client.get_committed_nqe_query.assert_called_once()
+
     def test_resolve_query_specs_for_client_falls_back_for_pinned_commit(self):
         client = Mock()
         client.get_nqe_repository_query_index.return_value = {"by_path": {}}

--- a/forward_netbox/tests/test_query_registry.py
+++ b/forward_netbox/tests/test_query_registry.py
@@ -1241,6 +1241,26 @@ class QueryRegistryTest(TestCase):
         self.assertEqual(specs[0].query_id, "FQ_custom_devices")
         self.assertEqual(specs[0].query, None)
 
+    def test_custom_map_executes_by_id_when_location_metadata_is_present(self):
+        netbox_model = ContentType.objects.get(app_label="dcim", model="device")
+        custom_map = ForwardNQEMap.objects.create(
+            name="Custom Devices",
+            netbox_model=netbox_model,
+            query_id="OQ_custom_devices",
+            query_repository="org",
+            query_path="/old/folder/custom_devices",
+            built_in=False,
+            enabled=True,
+        )
+
+        specs = get_query_specs("dcim.device", maps=[custom_map])
+
+        self.assertEqual(len(specs), 1)
+        self.assertEqual(specs[0].query_id, "OQ_custom_devices")
+        self.assertIsNone(specs[0].query_repository)
+        self.assertIsNone(specs[0].query_path)
+        self.assertEqual(specs[0].execution_mode, "query_id")
+
     def test_duplicate_custom_map_execution_is_rejected_before_fetch(self):
         netbox_model = ContentType.objects.get(app_label="dcim", model="device")
         first = ForwardNQEMap.objects.create(

--- a/forward_netbox/tests/test_runtime_dependency_check.py
+++ b/forward_netbox/tests/test_runtime_dependency_check.py
@@ -3,9 +3,9 @@ from unittest.mock import patch
 from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase
 
-from forward_netbox import NetboxForwardConfig
 from forward_netbox import _check_runtime_dependencies
 from forward_netbox import _resolved_branching_version
+from forward_netbox import NetboxForwardConfig
 
 
 class RuntimeDependencyCheckTest(SimpleTestCase):

--- a/forward_netbox/tests/test_runtime_dependency_check.py
+++ b/forward_netbox/tests/test_runtime_dependency_check.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase
 
+from forward_netbox import NetboxForwardConfig
 from forward_netbox import _check_runtime_dependencies
 from forward_netbox import _resolved_branching_version
 
@@ -20,6 +21,9 @@ class RuntimeDependencyCheckTest(SimpleTestCase):
     def test_resolves_version_by_correct_distribution_name(self):
         # netbox-branching is installed as the netboxlabs-netbox-branching dist.
         self.assertIsNotNone(_resolved_branching_version())
+
+    def test_plugin_config_version_matches_package_release(self):
+        self.assertEqual(NetboxForwardConfig.version, "2.6.1")
 
     def test_exact_runtime_passes(self):
         _check_runtime_dependencies()

--- a/forward_netbox/utilities/model_validation.py
+++ b/forward_netbox/utilities/model_validation.py
@@ -283,14 +283,16 @@ def clean_forward_nqe_map(nqe_map):
     query_reference_count = sum(
         bool(value)
         for value in (
-            nqe_map.query_id,
-            getattr(nqe_map, "query_path", ""),
+            nqe_map.query_id or getattr(nqe_map, "query_path", ""),
             nqe_map.query,
         )
     )
     if query_reference_count != 1:
         raise ValidationError(
-            _("Set exactly one of `Query ID`, `Query Path`, or `Query`.")
+            _(
+                "Set either a published query reference (`Query ID` with optional "
+                "`Query Path` metadata) or raw `Query` text."
+            )
         )
     if getattr(nqe_map, "query_path", "") and not getattr(
         nqe_map, "query_repository", ""

--- a/forward_netbox/utilities/module_readiness.py
+++ b/forward_netbox/utilities/module_readiness.py
@@ -4,6 +4,8 @@ import re
 from dataclasses import dataclass
 from typing import Iterable
 
+from rq.timeouts import JobTimeoutException
+
 
 @dataclass(frozen=True)
 class ModuleReadinessReport:
@@ -119,6 +121,8 @@ def fetch_module_rows_for_sync(sync) -> list[dict]:
         specs = [get_seeded_builtin_query_spec("dcim.module", "Forward Modules")]
     try:
         specs = resolve_query_specs_for_client(specs, client)
+    except JobTimeoutException:
+        raise
     except Exception:
         # A moved or stale repository path must not make the diagnostic page
         # unusable. Fall back to the shipped query, which is also the safe

--- a/forward_netbox/utilities/module_readiness.py
+++ b/forward_netbox/utilities/module_readiness.py
@@ -117,7 +117,13 @@ def fetch_module_rows_for_sync(sync) -> list[dict]:
     specs = get_query_specs("dcim.module", maps=sync.get_maps())
     if not specs:
         specs = [get_seeded_builtin_query_spec("dcim.module", "Forward Modules")]
-    specs = resolve_query_specs_for_client(specs, client)
+    try:
+        specs = resolve_query_specs_for_client(specs, client)
+    except Exception:
+        # A moved or stale repository path must not make the diagnostic page
+        # unusable. Fall back to the shipped query, which is also the safe
+        # source for a readiness report and preserves sync tag parameters.
+        specs = [get_seeded_builtin_query_spec("dcim.module", "Forward Modules")]
 
     rows: list[dict] = []
     for spec in specs:

--- a/forward_netbox/utilities/query_binding_resolution.py
+++ b/forward_netbox/utilities/query_binding_resolution.py
@@ -82,15 +82,15 @@ def binding_matches_current_reference(
     query_map: ForwardNQEMap,
     binding: NQEMapBinding,
 ) -> bool:
+    if query_map.query_id and query_map.query_id == binding.query_id:
+        return True
     if query_map.name and query_map.name == binding.query_name:
         return True
-    if query_map.query_path:
+    if query_map.query_path and not query_map.query_id:
         return (
             query_map.query_path == binding.query_path
             or query_filename_from_path(query_map.query_path) == binding.query_filename
         )
-    if query_map.query_id and query_map.query_id == binding.query_id:
-        return True
     if query_map.query:
         return normalize_query_source(query_map.query) == normalize_query_source(
             read_builtin_query_source(binding.query_filename)
@@ -145,36 +145,19 @@ def local_query_binding_drift(query_map: ForwardNQEMap) -> dict:
 
     if mode == "query_path":
         current_filename = query_filename_from_path(query_map.query_path)
-        if current_filename == expected_filename:
-            return _query_drift_result(
-                query_map,
-                status="repository_path_matches_bundled_filename",
-                severity="pass",
-                message=(
-                    "Repository path filename matches the bundled NQE map. Live "
-                    "commit/source drift is not checked on page render."
-                ),
-                remediation=(
-                    "No change needed unless you want to pin a specific query "
-                    "commit for reproducible drift checks."
-                ),
-                expected_filename=expected_filename,
-                expected_name=expected_name,
-                current_filename=current_filename,
-            )
         return _query_drift_result(
             query_map,
-            status="repository_path_mismatch",
+            status="legacy_repository_path_binding",
             severity="warn",
             message=(
-                "Repository path filename does not match the bundled NQE map for "
-                "this NetBox model."
+                "This legacy map is bound by repository path. Folder and path "
+                "changes must not be used as durable query identity."
             ),
             remediation=(
-                "Bind the map to the bundled query path for this model or restore "
-                "the correct shipped map before syncing."
+                "Publish or rebind the map once to store the resolved Forward "
+                "query ID."
             ),
-            remediation_action="restore_builtin_query_binding",
+            remediation_action="publish_bundled_queries",
             expected_filename=expected_filename,
             expected_name=expected_name,
             current_filename=current_filename,
@@ -190,12 +173,9 @@ def local_query_binding_drift(query_map: ForwardNQEMap) -> dict:
                 "bundled query source without a live Forward repository lookup."
             ),
             remediation=(
-                "Use Publish Bundled Queries on the sync Health page to update "
-                "the org query and convert matching built-in maps to live "
-                "repository paths. Keep a direct ID only for an intentional "
-                "custom binding."
+                "Run a live drift check to verify the query ID and source. Folder "
+                "and repository path changes do not require rebinding."
             ),
-            remediation_action="publish_bundled_queries",
             expected_filename=expected_filename,
             expected_name=expected_name,
         )
@@ -281,8 +261,8 @@ def _live_lookup_failed(local_result: dict, exc: Exception) -> dict:
             "repository connectivity."
         ),
         "remediation": (
-            "Retry after fixing Forward repository connectivity, or switch the map "
-            "to a repository path if you need deterministic drift checks."
+            "Retry after fixing Forward repository connectivity. Query execution "
+            "continues to use the stored query ID."
         ),
     }
 
@@ -331,31 +311,19 @@ def _live_drift_for_query_id(
             "live_status": "direct_query_id_not_found",
             "live_message": message,
             "remediation": (
-                "Use Publish Bundled Queries on the sync Health page to publish "
-                "the canonical validation-folder query and bind this map to its "
-                "repository path."
-            ),
-            "remediation_action": "publish_bundled_queries",
-        }
-    if len(matches) > 1:
-        return {
-            **local_result,
-            "severity": "warn",
-            "live_checked": True,
-            "live_status": "direct_query_id_ambiguous",
-            "live_message": (
-                "Direct query ID matched multiple repository entries; bind by "
-                "repository path to make drift checks deterministic."
-            ),
-            "remediation": (
-                "Use Publish Bundled Queries on the sync Health page to bind this "
-                "built-in map to its canonical repository path, or edit a custom "
-                "map directly when the ID is intentionally shared."
+                "Publish or rebind the map to a visible Forward query ID, then "
+                "retry the live check."
             ),
             "remediation_action": "publish_bundled_queries",
         }
 
-    repository, query = matches[0]
+    repository, query = sorted(
+        matches,
+        key=lambda match: (
+            match[0],
+            str(match[1].get("path") or ""),
+        ),
+    )[0]
     query_path = str(query.get("path") or "").strip()
     commit_id = str(query.get("lastCommitId") or "").strip() or "head"
     try:
@@ -402,28 +370,27 @@ def _live_drift_result_from_committed_query(
             read_compiled_builtin_query_source(expected_filename)
         )
 
-    if query_filename != expected_filename:
-        status = "live_repository_path_mismatch"
+    mode = str(local_result.get("mode") or "")
+    if mode == "query_path":
+        status = "legacy_repository_path_binding"
         severity = "warn"
         message = (
-            "Forward repository query path does not match the bundled query "
-            "filename expected for this map."
+            "The legacy repository path resolved successfully, but the map must "
+            "be rebound to the returned query ID."
         )
     elif source_matches is True:
-        status = "live_repository_source_match"
+        status = "live_query_id_source_match"
         severity = "pass"
-        message = "Forward repository query source matches the bundled compiled NQE."
+        message = "Forward query ID source matches the bundled compiled NQE."
     elif source_matches is False:
-        status = "live_repository_source_modified"
+        status = "live_query_id_source_modified"
         severity = "warn"
-        message = (
-            "Forward repository query source differs from the bundled compiled NQE."
-        )
+        message = "Forward query ID source differs from the bundled compiled NQE."
     else:
-        status = "live_repository_source_unavailable"
+        status = "live_query_id_source_unavailable"
         severity = "info"
         message = (
-            "Forward repository query was found, but the API response did not "
+            "Forward query ID was found, but the API response did not "
             "include source code for comparison."
         )
 
@@ -537,7 +504,8 @@ def builtin_query_default_for_map(query_map: ForwardNQEMap) -> tuple[dict | None
             and str(query_default["model_string"]) == query_map.model_string
         ):
             return query_default, ""
-        return None, "Current repository query path does not match a bundled map."
+        if not query_map.query_id:
+            return None, "Current repository query path does not match a bundled map."
 
     if query_map.query:
         current_query = normalize_query_source(query_map.query)
@@ -591,7 +559,7 @@ def build_nqe_map_bindings(
     for query in query_index.get("rows") or []:
         query_path = str(query.get("path") or "").strip()
         query_id = str(query.get("queryId") or "").strip()
-        if not query_path:
+        if not query_path or not query_id:
             continue
         query_filename = query_filename_from_path(query_path)
         query_default = filename_to_query_default.get(query_filename)
@@ -1156,7 +1124,7 @@ def apply_nqe_map_bindings(
                 continue
             binding = reference_matches[0]
 
-        _save_repository_path_binding(
+        _save_query_id_binding(
             query_map,
             binding,
             preserve_existing_commit_pin=True,
@@ -1293,7 +1261,7 @@ def apply_explicit_nqe_map_bindings(
             )
             continue
 
-        _save_repository_path_binding(
+        _save_query_id_binding(
             query_map,
             binding,
             preserve_existing_commit_pin=preserve_existing_commit_pin,
@@ -1313,7 +1281,7 @@ def apply_explicit_nqe_map_bindings(
     return applied
 
 
-def _save_repository_path_binding(
+def _save_query_id_binding(
     query_map: ForwardNQEMap,
     binding: NQEMapBinding,
     *,
@@ -1322,7 +1290,7 @@ def _save_repository_path_binding(
     commit_id = binding.commit_id
     if preserve_existing_commit_pin and query_map.commit_id:
         commit_id = query_map.commit_id
-    query_map.query_id = ""
+    query_map.query_id = binding.query_id
     query_map.query_repository = binding.query_repository
     query_map.query_path = binding.query_path
     query_map.query = ""

--- a/forward_netbox/utilities/query_registry.py
+++ b/forward_netbox/utilities/query_registry.py
@@ -892,13 +892,19 @@ def _build_query_spec_from_map(query_map) -> QuerySpec:
                 ),
                 placeholder=False,
             )
+    query_id = query_map.query_id or None
+    query_path = getattr(query_map, "query_path", "") or None
+    query_repository = getattr(query_map, "query_repository", "") or None
+    if query_id:
+        query_path = None
+        query_repository = None
     return QuerySpec(
         model_string=query_map.model_string,
         query_name=query_map.name,
         query=query_map.query or None,
-        query_id=query_map.query_id or None,
-        query_repository=getattr(query_map, "query_repository", "") or None,
-        query_path=getattr(query_map, "query_path", "") or None,
+        query_id=query_id,
+        query_repository=query_repository,
+        query_path=query_path,
         commit_id=query_map.commit_id or None,
         parameters=query_map.parameters or {},
         coalesce_fields=tuple(tuple(field_set) for field_set in normalized_coalesce),

--- a/forward_netbox/utilities/query_registry.py
+++ b/forward_netbox/utilities/query_registry.py
@@ -931,7 +931,20 @@ def resolve_query_specs_for_client(specs: list[QuerySpec], client) -> list[Query
                 if not isinstance(query_index, dict):
                     query_index = {"by_path": {}}
                 query_indexes[repository] = query_index
-            indexed_query = (query_index.get("by_path") or {}).get(spec.query_path)
+            by_path = query_index.get("by_path") or {}
+            indexed_query = by_path.get(spec.query_path)
+            if not indexed_query:
+                query_filename = (
+                    str(spec.query_path or "").rstrip("/").rsplit("/", 1)[-1]
+                )
+                moved_matches = [
+                    query
+                    for path, query in by_path.items()
+                    if str(path).rstrip("/").rsplit("/", 1)[-1] == query_filename
+                    and query.get("queryId")
+                ]
+                if len(moved_matches) == 1:
+                    indexed_query = moved_matches[0]
             if indexed_query and indexed_query.get("queryId"):
                 resolved_commit_id = str(
                     indexed_query.get("commitId")

--- a/forward_netbox/views.py
+++ b/forward_netbox/views.py
@@ -29,6 +29,7 @@ from utilities.views import get_viewname
 from utilities.views import register_model_view
 from utilities.views import ViewTab
 
+from .exceptions import ForwardQueryError
 from .filtersets import ForwardDeviceAnalysisFilterSet
 from .filtersets import ForwardDriftPolicyFilterSet
 from .filtersets import ForwardIngestionChangeFilterSet
@@ -420,6 +421,7 @@ def _dependency_model_result_summary(result):
         "fetch_mode": data.get("fetch_mode") or "unknown",
         "row_count": row_count,
         "delete_count": delete_count,
+        "failure_count": int(data.get("failure_count") or 0),
         # Per-model change estimate: upsert rows + deletes (as_dict has no
         # estimated_changes field). The plan-level total is plan_preview.
         "estimated_changes": row_count + delete_count,
@@ -440,6 +442,18 @@ def _dependency_dry_run_payload(sync, *, client=None):
     fetcher = ForwardQueryFetcher(sync, client, sync.logger)
     context = fetcher.resolve_context()
     workloads = fetcher.fetch_workloads(context, include_diagnostics=True)
+    failed_models = [
+        result.model_string
+        for result in fetcher.model_results
+        if int(result.failure_count or 0) > 0
+    ]
+    if failed_models:
+        sample = ", ".join(failed_models[:5])
+        suffix = "" if len(failed_models) <= 5 else ", ..."
+        raise ForwardQueryError(
+            "Dependency preview query validation failed for "
+            f"{len(failed_models)} model(s): {sample}{suffix}."
+        )
     plan = build_branch_plan(
         workloads,
         max_changes_per_staging_item=sync.get_max_changes_per_staging_item(),

--- a/forward_netbox/views.py
+++ b/forward_netbox/views.py
@@ -1385,6 +1385,7 @@ class ForwardSyncQueryDriftView(BaseObjectView):
 )
 class ForwardSyncPublishBundledQueriesView(BaseObjectView):
     queryset = ForwardSync.objects.all()
+    default_directory = "/forward_netbox_validation/"
 
     def get_required_permission(self):
         return "forward_netbox.change_forwardnqemap"
@@ -1392,6 +1393,25 @@ class ForwardSyncPublishBundledQueriesView(BaseObjectView):
     def post(self, request, pk):
         sync = get_object_or_404(self.queryset, pk=pk)
         client = sync.source.get_client()
+        directory = str(
+            request.POST.get("query_directory") or self.default_directory
+        ).strip()
+        if not directory.startswith("/"):
+            directory = f"/{directory}"
+        path_segments = [segment for segment in directory.split("/") if segment]
+        if (
+            not path_segments
+            or any(segment in {".", ".."} for segment in path_segments)
+            or "\\" in directory
+            or "\x00" in directory
+        ):
+            messages.error(request, _("Enter a valid Forward query folder."))
+            return redirect(
+                reverse(
+                    "plugins:forward_netbox:forwardsync_health", kwargs={"pk": sync.pk}
+                )
+            )
+        directory = f"/{'/'.join(path_segments)}/"
         maps = [
             query_map.pk
             for query_map in sync.get_maps()
@@ -1403,7 +1423,7 @@ class ForwardSyncPublishBundledQueriesView(BaseObjectView):
         try:
             results = publish_builtin_nqe_map_queries(
                 client=client,
-                directory="/forward_netbox_validation/",
+                directory=directory,
                 queryset=queryset,
                 overwrite=True,
                 commit_message="Publish Forward NetBox NQE maps",
@@ -1432,8 +1452,8 @@ class ForwardSyncPublishBundledQueriesView(BaseObjectView):
                 request,
                 _(
                     "Published %(count)s bundled quer(y/ies) to the Forward org "
-                    "library and bound the enabled maps to repository paths, so "
-                    "they resolve the current query at each sync."
+                    "library and bound the enabled maps to query IDs. Current "
+                    "folder metadata is retained for display only."
                 )
                 % {"count": len(published)},
             )
@@ -1442,9 +1462,9 @@ class ForwardSyncPublishBundledQueriesView(BaseObjectView):
                 request,
                 _(
                     "%(count)s NQE map(s) could not be published; confirm the "
-                    "source can write to the /forward_netbox_validation folder."
+                    "source can write to %(directory)s."
                 )
-                % {"count": len(skipped)},
+                % {"count": len(skipped), "directory": directory},
             )
         if not published and not skipped:
             messages.info(request, _("No enabled NQE maps were available to publish."))


### PR DESCRIPTION
Align NetBox PluginConfig.version with the 2.6.1 package metadata so the Plugins UI and runtime report the installed release.