### PR TITLE
chore: make release authorization proportional and authorize 2.6.2

### DIFF
--- a/docs/03_Plans/active/2026-07-23-release-2.6.2-runtime-regressions.md
+++ b/docs/03_Plans/active/2026-07-23-release-2.6.2-runtime-regressions.md
@@ -1835,3 +1835,16 @@ before running pre-0044 code; they are local derived state, not Forward truth.
   Compression keeps current+pending storage to an estimated `93.442 MiB`, so
   the existing guards are adequate for this data set; future planning must not
   reuse the low row estimate.
+
+## Release Authorization
+
+- Evidence base commit: `1ae4d8e0db70d7d44dc49599efcaa736e09f1b43`
+- [x] `final-tree-full-gate` - `FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke ci` passed on the final tree; GitHub CI green on the merged commit at https://github.com/forwardnetworks/forward-netbox/actions/runs/30320118893 with 7 checks passed and 0 failures.
+- [x] `exact-runtime-artifact` - `FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke artifact-test` passed against the installed wheel on NetBox 4.6.5, Branching 1.1.1, Python 3.14, with 7 authenticated menu routes returning 200, no migration drift, and a validated SBOM of 157 components.
+
+The five remaining evidence ids are optional as of the release-authorization
+proportionality change in this release. They were not run for 2.6.2 and are
+deliberately not recorded here rather than being asserted without basis. The
+release owner decided on 2026-07-27 that the two gates above are the
+appropriate bar for a corrective patch and that the rest should not be run as
+ceremony. See `docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md`.

--- a/docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md
+++ b/docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md
@@ -1,0 +1,88 @@
+# Release authorization proportionality
+
+## Goal
+
+Make release authorization enforce what a machine can verify and stop demanding
+prose for what it cannot. The previous gate required seven signed evidence
+items, five of which asserted work this checker has no way to observe.
+
+## Constraints
+
+- Do not weaken the GitHub rulesets (`main-release-integrity`,
+  `version-tag-integrity`). Protected merge and immutable tags stay.
+- Do not weaken the controls that caught real defects: sensitive-content
+  scanning, version-surface consistency, `artifact-test`, and the full suite in
+  CI.
+- Authorization must still bind to a specific tree; it must not be possible to
+  transplant an approval onto a different commit.
+
+## Touched Surfaces
+
+- `scripts/check_release_authorization.py`
+
+## Approach
+
+Two changes.
+
+**Required evidence reduced to the machine-enforced set.**
+`REQUIRED_EVIDENCE_IDS` is now `final-tree-full-gate` and
+`exact-runtime-artifact`. Both correspond to gates that actually run against the
+tagged tree and whose outcome is recoverable afterwards from the recorded run.
+
+`scale-and-failure`, `ui-validation`, `ownership-audit`,
+`customer-equivalent-acceptance` and `independent-review` move to
+`OPTIONAL_EVIDENCE_IDS`. They remain recognized and are still fully validated
+whenever a release records them — the concreteness, command-binding and
+retrospective-outcome rules are unchanged. They are simply no longer mandatory
+for every release.
+
+**The evidence-only commit requirement is removed.**
+`release_evidence_commit_binding` no longer demands that the tagged commit
+change only the release plan. The plan may ship in the same commit as the code
+it authorizes.
+
+Still enforced: the tagged commit must have exactly one parent, the working tree
+must be clean, and the plan's recorded evidence base commit must equal that
+parent.
+
+## Rejected alternatives
+
+- **Leave the gate as-is.** It regex-matches prose for a command string, a
+  retrospective-sounding word and a digit. It never verified a command ran, so
+  it was expensive for an honest release and trivial for a dishonest one. That
+  combination is worse than no gate, because it looks like assurance.
+- **Delete authorization entirely.** The tree binding is cheap and real; losing
+  it would allow an approval to be reused against a different commit.
+- **Keep the second pull request.** Its only content was prose, and the branch
+  ruleset requires zero approving reviews, so it never delivered the
+  independent sign-off it appeared to represent.
+
+## Validation
+
+- `invoke ci` and `invoke artifact-test` in the release-gate runtime.
+- The reduced required set still fails closed when either required id is
+  missing, unchecked, or non-concrete.
+
+## Rollback
+
+Revert `scripts/check_release_authorization.py`. The optional ids retain their
+original validation logic, so restoring them to `REQUIRED_EVIDENCE_IDS`
+reinstates the previous behavior exactly.
+
+## Decision Log
+
+- Release owner decided on 2026-07-27 that CI's checks plus `artifact-test`
+  are the appropriate bar for a corrective patch, and that the remaining items
+  should not be run as ceremony.
+- Prefer machine-verified evidence over attestation. The durable improvement is
+  a workflow-emitted, SHA-bound manifest recording which gates ran and their
+  conclusions; reinstate any optional id alongside that, not alongside another
+  prose field.
+- Requirements should scale with release type. A corrective patch does not need
+  the same acceptance and UI validation as a feature release.
+
+## Completion Evidence
+
+- `scripts/check_release_authorization.py` requires two ids and binds
+  authorization to the tagged commit's parent.
+- 2.6.2 authorized under the reduced set.

--- a/docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md
+++ b/docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md
@@ -45,6 +45,13 @@ Still enforced: the tagged commit must have exactly one parent, the working tree
 must be clean, and the plan's recorded evidence base commit must equal that
 parent.
 
+**Optional does not mean unvalidated.** Only presence is optional. Any recorded
+known id is still held to the full concreteness, command-binding and
+retrospective-outcome standard, because an id recorded with hollow evidence
+reads as a claim the work was done and is worse than an absent one. The harness
+rejection cases build plans from every known id so they cover the optional ones
+as well.
+
 ## Rejected alternatives
 
 - **Leave the gate as-is.** It regex-matches prose for a command string, a

--- a/scripts/check_release_authorization.py
+++ b/scripts/check_release_authorization.py
@@ -453,17 +453,18 @@ def check_release_authorization(
             match.group("evidence").strip(),
         )
 
+    # Only the required ids must be present, but any recorded id is held to the
+    # full standard. Recording an optional id with hollow evidence is worse than
+    # omitting it, because it reads as a claim that the work was done.
+    recorded = KNOWN_EVIDENCE_IDS & entries.keys()
     missing = sorted(REQUIRED_EVIDENCE_IDS - entries.keys())
     unchecked = sorted(
-        evidence_id
-        for evidence_id in REQUIRED_EVIDENCE_IDS
-        if evidence_id in entries and not entries[evidence_id][0]
+        evidence_id for evidence_id in recorded if not entries[evidence_id][0]
     )
     placeholders = sorted(
         evidence_id
-        for evidence_id in REQUIRED_EVIDENCE_IDS
-        if evidence_id in entries
-        and not _evidence_is_concrete(evidence_id, entries[evidence_id][1])
+        for evidence_id in recorded
+        if not _evidence_is_concrete(evidence_id, entries[evidence_id][1])
     )
     if missing or unchecked or placeholders:
         raise ValueError(

--- a/scripts/check_release_authorization.py
+++ b/scripts/check_release_authorization.py
@@ -11,15 +11,29 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PLAN_ROOT = REPO_ROOT / "docs/03_Plans"
+# Required evidence is limited to the gates a machine actually enforces on the
+# tagged tree: the full CI gate (with its run URL) and the installed-artifact
+# test. Both are verifiable after the fact from the recorded run.
+#
+# The remaining ids below stay recognized and are still validated whenever a
+# release records them, but they are no longer mandatory. They asserted work
+# this checker cannot observe — it regex-matches prose for a command string, a
+# retrospective-sounding word and a digit, so it never confirmed the command
+# ran. That made honest releases expensive and dishonest ones trivial, which is
+# the wrong trade. Reinstate an id here only alongside machine-verified
+# evidence, not another attestation.
 REQUIRED_EVIDENCE_IDS = {
     "final-tree-full-gate",
     "exact-runtime-artifact",
+}
+OPTIONAL_EVIDENCE_IDS = {
     "scale-and-failure",
     "ui-validation",
     "ownership-audit",
     "customer-equivalent-acceptance",
     "independent-review",
 }
+KNOWN_EVIDENCE_IDS = REQUIRED_EVIDENCE_IDS | OPTIONAL_EVIDENCE_IDS
 ENTRY_RE = re.compile(
     r"^- \[(?P<checked>[ xX])\] `(?P<id>[a-z0-9-]+)` - (?P<evidence>.+)$"
 )
@@ -482,26 +496,27 @@ def _git_capture(*args: str) -> str:
 
 
 def release_evidence_commit_binding(path: Path) -> tuple[str, str]:
-    """Require an evidence-only commit whose sole parent is the tested tree."""
+    """Bind authorization to the tagged commit and its parent.
+
+    A separate evidence-only commit is no longer required. It forced a second
+    pull request whose sole content was prose, and the branch ruleset requires
+    zero approving reviews, so it never delivered the independent sign-off it
+    appeared to represent. The release plan may now ship in the same commit as
+    the code it authorizes.
+
+    What still holds: the tagged commit must be a single-parent commit on a
+    clean tree, and the plan's recorded evidence base commit must match that
+    parent, so authorization cannot be transplanted onto a different tree.
+    """
     head = _git_capture("rev-parse", "HEAD")
     commit_line = _git_capture("rev-list", "--parents", "-n", "1", head).split()
     if len(commit_line) != 2:
-        raise ValueError("Release evidence commit must have exactly one parent.")
+        raise ValueError("Release commit must have exactly one parent.")
     base = commit_line[1]
-    changed_files = {
-        line
-        for line in _git_capture("diff", "--name-only", base, head).splitlines()
-        if line
-    }
     try:
-        plan_path = str(path.resolve().relative_to(REPO_ROOT))
+        path.resolve().relative_to(REPO_ROOT)
     except ValueError as exc:
         raise ValueError("Release plan must be inside the repository.") from exc
-    if changed_files != {plan_path}:
-        raise ValueError(
-            "Release evidence commit may change only its release plan; "
-            f"changed={sorted(changed_files)}."
-        )
     if _git_capture("status", "--porcelain"):
         raise ValueError("Release authorization requires a clean working tree.")
     return base, head

--- a/scripts/tests/test_release_authorization.py
+++ b/scripts/tests/test_release_authorization.py
@@ -85,7 +85,10 @@ class ReleaseAuthorizationTest(unittest.TestCase):
         entries = "\n".join(
             f"- [{marker}] `{evidence_id}` - "
             f"{evidence_overrides.get(evidence_id, evidence if evidence is not None else self.VALID_EVIDENCE[evidence_id])}"
-            for evidence_id in sorted(release_authorization.REQUIRED_EVIDENCE_IDS)
+            # Every known id, not just the required ones: an optional id is
+            # validated to the same standard whenever a release records it, so
+            # the rejection cases must cover them too.
+            for evidence_id in sorted(release_authorization.KNOWN_EVIDENCE_IDS)
         )
         base_line = (
             f"- Evidence base commit: `{base_commit}`\n\n" if base_commit else ""


### PR DESCRIPTION
Reduces required release evidence to the two gates a machine actually enforces on the tagged tree — `final-tree-full-gate` and `exact-runtime-artifact` — and drops the evidence-only second pull request.

The other five evidence ids remain recognized and fully validated when a release records them; they are simply no longer mandatory. The checker regex-matches prose for a command string, a retrospective-sounding word and a digit, so it never confirmed the underlying work ran. That made honest releases expensive and dishonest ones trivial.

Authorization still binds to the tagged commit's parent on a clean tree, so an approval cannot be transplanted onto a different tree. Rulesets, sensitive-content scanning, version-surface consistency and `artifact-test` are unchanged.

Also records the 2.6.2 authorization against the two gates that were actually run in the release-gate runtime. The remaining ids are deliberately absent rather than asserted without basis.

Plan: `docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md`