### PR TITLE
chore: fail the release gate on static defects before docker starts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,8 +39,10 @@ repos:
         # These modules keep a module docstring ahead of their imports, which
         # reorder-python-imports strips the blank line from and black restores,
         # so the two hooks never converge. Formatting stays owned by black.
-        exclude: >-
-          ^forward_netbox/utilities/(merge|diagnostics|fast_baseline|fast_baseline_models|tier3_reducers|contributor_baseline)\.py$
+        # Written on one line: yamlfmt folds a block scalar and injects spaces
+        # into the alternation, which silently breaks the pattern.
+        # yamllint disable-line rule:line-length
+        exclude: "^(forward_netbox/utilities/(merge|diagnostics|fast_baseline|fast_baseline_models|tier3_reducers|contributor_baseline)|scripts/check_release_preflight|scripts/tests/test_release_preflight)\\.py$"
   - repo: https://github.com/psf/black
     rev: 25.9.0
     hooks:

--- a/docs/03_Plans/active/2026-07-28-release-2.6.4-gate-ordering.md
+++ b/docs/03_Plans/active/2026-07-28-release-2.6.4-gate-ordering.md
@@ -1,0 +1,112 @@
+# 2.6.4 Release Gate Ordering
+
+## Goal
+
+Make the local release gate report statically-detectable failures in seconds
+instead of after half an hour, and record the remaining 2.6.4 follow-up work.
+
+Releasing 2.6.3 on 2026-07-28 took six full ~35-minute gate runs. Every failure
+was detectable without starting docker:
+
+1. a provenance test asserting a stale error message
+2. `forward_netbox/tests/test_runtime_dependency_check.py` hardcoding the
+   previous release version - reported ~13 minutes in, inside the Django suite
+3. the harness plan-file gate
+4. port 8000 held by another compose project
+5. the `playwright` npm package never installed - reported ~30 minutes in,
+   after the entire Django suite had already passed
+
+Roughly five minutes of real defects cost about three and a half hours.
+
+## Constraints
+
+- Do not weaken any existing check. This is ordering and coverage, not removal.
+- The preflight must fail closed: an unreadable file or an unexpected number of
+  version literals is a failure, not a skip.
+- Keep the checks static. Anything needing docker belongs in the later stages.
+
+## Touched Surfaces
+
+- `scripts/check_release_preflight.py` (new)
+- `scripts/tests/test_release_preflight.py` (new)
+- `tasks.py` - new `release-preflight` task, added first in `ci`'s pre-chain
+
+## Approach
+
+A `release-preflight` task runs ahead of every expensive stage and covers the
+two failures that were ordered worst:
+
+**Version surface consistency.** Compares `pyproject.toml` against every place
+the release version is written: the package `__init__`, the fast-baseline
+runtime pin, and the runtime version test. The list is explicit rather than
+globbed, because a surface that silently stops being checked is the exact
+failure this guards against. The fast-baseline pin is load-bearing - a stale
+value silently reverts a first sync to the slow path, so it is covered by a
+dedicated test.
+
+**UI harness dependencies.** Asserts every `devDependencies` entry in
+`package.json` is present in `node_modules`. `invoke ci` runs the UI suite last,
+so a missing `npm install` previously surfaced only after the full Django suite.
+
+Both were verified against the real 2.6.3 failures: reintroducing the stale
+version literal and removing `node_modules` each produce a sub-second, specific
+diagnostic.
+
+## Rejected alternatives
+
+- **Parallelise the stages instead.** Real, but it does not help the case that
+  actually hurt: a static defect still consumes a docker bring-up and a test
+  run before anything reports. Ordering is the cheaper and more certain fix.
+  Parallelism remains open for later.
+- **Glob the version surfaces.** Fewer edits when a surface is added, but a
+  renamed or moved file would silently drop out of coverage.
+- **Fold these into `check_harness.py`.** That script is already large and is
+  about repository shape; release-time preconditions are a separate concern
+  with a separate failure mode.
+
+## Validation
+
+- `scripts/tests/test_release_preflight.py` - 8 tests, including both real
+  2.6.3 failures and the `min_version`/`max_version` false-positive case.
+- Manual injection of each failure against the working tree.
+
+## Rollback
+
+Remove `release_preflight` from `ci`'s pre-chain. The task and script are
+additive and hold no state.
+
+## Remaining 2.6.4 follow-up work
+
+Carried from the 2.6.2/2.6.3 tranche, not started here:
+
+1. **Protected-delete ordering** (gating). Canonical delete intent is exact
+   (1,434 expected / 1,434 matched / 0 spurious / 0 missing) but physical
+   convergence fails: Device 6 to 5, Interface 561 to 559, IPAddress 54 to 63.
+   Same class as the fixed `netbox_dlm.softwareversion` case - a protected
+   delete scheduled before the update releasing its foreign key. The proven
+   pattern is in `bulk_merge.py`.
+2. **Diff enablement for blocked models**, pending item 1: Interfaces
+   (535,777 rows, the largest win), BGP Peers, BGP AF, BGP Peer AF, IPv4
+   addresses, Device. Already cleared: 12 Tier 1 contracts, Modules, OSPF
+   Instances, OSPF Interfaces, MAC.
+3. **Proven performance engines**, held outside the repository: set-based merge
+   (14.17x on MAC), COPY/SQL staging (8.98x on MAC), and a corrected
+   delete-correctness comparator with 27 tests.
+4. **Smaller items.** IPAddress baseline shard degradation (70.2s to 149.0s);
+   the exact-noop parity gap emitting 360 representational BGP-peer updates;
+   publishing the corrected null-safe platform query to the shared `fwd` org so
+   other customers stop carrying the null-unsafe version.
+5. **Further release-CI relaxation.** A workflow-emitted, SHA-bound run
+   manifest to replace prose evidence matching; relaxing the evidence-base
+   commit rule to ancestor-of-HEAD; skipping the duplicate push-and-pull-request
+   CI runs; and letting `stage_finish` accept a green run on an identical tree.
+
+Do not release 2.6.4 until the customer's field feedback is in.
+
+## Decision Log
+
+- 2026-07-28: gate ordering pulled forward at the release owner's request after
+  the 2.6.3 experience, ahead of the larger correctness items above.
+- Preflight covers only statically-checkable preconditions. Environmental
+  conflicts such as a held port stay with the stage that owns the resource,
+  which already fails quickly.

--- a/forward_netbox/utilities/merge.py
+++ b/forward_netbox/utilities/merge.py
@@ -27,19 +27,18 @@ from netbox.context_managers import event_tracking
 from netbox_branching.choices import BranchEventTypeChoices
 from netbox_branching.choices import BranchStatusChoices
 from netbox_branching.merge_strategies import get_merge_strategy
-from rq.timeouts import JobTimeoutException
-
-from .bulk_merge import _ApplyOneFailure
-from .bulk_merge import bulk_merge_changes
-from .bulk_delete import lock_related_writes_for_delete
 from netbox_branching.models import Branch
 from netbox_branching.models import BranchEvent
 from netbox_branching.signals import post_merge
 from netbox_branching.utilities import record_applied_change
+from rq.timeouts import JobTimeoutException
 
 from ..choices import ForwardIngestionPhaseChoices
 from ..exceptions import ForwardPartialMergeError
 from ..models import ForwardIngestionIssue
+from .bulk_delete import lock_related_writes_for_delete
+from .bulk_merge import _ApplyOneFailure
+from .bulk_merge import bulk_merge_changes
 from .diagnostics import exception_type
 from .diagnostics import safe_operation_failure
 

--- a/scripts/check_release_preflight.py
+++ b/scripts/check_release_preflight.py
@@ -1,0 +1,152 @@
+"""Fast, static preflight for the local release gate.
+
+Every check here is sub-second and fails closed. The point is ordering: the
+gate's expensive stages (docker bring-up, the ~13-minute Django suite, the
+Playwright run) sit behind these, so a one-line version mismatch or a missing
+npm dependency is reported in seconds instead of after half an hour.
+
+Releasing 2.6.3 cost six ~35-minute gate runs, and every failure was
+detectable statically:
+
+* a hardcoded plugin version left at the previous release
+* the Playwright package never installed, surfaced ~30 minutes in
+
+Both are covered below.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+PACKAGE_INIT = REPO_ROOT / "forward_netbox" / "__init__.py"
+FAST_BASELINE = REPO_ROOT / "forward_netbox" / "utilities" / "fast_baseline.py"
+RUNTIME_VERSION_TEST = (
+    REPO_ROOT / "forward_netbox" / "tests" / "test_runtime_dependency_check.py"
+)
+PACKAGE_JSON = REPO_ROOT / "package.json"
+NODE_MODULES = REPO_ROOT / "node_modules"
+
+
+class PreflightError(Exception):
+    """A release preflight check failed."""
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - unreadable tree is fatal anyway
+        raise PreflightError(f"cannot read {path.relative_to(REPO_ROOT)}: {exc}")
+
+
+def declared_version() -> str:
+    with PYPROJECT.open("rb") as handle:
+        return tomllib.load(handle)["tool"]["poetry"]["version"]
+
+
+def _sole_match(path: Path, pattern: str, label: str) -> str:
+    matches = re.findall(pattern, _read(path))
+    if len(matches) != 1:
+        raise PreflightError(
+            f"{label}: expected exactly one version literal in "
+            f"{path.relative_to(REPO_ROOT)}, found {len(matches)}"
+        )
+    return matches[0]
+
+
+def version_surfaces() -> dict[str, str]:
+    """Every place the release version is written out.
+
+    Kept explicit rather than globbed: a surface that silently stops being
+    checked is exactly the failure this guards against. `fast_baseline` is the
+    load-bearing one - its pin gates the fast baseline engine, so a stale value
+    silently reverts a first sync to the slow path.
+    """
+    return {
+        # Anchored so the neighbouring min_version/max_version NetBox pins are
+        # not mistaken for the plugin version.
+        "forward_netbox/__init__.py": _sole_match(
+            PACKAGE_INIT, r'(?m)^\s*version\s*=\s*"([^"]+)"', "package __init__"
+        ),
+        # The pin is a dict entry whose value routinely wraps to its own line.
+        "forward_netbox/utilities/fast_baseline.py": _sole_match(
+            FAST_BASELINE,
+            r'"forward_netbox":\s*"([^"]+)"',
+            "fast-baseline runtime pin",
+        ),
+        "forward_netbox/tests/test_runtime_dependency_check.py": _sole_match(
+            RUNTIME_VERSION_TEST,
+            r'NetboxForwardConfig\.version,\s*"([^"]+)"',
+            "runtime version test",
+        ),
+    }
+
+
+def check_version_surfaces() -> str:
+    expected = declared_version()
+    drifted = {
+        path: found for path, found in version_surfaces().items() if found != expected
+    }
+    if drifted:
+        detail = ", ".join(
+            f"{path} has {found!r}" for path, found in sorted(drifted.items())
+        )
+        raise PreflightError(
+            f"version surfaces disagree with pyproject {expected!r}: {detail}"
+        )
+    return expected
+
+
+def check_ui_harness_dependencies() -> str:
+    """The Playwright package must be installed before the gate starts.
+
+    `invoke ci` runs the UI suite last, so a missing `npm install` was only
+    reported after the full Django suite had already passed.
+    """
+    if not PACKAGE_JSON.exists():
+        raise PreflightError("package.json is missing; the UI harness cannot run")
+    manifest = json.loads(_read(PACKAGE_JSON))
+    required = sorted(manifest.get("devDependencies", {}))
+    if not required:
+        raise PreflightError("package.json declares no UI harness dependencies")
+    missing = [name for name in required if not (NODE_MODULES / name).is_dir()]
+    if missing:
+        raise PreflightError(
+            f"UI harness dependencies are not installed: {', '.join(missing)}. "
+            "Run `npm install` before the release gate."
+        )
+    return ", ".join(required)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit the results as JSON")
+    arguments = parser.parse_args()
+
+    try:
+        version = check_version_surfaces()
+        dependencies = check_ui_harness_dependencies()
+    except PreflightError as exc:
+        print(f"release preflight failed: {exc}", file=sys.stderr)
+        return 1
+
+    result = {"version": version, "ui_harness_dependencies": dependencies}
+    if arguments.json:
+        print(json.dumps(result, sort_keys=True))
+    else:
+        print(f"release preflight passed: version {version} consistent across surfaces")
+        print(
+            f"release preflight passed: UI harness dependencies present ({dependencies})"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_release_preflight.py
+++ b/scripts/tests/test_release_preflight.py
@@ -1,0 +1,86 @@
+"""Tests for the fast release preflight.
+
+These pin the two failures that cost six full gate runs during the 2.6.3
+release: a version surface left at the previous release, and the UI harness
+dependencies never installed.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import check_release_preflight as preflight  # noqa: E402
+
+
+class VersionSurfaceTest(unittest.TestCase):
+    def test_all_surfaces_agree_in_the_real_tree(self):
+        self.assertEqual(
+            preflight.check_version_surfaces(), preflight.declared_version()
+        )
+
+    def test_rejects_a_surface_left_at_the_previous_release(self):
+        surfaces = preflight.version_surfaces()
+        stale = dict(surfaces)
+        stale["forward_netbox/tests/test_runtime_dependency_check.py"] = "0.0.1"
+        with mock.patch.object(preflight, "version_surfaces", return_value=stale):
+            with self.assertRaisesRegex(preflight.PreflightError, "0.0.1"):
+                preflight.check_version_surfaces()
+
+    def test_names_every_drifted_surface(self):
+        stale = {path: "0.0.1" for path in preflight.version_surfaces()}
+        with mock.patch.object(preflight, "version_surfaces", return_value=stale):
+            with self.assertRaises(preflight.PreflightError) as caught:
+                preflight.check_version_surfaces()
+        for path in stale:
+            self.assertIn(path, str(caught.exception))
+
+    def test_covers_the_fast_baseline_runtime_pin(self):
+        # The pin gates the fast baseline engine; a stale value silently
+        # reverts a first sync to the slow path, so it must stay checked.
+        self.assertIn(
+            "forward_netbox/utilities/fast_baseline.py",
+            preflight.version_surfaces(),
+        )
+
+    def test_ignores_the_neighbouring_netbox_version_pins(self):
+        # min_version/max_version sit beside the plugin version in __init__.
+        self.assertEqual(
+            preflight.version_surfaces()["forward_netbox/__init__.py"],
+            preflight.declared_version(),
+        )
+
+
+class UiHarnessDependencyTest(unittest.TestCase):
+    def test_passes_when_dependencies_are_installed(self):
+        # Built rather than read from the working tree: CI runs the harness
+        # tests before `npm install`, so asserting against the real
+        # node_modules would make this test depend on the environment.
+        with tempfile.TemporaryDirectory() as root:
+            installed = Path(root)
+            for name in json.loads(preflight._read(preflight.PACKAGE_JSON))[
+                "devDependencies"
+            ]:
+                (installed / name).mkdir(parents=True)
+            with mock.patch.object(preflight, "NODE_MODULES", installed):
+                self.assertIn("playwright", preflight.check_ui_harness_dependencies())
+
+    def test_rejects_missing_dependencies(self):
+        with mock.patch.object(preflight, "NODE_MODULES", Path("/nonexistent")):
+            with self.assertRaisesRegex(preflight.PreflightError, "npm install"):
+                preflight.check_ui_harness_dependencies()
+
+    def test_rejects_a_manifest_declaring_no_dependencies(self):
+        with mock.patch.object(preflight, "_read", return_value=json.dumps({})):
+            with self.assertRaisesRegex(preflight.PreflightError, "no UI harness"):
+                preflight.check_ui_harness_dependencies()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tasks.py
+++ b/tasks.py
@@ -529,6 +529,12 @@ def harness_check(context):
     context.run(f"{shlex.quote(sys.executable)} scripts/check_harness.py")
 
 
+@task(name="release-preflight")
+def release_preflight(context):
+    """Static checks that must fail before the gate spends time on docker."""
+    context.run(f"{shlex.quote(sys.executable)} scripts/check_release_preflight.py")
+
+
 @task(name="release-authorization-check")
 def release_authorization_check(context, version="2.6.0"):
     context.run(
@@ -1712,6 +1718,10 @@ def sync_release_gate(
 
 @task(
     pre=[
+        # Static, sub-second checks run first: everything below this line costs
+        # docker bring-up or minutes of test time, so a stale version surface or
+        # a missing UI dependency must be reported before any of it starts.
+        release_preflight,
         sensitive_check,
         harness_check,
         harness_test,


### PR DESCRIPTION
Releasing 2.6.3 took six full ~35-minute gate runs. Every failure was statically detectable; two were ordered worst:

- a version surface left at `2.6.2` — reported ~13 min in, inside the Django suite
- the `playwright` npm package never installed — reported ~30 min in, *after* the Django suite had already passed

Adds a `release-preflight` task, first in `ci`'s pre-chain:

**Version surface consistency** — compares `pyproject.toml` against the package `__init__`, the fast-baseline runtime pin, and the runtime version test. Explicit list rather than a glob, so a moved file can't silently drop out of coverage. The fast-baseline pin gets a dedicated test because a stale value silently reverts a first sync to the slow path.

**UI harness dependencies** — asserts every `package.json` devDependency is present in `node_modules`.

Both verified against the real 2.6.3 failures: reintroducing the stale literal and removing `node_modules` each produce a sub-second, specific diagnostic. 8 new tests, including the `min_version`/`max_version` false-positive case.

No existing check is weakened — this is ordering and coverage only.

The plan file also records the remaining 2.6.4 follow-ups (protected-delete ordering, diff enablement, the held performance engines, further CI relaxation). **2.6.4 is not to be released pending field feedback.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qa2pEe4utNff6s1HoCap1J