### PR TITLE
release: 2.6.4 — query-ID bound maps could never resolve a commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
         # Written on one line: yamlfmt folds a block scalar and injects spaces
         # into the alternation, which silently breaks the pattern.
         # yamllint disable-line rule:line-length
-        exclude: "^(forward_netbox/utilities/(merge|diagnostics|fast_baseline|fast_baseline_models|tier3_reducers|contributor_baseline)|forward_netbox/tests/(test_empty_workload_failure|test_query_spec_head_resolution)|scripts/check_release_preflight|scripts/tests/test_release_preflight)\\.py$"
+        exclude: "^(forward_netbox/utilities/(merge|diagnostics|fast_baseline|fast_baseline_models|tier3_reducers|contributor_baseline)|forward_netbox/tests/(test_empty_workload_failure|test_query_spec_head_resolution|test_head_commit_from_listing|test_query_id_binding_end_to_end)|scripts/check_release_preflight|scripts/tests/test_release_preflight)\\.py$"
   - repo: https://github.com/psf/black
     rev: 25.9.0
     hooks:

--- a/docs/03_Plans/active/2026-07-28-release-2.6.4-query-id-binding.md
+++ b/docs/03_Plans/active/2026-07-28-release-2.6.4-query-id-binding.md
@@ -47,13 +47,29 @@ was invisible.
 
 ## Approach
 
-**Head resolution works for either binding.** A map that keeps its path resolves
-through it. A map bound only by a query ID resolves head from the repository
-query index via `resolve_nqe_query_head_commit`. Two guards: a commit is adopted
-only when the path still resolves to the bound query ID, so a moved path cannot
-graft another query's revision; and an ambiguous or unresolvable ID leaves the
-spec untouched so the existing contract reporting explains the refusal rather
-than failing the whole fetch. An explicit pin is never overwritten.
+**Query-ID bound customer maps resolve head.** Unpinned head resolution ran
+only for `built_in` specs, so a customer map bound by query ID kept an empty
+commit and the contract refused it as `unresolved_full_commit`. Diff execution
+is query-ID-only, so this is the primary binding, not an edge case.
+`_resolve_unpinned_customer_full_revision` resolves head for a customer map
+that is unpinned and carries a repository path, adopting the commit only when
+the path still resolves to the bound query ID. Source verification is
+unchanged: `_hydrate_diff_contract_sources` still loads committed source, and a
+lookup failure or identity mismatch leaves the contract closed.
+
+**A commit-less repository row no longer short-circuits the lookup.** The org
+directory listing (`/nqe/queries`) returns only intent/path/queryId/repository
+with no commit field, while every other repository is read through
+`/nqe/repos/{repo}/commits/head/queries`, which does report `lastCommitId`.
+Returning a listing row left the caller with an empty commit, so
+`get_committed_nqe_query` now falls through to the commits endpoint whenever the
+indexed row carries no commit.
+
+Verified against the live org repository rather than inferred: the directory
+listing returns 3,983 rows and recurses to depth 9 (an earlier nested-folder
+theory was wrong and was reverted), the row for the reported map carries a
+query ID and no commit, and all 59 queries in that folder resolve a
+`lastCommitId` through the commits endpoint.
 
 **An empty workload caused by failures fails closed.** `failed_model_strings`
 decides whether an empty workload means convergence or wholesale failure, and
@@ -90,11 +106,14 @@ distinguishing consequences, not hiding one of them.
 
 ## Validation
 
-- Full Django suite: 1,642 tests, `OK (skipped=3)`.
+- Full Django suite: 1,652 tests, `OK (skipped=3)`.
 - Harness suite: 219 tests, OK, including the worker-timeout boundary rule.
-- 14 new tests covering both binding modes, the moved-path guard, pin
-  precedence, unresolvable and ambiguous IDs, a failing repository lookup, and a
-  client without the resolver.
+- 24 new tests. The end-to-end guard resolves a query-ID bound customer map
+  against the real commit-less listing shape and asserts the contract comes out
+  `full_eligible`; with the fix removed it fails with the production symptom,
+  `unresolved_full_commit`. Also covered: pin precedence, a path that now
+  resolves to a different query, a failing repository lookup, a map with no
+  path, and the commits-endpoint fallthrough.
 
 ## Rollback
 
@@ -110,9 +129,9 @@ needs no data repair.
 
 ## Release Authorization
 
-- Evidence base commit: `b1bdda31f867f451bce9709939eeb9bf147b69bb`
+- Evidence base commit: `2c59f67faffbcef1f8bdacf89a84e1cf496c89af`
 
-- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke ci` passed on the final 2.6.4 tree with exit status 0: 219 harness tests OK, 66 scenario tests OK, 1642 Django tests OK with 3 skipped, and the sync release gate reported clean strict release checks.
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke ci` passed on the final 2.6.4 tree with exit status 0: 219 harness tests OK, 66 scenario tests OK, 1652 Django tests OK with 3 skipped, and the sync release gate reported clean strict release checks.
 - [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke artifact-test` passed against the installed `forward_netbox-2.6.4-py3-none-any.whl` on NetBox 4.6.5, Branching 1.1.1, Python 3.14, with 7 authenticated menu routes returning 200, no migration drift, and a validated SBOM of 157 components.
 
 The optional evidence ids are not recorded: this is a corrective release for a

--- a/forward_netbox/tests/test_head_commit_from_listing.py
+++ b/forward_netbox/tests/test_head_commit_from_listing.py
@@ -1,0 +1,116 @@
+"""An org query's head commit must come from the endpoint that reports one.
+
+The repository directory listing returns only intent/path/queryId/repository -
+no commit field at all. Returning one of those rows left the caller with an
+empty commit, the execution contract rejected the map as
+`unresolved_full_commit`, and a customer's whole sync fetched nothing while
+reporting success. The commits endpoint does report `lastCommitId`, so a
+commit-less index row must fall through to it rather than short-circuit.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from django.test import TestCase
+
+from forward_netbox.utilities import forward_api_impl
+from forward_netbox.utilities.forward_api import ForwardClient
+from forward_netbox.utilities.crypto import encrypt_secret
+
+PATH = "/Nested_Folder/forward_netbox_validation/forward_locations"
+QUERY_ID = "Q_bound"
+HEAD = "commit_head_value"
+
+# Exactly the shape the live directory listing returns for an org query.
+LISTING_ROW = {
+    "intent": "",
+    "path": PATH,
+    "queryId": QUERY_ID,
+    "repository": "org",
+}
+
+
+class HeadCommitResolutionTest(TestCase):
+    def setUp(self):
+        shared_cache = forward_api_impl._shared_read_cache()
+        if hasattr(shared_cache, "clear"):
+            shared_cache.clear()
+        self.client = ForwardClient(
+            SimpleNamespace(
+                url="https://fwd.app",
+                parameters={
+                    "username": "user@example.com",
+                    "password": encrypt_secret("secret"),
+                    "verify": True,
+                    "timeout": 1200,
+                },
+            )
+        )
+
+    def _index(self, row):
+        return {
+            "rows": [dict(row)],
+            "by_path": {str(row["path"]): dict(row)},
+            "by_query_id": {str(row.get("queryId")): [dict(row)]},
+        }
+
+    def _commits_response(self):
+        response = Mock()
+        response.json.return_value = {
+            "queries": [
+                {
+                    "path": PATH,
+                    "queryId": QUERY_ID,
+                    "lastCommitId": HEAD,
+                    "sourceCodeSha": "abc123",
+                }
+            ]
+        }
+        return response
+
+    def test_commitless_listing_row_falls_through_and_resolves_head(self):
+        # The customer case: the row exists but carries no commit.
+        self.client._request = Mock(return_value=self._commits_response())
+        resolved = self.client.get_committed_nqe_query(
+            repository="org",
+            query_path=PATH,
+            commit_id="head",
+            query_index=self._index(LISTING_ROW),
+        )
+        self.assertEqual(resolved.get("lastCommitId"), HEAD)
+        self.assertEqual(resolved.get("queryId"), QUERY_ID)
+        self.client._request.assert_called_once()
+
+    def test_a_listing_row_carrying_a_commit_needs_no_request(self):
+        row = dict(LISTING_ROW, lastCommitId=HEAD)
+        self.client._request = Mock()
+        resolved = self.client.get_committed_nqe_query(
+            repository="org",
+            query_path=PATH,
+            commit_id="head",
+            query_index=self._index(row),
+        )
+        self.assertEqual(resolved.get("lastCommitId"), HEAD)
+        self.client._request.assert_not_called()
+
+    def test_the_fallthrough_requests_the_head_commit(self):
+        self.client._request = Mock(return_value=self._commits_response())
+        self.client.get_committed_nqe_query(
+            repository="org",
+            query_path=PATH,
+            commit_id="head",
+            query_index=self._index(LISTING_ROW),
+        )
+        route = self.client._request.call_args[0][1]
+        self.assertIn("/nqe/repos/org/commits/head/queries", route)
+
+    def test_an_explicitly_pinned_commit_is_still_honoured(self):
+        self.client._request = Mock(return_value=self._commits_response())
+        self.client.get_committed_nqe_query(
+            repository="org",
+            query_path=PATH,
+            commit_id="pinned_commit",
+            query_index=self._index(LISTING_ROW),
+        )
+        route = self.client._request.call_args[0][1]
+        self.assertIn("/commits/pinned_commit/queries", route)

--- a/forward_netbox/tests/test_query_id_binding_end_to_end.py
+++ b/forward_netbox/tests/test_query_id_binding_end_to_end.py
@@ -1,0 +1,120 @@
+"""A customer map bound by query ID must resolve and become executable.
+
+This is the primary binding, not an edge case: diff execution is query-ID-only,
+and `Resolve to Query ID` deliberately produces exactly this shape. It had no
+coverage against a realistic repository response, so two defects shipped:
+
+* unpinned head resolution only ran for built-in specs, so a customer map kept
+  an empty commit and the contract refused it as `unresolved_full_commit`
+* the org directory listing carries no commit field at all, so any code path
+  trusting it resolved nothing
+
+Every fixture here mirrors the live API: the directory listing returns
+intent/path/queryId/repository with no commit, and only the commits endpoint
+reports `lastCommitId`.
+"""
+
+from django.test import SimpleTestCase
+
+from forward_netbox.utilities.query_execution_contract import (
+    resolve_execution_contract,
+)
+from forward_netbox.utilities.query_registry import QuerySpec
+from forward_netbox.utilities.query_registry import resolve_query_specs_for_client
+
+PATH = "/Customer_Folder/forward_netbox_validation/forward_locations"
+QUERY_ID = "Q_customer"
+HEAD = "9f28247c1b4e4d0a8f0b2c7d5e6a1b3c4d5e6f70"
+SOURCE = "queries { devices { name } }"
+
+
+class _Client:
+    """Client mirroring the live split between listing and commits endpoints."""
+
+    def __init__(self, *, query_id=QUERY_ID, commit=HEAD, source=SOURCE):
+        self._query_id = query_id
+        self._commit = commit
+        self._source = source
+        self.committed_lookups = []
+
+    def get_committed_nqe_query(
+        self, *, repository="org", query_path="", commit_id="head", **kwargs
+    ):
+        self.committed_lookups.append((query_path, commit_id))
+        return {
+            "path": query_path,
+            "queryId": self._query_id,
+            "lastCommitId": self._commit,
+            "sourceCode": self._source,
+            "repository": repository,
+        }
+
+    def get_nqe_repository_query_index(self, *, repository="org", directory="/"):
+        # The org listing carries no commit field. Nothing may depend on one.
+        row = {
+            "intent": "",
+            "path": PATH,
+            "queryId": self._query_id,
+            "repository": repository,
+        }
+        return {
+            "rows": [row],
+            "by_path": {PATH: dict(row)},
+            "by_query_id": {self._query_id: [dict(row)]},
+        }
+
+
+def _spec(**overrides):
+    fields = {
+        "model_string": "dcim.site",
+        "query_name": "Forward Locations",
+        "query_id": QUERY_ID,
+        "query_repository": "org",
+        "query_path": None,
+        "resolved_query_path": PATH,
+        "built_in": False,
+    }
+    fields.update(overrides)
+    return QuerySpec(**fields)
+
+
+class QueryIdBindingResolutionTest(SimpleTestCase):
+    def test_an_unpinned_customer_map_resolves_head(self):
+        [resolved] = resolve_query_specs_for_client([_spec()], _Client())
+        self.assertEqual(resolved.commit_id, HEAD)
+
+    def test_the_resolved_contract_is_executable(self):
+        # The whole point: a resolved map must not be refused as
+        # unresolved_full_commit, which is what emptied a customer's sync.
+        [resolved] = resolve_query_specs_for_client([_spec()], _Client())
+        contract = resolve_execution_contract(resolved, effective_parameters={})
+        self.assertNotEqual(contract.full_reason_code, "unresolved_full_commit")
+        self.assertTrue(
+            contract.full_eligible,
+            f"contract refused the map: {contract.full_reason_code}",
+        )
+
+    def test_a_pinned_commit_is_preserved(self):
+        [resolved] = resolve_query_specs_for_client(
+            [_spec(commit_id="pinned_commit_value")], _Client()
+        )
+        self.assertEqual(resolved.commit_id, "pinned_commit_value")
+
+    def test_a_path_resolving_to_another_query_is_refused(self):
+        client = _Client(query_id="Q_someone_else")
+        [resolved] = resolve_query_specs_for_client([_spec()], client)
+        self.assertFalse(resolved.commit_id)
+
+    def test_a_repository_failure_leaves_the_map_unresolved(self):
+        class _Failing(_Client):
+            def get_committed_nqe_query(self, **kwargs):
+                raise RuntimeError("repository unavailable")
+
+        [resolved] = resolve_query_specs_for_client([_spec()], _Failing())
+        self.assertFalse(resolved.commit_id)
+
+    def test_a_map_without_any_path_is_left_alone(self):
+        [resolved] = resolve_query_specs_for_client(
+            [_spec(resolved_query_path=None)], _Client()
+        )
+        self.assertFalse(resolved.commit_id)

--- a/forward_netbox/utilities/forward_api_impl.py
+++ b/forward_netbox/utilities/forward_api_impl.py
@@ -1498,7 +1498,19 @@ class ForwardClient:
                 has_source = any(
                     indexed_query.get(key) for key in ("sourceCode", "source", "query")
                 )
-                if not require_source_code or has_source:
+                # The directory listing carries no commit for org queries, only
+                # intent/path/queryId/repository. Returning such a row leaves the
+                # caller with an empty commit, which the execution contract
+                # rejects as unresolved_full_commit - so every org-bound map was
+                # refused and whole syncs fetched nothing. Fall through to the
+                # commits endpoint, which does report lastCommitId.
+                indexed_commit = str(
+                    indexed_query.get("commitId")
+                    or indexed_query.get("lastCommitId")
+                    or (indexed_query.get("lastCommit") or {}).get("id")
+                    or ""
+                ).strip()
+                if indexed_commit and (not require_source_code or has_source):
                     query = dict(indexed_query)
                     query.setdefault("repository", repository)
                     query.setdefault("intent", "")

--- a/forward_netbox/utilities/query_registry.py
+++ b/forward_netbox/utilities/query_registry.py
@@ -1346,7 +1346,51 @@ def _finalize_resolved_spec(
             client,
             preferred_commit_id=preferred_commit_id,
         )
+        spec = _resolve_unpinned_customer_full_revision(spec, client)
     return _hydrate_diff_contract_sources(spec, client)
+
+
+def _resolve_unpinned_customer_full_revision(spec: QuerySpec, client) -> QuerySpec:
+    """Resolve head for a customer map bound to a query ID without a pin.
+
+    Only built-in specs had unpinned head resolution, so a customer map bound
+    by query ID kept an empty commit, the execution contract refused it as
+    `unresolved_full_commit`, and every such model was skipped. Diff execution
+    is query-ID-only, so this is the primary binding, not an edge case.
+
+    Source verification is unchanged: `_hydrate_diff_contract_sources` still
+    loads the committed source for the resolved commit, and a lookup failure or
+    identity mismatch leaves the contract closed.
+    """
+    if spec.built_in or not spec.run_query_id:
+        return spec
+    if str(spec.commit_id or "").strip() not in ("", "head"):
+        return spec
+    query_path = str(spec.resolved_query_path or spec.query_path or "").strip()
+    if not query_path:
+        return spec
+    try:
+        resolved = client.get_committed_nqe_query(
+            repository=spec.query_repository or "org",
+            query_path=query_path,
+            commit_id="head",
+        )
+    except JobTimeoutException:
+        raise
+    except Exception:
+        return spec
+    if str(resolved.get("queryId") or "").strip() != str(spec.run_query_id).strip():
+        # The path now resolves to a different query; its head is not ours.
+        return spec
+    commit_id = str(
+        resolved.get("commitId")
+        or resolved.get("lastCommitId")
+        or (resolved.get("lastCommit") or {}).get("id")
+        or ""
+    ).strip()
+    if not commit_id or commit_id == "head":
+        return spec
+    return replace(spec, commit_id=commit_id)
 
 
 def _hydrate_diff_contract_sources(spec: QuerySpec, client) -> QuerySpec:


### PR DESCRIPTION
## The defect

A customer upgraded 2.6.1 → 2.6.3, ran **Resolve to Query ID** as our notes direct, and got a sync reporting **Completed / Validation Passed** with zero changes, no branch, and Drift stuck at "not measured". Every fetch had actually been rejected: **2 NQE calls for 29 enabled models**, against 3,176 correctly-scoped devices.

Two independent causes:

1. **Unpinned head resolution ran only for `built_in` specs.** A customer map bound by query ID kept an empty commit, so the contract refused it as `unresolved_full_commit` and skipped the model. **Diff execution is query-ID-only, so this is the primary binding, not an edge case.**
2. **The org directory listing carries no commit field** — only `intent/path/queryId/repository`. Other repositories are read through `/nqe/repos/{repo}/commits/head/queries`, which *does* report `lastCommitId`. Returning a listing row left the caller with an empty commit.

## Verified against the live org repository, not inferred

- the listing returns 3,983 rows and **recurses to depth 9** (an earlier nested-folder theory was wrong and is reverted)
- the reported map's row carries a query ID and **no commit**
- **all 59 queries in that folder resolve a `lastCommitId`** through the commits endpoint

## Why this shipped twice

Every existing fixture fabricated a listing row *containing* `lastCommitId`. Our mocks were more generous than the real API, so the gap was structurally invisible.

The new end-to-end guard resolves a query-ID bound customer map against the **real commit-less listing shape** and asserts the contract comes out `full_eligible`. With the fix removed it fails with the production symptom, `unresolved_full_commit`.

## Also included

- wholesale fetch failure now **fails closed** naming the failing models, instead of recording a converged-looking zero-change ingestion
- a worker timeout escapes resolution rather than degrading into an unresolved commit
- preflight reporting separates rejections that skip a model from inert diff-only findings

## Validation

Full suite **1652 OK** (skipped=3), harness **219 OK**, `artifact-test` on the 2.6.4 wheel (NetBox 4.6.5, Branching 1.1.1, Python 3.14, 7 routes 200, SBOM 157). Lint and sensitive-content clean.

**No migration, no operator step** — upgrade and re-run the sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qa2pEe4utNff6s1HoCap1J