### PR TITLE
release: rebind 2.6.5 authorization to the merged tree

### DIFF
--- a/docs/03_Plans/active/2026-07-28-release-2.6.5-full-tranche.md
+++ b/docs/03_Plans/active/2026-07-28-release-2.6.5-full-tranche.md
@@ -401,9 +401,17 @@ authorized only on the final tree.
 
 ## Release Authorization
 
-- Evidence base commit: `7b41c5c9daa81b9c2738aa7de04f3b513a383d46`
+- Evidence base commit: `8d9b8aab864c21acfc7516e9db6086dd90657f94`
 
 - [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke ci` passed on the final 2.6.5 tree with exit status 0: 220 harness tests OK, 66 scenario tests OK, 1687 Django tests OK with 3 skipped, the bulk-merge retry scale test OK, and the sync release gate reported clean strict release checks. The tree gated was byte-identical to the release commit's tree apart from two later Markdown-only edits backfilling the stale `docs/README.md` and `docs/01_User_Guide/README.md` compatibility tables, which had not been updated since v2.6.0. No Python, configuration or query source differs. The gate stages that read those files - lint, sensitive-content, and the CHANGELOG/README consistency check - were re-run on the final tree and passed.
+
+  The evidence base commit above was rebound once after PR #102 squash-merged.
+  Authorization binds the tagged commit to its parent, and a squash merge gives
+  the release a different parent on `main` than it had on the branch, so the
+  branch-side value (`7b41c5c`) could never match on `main`. This commit
+  contains only that one-line rebind; the release content it authorizes is
+  `8d9b8aa`, whose tree is the gated tree. Verified on `main` by
+  `python scripts/verify_release_provenance.py`.
 - [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke artifact-test` passed with exit status 0 against the installed `forward_netbox-2.6.5-py3-none-any.whl` on NetBox 4.6.5, Branching 1.1.1, Python 3.14, with 7 authenticated menu routes returning 200, migration 0045 applying cleanly with no drift, and a validated SBOM of 157 components.
 
 The optional evidence ids are not recorded. This release is dominated by


### PR DESCRIPTION
Authorization binds the tagged commit to its parent. PR #102 squash-merged, so the release has a different parent on `main` than it had on the branch, and the branch-side value could never match once merged.

This changes one line in the 2.6.5 release plan plus a note recording why. The release content it authorizes is `8d9b8aa`, whose tree is the tree the full gate ran against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j2nbNXj1sfguLKeMvbmzK