### PR TITLE
fix: let a merged release be tagged at all

### DIFF
--- a/docs/03_Plans/active/2026-07-29-release-2.6.6-tranche.md
+++ b/docs/03_Plans/active/2026-07-29-release-2.6.6-tranche.md
@@ -138,6 +138,15 @@ changes, or a ratio outside the clamp range leave the learned density untouched.
   install from `main` is self-describing rather than indistinguishable from the
   published release. A customer installed from `main` inside that window and
   reported running a version PyPI did not yet have.
+- That evidence-base preflight, added earlier in this same tranche, then blocked
+  this release. `origin/main` is the right comparison only *before* the merge;
+  once merged it is the commit about to be tagged, so the check demanded the plan
+  record the tagged commit while `release_evidence_commit_binding` demanded its
+  parent. No value satisfied both, and the release could not be tagged at all —
+  the check skipped an already-tagged release but not the window between merge
+  and tag, which is exactly where a release sits. It now compares against `HEAD^`
+  once `HEAD` is `origin/main`: the same rule, evaluated from the side of the
+  merge the repository is on.
 - The preflight now checks the plan's evidence base commit against
   `origin/main`. Authorization binds the tagged commit to its parent, and a
   squash merge means a branch-side value can never match once merged; 2.6.5 lost
@@ -239,26 +248,16 @@ restores the previous behaviour wholesale if needed.
 
 ## Release Authorization
 
-- Evidence base commit: `20dafb2801549eb1a1799485b26e143e353ab8da`
+- Evidence base commit: `0763c95ffbc09fca9f57e8568c9882129906a52e`
 
-- [x] `final-tree-full-gate` - `FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate
-  FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data
-  FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke ci` passed on the
-  final 2.6.6 tree with exit status 0: 231 harness tests OK, 66 scenario tests
-  OK, 1759 Django tests OK with 3 skipped, the bulk-merge retry scale test OK,
-  and the release preflight reported version 2.6.6 consistent across all four
-  surfaces. Run against the complete 15-commit tree, including the Health
-  message and documentation changes made last; an earlier passing run on a
-  two-commit-older tree was discarded rather than reported, because the later
-  Health change is code.
-- [x] `exact-runtime-artifact` - `invoke package artifact-test` passed with exit
-  status 0 on the same tree: the built wheel installed into NetBox v4.6.5
-  reported `forward_netbox 2.6.6`, `netbox 4.6.5`, `netbox_branching 1.1.1` and
-  157 SBOM components, with all seven plugin menu routes returning 200. Rebuilt
-  and re-run on the final tree; the earlier run predated the Health change that
-  ships inside the wheel.
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke ci` passed on the final 2.6.6 tree with exit status 0: 233 harness tests OK, 66 scenario tests OK, 1759 Django tests OK with 3 skipped, the bulk-merge retry scale test OK, the UI surface stage OK, and the release preflight reporting version 2.6.6 consistent across all four version surfaces. Re-run from scratch under the exact release-gate environment above rather than reusing an earlier green run whose environment could not be demonstrated from its log.
+- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke artifact-test` passed with exit status 0: the built wheel installed into NetBox 4.6.5 on Python 3.14.4 reported package version 2.6.6, netbox 4.6.5, Branching 1.1.1 and a CycloneDX 1.6 runtime SBOM of 157 components, with all seven plugin menu routes returning 200. Run as the bare task so the recorded command is the one that executed.
 
 Authorized for release by the owner on 2026-07-29.
+
+The gated tree and the tagged tree differ only in this Markdown evidence text,
+which cannot describe the run that produced it without doing so afterwards. No
+Python, configuration, template or query source differs between them.
 
 Two limits are recorded deliberately rather than resolved. The DLM catalogue
 root cause is strongly supported by the customer's own counts - 44 pending CVE

--- a/scripts/check_release_preflight.py
+++ b/scripts/check_release_preflight.py
@@ -149,6 +149,15 @@ def check_release_plan_evidence_base(version: str) -> str:
     Reported here, before the push, so the round trip is seconds instead of an
     hour. Skipped when `origin/main` is unknown (a fresh clone or offline run),
     since a missing remote ref is not evidence of a wrong value.
+
+    `origin/main` is only the right comparison *before* the merge. Once the
+    release has merged, `origin/main` is the release commit itself, so demanding
+    it here would tell the operator to record the tagged commit in place of its
+    parent — the exact value `release_evidence_commit_binding` then rejects,
+    since it binds against `HEAD^`. In that window the two checks contradicted
+    each other and the release could not be tagged at all. So when `HEAD` is
+    already `origin/main`, compare against `HEAD^`: same rule, evaluated from
+    the side of the merge the repository is actually on.
     """
     if _git("tag", "--list", f"v{version}"):
         # Already tagged: the recorded value was correct at tag time and is now
@@ -165,18 +174,29 @@ def check_release_plan_evidence_base(version: str) -> str:
     )
     if match is None:
         return "skipped (plan records no evidence base commit yet)"
-    expected = _git("rev-parse", "origin/main")
-    if len(expected) != 40:
+    remote_main = _git("rev-parse", "origin/main")
+    if len(remote_main) != 40:
         return "skipped (origin/main is unknown in this checkout)"
+    merged = _git("rev-parse", "HEAD") == remote_main
+    reference = "HEAD^" if merged else "origin/main"
+    expected = _git("rev-parse", reference) if merged else remote_main
+    if len(expected) != 40:
+        return f"skipped ({reference} is unknown in this checkout)"
     recorded = match.group(1)
     if recorded != expected:
+        detail = (
+            f"the release has merged, so the commit about to be tagged is HEAD "
+            f"and its parent is {expected}"
+            if merged
+            else f"a squash merge will make the release commit's parent "
+            f"{expected} (origin/main)"
+        )
         raise PreflightError(
             f"{plans[0].relative_to(REPO_ROOT)} records evidence base commit "
-            f"{recorded}, but a squash merge will make the release commit's "
-            f"parent {expected} (origin/main). Authorization will fail after "
-            "the merge and require a second PR. Record the origin/main value."
+            f"{recorded}, but {detail}. Authorization binds the tagged commit to "
+            f"its parent, so record {expected}."
         )
-    return f"{recorded[:12]} matches origin/main"
+    return f"{recorded[:12]} matches {reference}"
 
 
 def main() -> int:

--- a/scripts/tests/test_release_preflight.py
+++ b/scripts/tests/test_release_preflight.py
@@ -176,6 +176,55 @@ class EvidenceBaseCommitTest(unittest.TestCase):
                     preflight.check_release_plan_evidence_base("9.9.9"),
                 )
 
+    def test_accepts_the_tag_parent_once_the_release_has_merged(self):
+        # Between merge and tag, origin/main IS the commit about to be tagged.
+        # Comparing against it would demand the plan record the tagged commit in
+        # place of its parent - which release_evidence_commit_binding rejects,
+        # because it binds against HEAD^. The two checks contradicted each other
+        # and no value could satisfy both, so the release could not be tagged.
+        with tempfile.TemporaryDirectory() as directory:
+            self._plan(directory, "9.9.9", self.BRANCH_PARENT)
+            with (
+                mock.patch.object(preflight, "REPO_ROOT", Path(directory)),
+                mock.patch.object(
+                    preflight,
+                    "_git",
+                    self._git(
+                        {
+                            ("rev-parse", "origin/main"): self.MAIN,
+                            ("rev-parse", "HEAD"): self.MAIN,
+                            ("rev-parse", "HEAD^"): self.BRANCH_PARENT,
+                        }
+                    ),
+                ),
+            ):
+                self.assertIn(
+                    "matches HEAD^",
+                    preflight.check_release_plan_evidence_base("9.9.9"),
+                )
+
+    def test_rejects_the_tagged_commit_itself_once_merged(self):
+        with tempfile.TemporaryDirectory() as directory:
+            self._plan(directory, "9.9.9", self.MAIN)
+            with (
+                mock.patch.object(preflight, "REPO_ROOT", Path(directory)),
+                mock.patch.object(
+                    preflight,
+                    "_git",
+                    self._git(
+                        {
+                            ("rev-parse", "origin/main"): self.MAIN,
+                            ("rev-parse", "HEAD"): self.MAIN,
+                            ("rev-parse", "HEAD^"): self.BRANCH_PARENT,
+                        }
+                    ),
+                ),
+            ):
+                with self.assertRaisesRegex(
+                    preflight.PreflightError, "the release has merged"
+                ):
+                    preflight.check_release_plan_evidence_base("9.9.9")
+
     def test_skips_a_plan_that_records_nothing_yet(self):
         with tempfile.TemporaryDirectory() as directory:
             plans = Path(directory) / "docs" / "03_Plans" / "active"


### PR DESCRIPTION
Unblocks tagging `v2.6.6`, and fixes the defect that blocked it — which 2.6.6 introduced itself.

## The bug

The evidence-base preflight added in 2.6.6 compares the plan's recorded commit against `origin/main`. That is correct only **before** the merge. Once the release has merged, `origin/main` *is* the commit about to be tagged — so the preflight demanded the plan record the tagged commit, while `release_evidence_commit_binding` demanded its parent (`HEAD^`).

No value satisfied both, so `v2.6.6` could not be tagged after its own PR merged. The check skipped an already-tagged release but not the window between merge and tag, which is precisely where a release sits while being tagged.

It now compares against `HEAD^` once `HEAD` is `origin/main`: the same rule, evaluated from the side of the merge the repository is actually on. The pre-merge path is unchanged and its existing tests still cover it; two new tests cover the merged window, including the case that previously passed preflight and then failed authorization.

## Evidence entries corrected

Three things were wrong with the authorization entries, all caught by `check_release_authorization.py` rather than by inspection:

- They wrapped across lines. `ENTRY_RE` matches a single physical line, so only the first line was read as evidence.
- `exact-runtime-artifact` requires `Python 3.14` and `SBOM` to be named. Both now recorded from the run: Python 3.14.4, CycloneDX 1.6, 157 components.
- `_evidence_commands` only parses commands whose first token is `rtk`, with environment supplied as `rtk env NAME=VAL … invoke <task>`. Both commands were re-run in that exact form rather than reworded to look compliant.

## Validation

`rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.5 invoke ci` — exit 0: harness 233, scenario 66, Django 1759 OK (3 skipped), bulk-merge retry scale OK, UI surface OK.

`rtk env <same> invoke artifact-test` — exit 0: wheel into NetBox 4.6.5 on Python 3.14.4 reporting 2.6.6, branching 1.1.1, 157 SBOM components, seven menu routes 200.

`check_release_authorization.py --version 2.6.6` now passes, with the base commit bound to `0763c95`.

## Known gap, deliberately not fixed here

`_commands_satisfy` asserts that `invoke ci` never binds an HTTP port, and therefore requires the environment to equal the four release variables exactly. That premise is false — the compose file maps `${FORWARD_NETBOX_HOST_PORT:-8000}:8000` and the UI stage brings up a stack — so the gate can only ever run on the default port and collides with any local stack holding 8000.

Allowing an optional *consistent* port/URL pair here, as `ui-validation` already does, would remove that collision. It is left out of this PR on purpose: loosening a release control so that one's own evidence passes deserves its own review rather than riding along with the change it unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j2nbNXj1sfguLKeMvbmzK