### PR TITLE
docs: archive 2.6.10 release evidence

### DIFF
--- a/docs/03_Plans/completed/2026-07-31-release-2.6.10-evidence.md
+++ b/docs/03_Plans/completed/2026-07-31-release-2.6.10-evidence.md
@@ -1,0 +1,74 @@
+# 2.6.10 Release Evidence (archived)
+
+## Goal
+
+Archive the `v2.6.10` evidence and provide the post-release documentation bridge
+that lets `2.6.11` re-anchor release provenance.
+
+`v2.6.10` was tagged at `cdde41c` and **never published**: the tag-time
+provenance check failed, so build, publish and the GitHub release were skipped
+and PyPI stayed on `2.6.9`.
+
+## Constraints
+
+- Exactly one changed path, matching `docs/03_Plans/completed/*.md` - the shape
+  `_require_prior_release_bridge` requires of a bridge commit.
+- No runtime change.
+- The bridge must sit directly on the release commit.
+
+## Touched Surfaces
+
+This file only.
+
+## Approach
+
+`scripts/verify_release_provenance.py` walks every first-parent commit from
+`PRIOR_RELEASE_TAG` to the release commit and requires each to still have a
+successful main-push run for every required workflow. Those anchors had been
+pinned at `v2.5.11` (2026-07-17), so the verified chain had grown to 42 commits.
+GitHub expires workflow runs on a retention window, and the run for `fd8a3be`
+(2026-07-23) aged out between the `2.6.9` publish and this one - which is why the
+identical check passed hours earlier and failed here. This is progressive, not a
+one-off: left alone it fails every subsequent release, earlier each time.
+
+The anchors went stale for a process reason. Each release is meant to be
+followed by a commit archiving its evidence under `docs/03_Plans/completed/`,
+after which the anchors advance. `2.6.7`, `2.6.8`, `2.6.9` and `2.6.10` were
+tagged by hand rather than through `release.py --auto-finish`, so that step never
+ran - the same omission that left `2.6.9` marked "release candidate" in the
+compatibility tables after it shipped.
+
+A `git mv` from `docs/03_Plans/active/` would show two paths and fail the
+one-path check, so the active plans stay where they are and are archived
+separately.
+
+## Validation
+
+`git diff --name-only cdde41c HEAD` returns this file alone. `2.6.11` re-anchors
+`PRIOR_RELEASE_TAG` and `PRIOR_POST_RELEASE_DOC_COMMIT` onto this commit, cutting
+the verified chain from 42 commits to three.
+
+## Rollback
+
+Revert the commit. Nothing depends on it until `2.6.11` re-anchors onto it.
+
+## Decision Log
+
+- 2026-07-31: Re-anchored to `v2.6.10` rather than `v2.6.9`. The bridge must be a
+  direct child of the prior release tag, and `cdde41c` already occupies that slot
+  after `9e09309`, so `2.6.9` cannot be used as an anchor retroactively.
+- 2026-07-31: A new file rather than an edit to an existing archived plan. Both
+  satisfy the one-path rule; a new file keeps the `2.6.10` record self-contained.
+
+## Delivered in the unpublished 2.6.10 tree
+
+Reachable from GitHub at the tag, and carried forward into `2.6.11`:
+
+- Non-field validation rules name themselves in the UI. Confirmed in the field: a
+  merge failure that had read only `ValidationError` on `__all__` now reads
+  `violating primary-ip-reassignment-blocked`.
+- A row the destination refuses on its own validation rule is recorded and
+  skipped rather than failed. Confirmed in the field: the reporting sync
+  completed with one error instead of wedging baseline promotion.
+- The ingestion log download carries the issue rows behind a run.
+- The baseline delete refusal reads as expected behaviour rather than an error.


### PR DESCRIPTION
The post-release documentation bridge for `v2.6.10`, which was tagged at `cdde41c` and never published.

## Why this exists

`verify_release_provenance.py` walks every first-parent commit from `PRIOR_RELEASE_TAG` to the release commit and requires each to still have a successful main-push run for every required workflow. Those anchors have been pinned at `v2.5.11` (2026-07-17), so the verified chain had grown to **42 commits**. GitHub expires workflow runs on a retention window, and the run for `fd8a3be` (2026-07-23) aged out between the `2.6.9` publish and the `2.6.10` attempt — which is why the identical check passed hours earlier and failed here.

Progressive, not a one-off: untouched it fails every subsequent release, earlier each time.

## Shape

`_require_prior_release_bridge` requires the bridge to sit **directly** on the release commit and change **exactly one** path matching `docs/03_Plans/completed/*.md`. Verified:

```
$ git diff --name-only cdde41c HEAD
docs/03_Plans/completed/2026-07-31-release-2.6.10-evidence.md
```

A `git mv` from `active/` would show two paths and fail, which is why the active plans stay put and are archived separately.

No runtime change. `2.6.11` re-anchors `PRIOR_RELEASE_TAG` and `PRIOR_POST_RELEASE_DOC_COMMIT` onto this commit, cutting the chain from 42 to three.

This must merge before any `2.6.11` work, or `cdde41c` gains a child and re-anchoring becomes impossible — the same trap that made `2.6.9` unusable as an anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j2nbNXj1sfguLKeMvbmzK