### PR TITLE
fix: re-anchor release provenance and unblock the two field faults 2.6.10 exposed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git fetch --no-tags origin main:refs/remotes/origin/main
-          git fetch --force origin refs/tags/v2.5.11:refs/tags/v2.5.11
+          git fetch --force origin refs/tags/v2.6.10:refs/tags/v2.6.10
           set -o pipefail
           for attempt in $(seq 1 120); do
             provenance_log="$(mktemp)"

--- a/docs/03_Plans/active/2026-07-31-release-2.6.11-tranche.md
+++ b/docs/03_Plans/active/2026-07-31-release-2.6.11-tranche.md
@@ -21,9 +21,12 @@ tree exposed once a customer could finally see what was failing.
 
 ## Touched Surfaces
 
-- `scripts/verify_release_provenance.py` - anchors
+- `scripts/verify_release_provenance.py`, `scripts/check_harness.py`,
+  `.github/workflows/release.yml` - anchors
 - `forward_netbox/views.py` - scope reconciliation refresh
 - `forward_netbox/utilities/job_queue.py` - enqueue guard
+- `forward_netbox/utilities/ownership.py`, `forward_netbox/jobs.py` - conflict
+  reason slugs
 - This plan.
 
 ## Approach
@@ -40,6 +43,15 @@ weakened; it verifies a window GitHub actually retains.
 The anchors went stale because four consecutive releases were tagged by hand
 rather than through `release.py --auto-finish`, which is what creates the bridge
 and advances them.
+
+**Ownership conflicts.** Eight call sites raise `OwnershipConflictError` bare,
+and `safe_operation_failure` strips the message before the job record is
+written, so a customer's failed automatic reconciliation named the exception
+class and nothing else - the same shape as the merge `__all__` failure. The
+messages embed source device keys, which are device names, so they cannot be
+persisted; an allowlist maps the message to a slug this module defines, and an
+unmatched message records `unrecognized-ownership-conflict` rather than falling
+silent. Verified against the exact text of all four identity conditions.
 
 **Scope reconciliation.** The refresh view called
 `enqueue_forward_job(ScopeReconciliationJob, ...)` - the class. Every other
@@ -92,10 +104,6 @@ migration or persisted state.
   one device's primary being moved to an interface on another. Skipping keeps
   the sync converging, but the row will be skipped every run until the stale
   primary pointer is released as part of the same move.
-- `OwnershipConflictError` names no condition: five distinct causes in
-  `utilities/ownership.py` raise it bare and `safe_operation_failure` strips the
-  message, so the customer's failing auto reconciliation cannot be diagnosed.
-  Needs a reason slug and counts - never the source keys, which are device names.
 
 ## Release Authorization
 

--- a/docs/03_Plans/active/2026-07-31-release-2.6.11-tranche.md
+++ b/docs/03_Plans/active/2026-07-31-release-2.6.11-tranche.md
@@ -1,0 +1,106 @@
+# Release 2.6.11 Tranche
+
+## Goal
+
+Restore a publishable release path, and fix the two field faults the 2.6.10
+tree exposed once a customer could finally see what was failing.
+
+## Contract
+
+- Release provenance verifies against a chain that GitHub still retains.
+- The scope reconciliation refresh action queues work instead of returning 500.
+- A job class handed to `enqueue_forward_job` fails immediately, naming the fix,
+  rather than at transaction commit after a Job row already exists.
+- Upgrade and re-run the sync. No migration, no operator step.
+
+## Constraints
+
+- Persisted diagnostics stay free of customer data.
+- Do not weaken any fail-closed gate; the provenance check stays strict, it just
+  verifies a chain that still exists.
+
+## Touched Surfaces
+
+- `scripts/verify_release_provenance.py` - anchors
+- `forward_netbox/views.py` - scope reconciliation refresh
+- `forward_netbox/utilities/job_queue.py` - enqueue guard
+- This plan.
+
+## Approach
+
+**Provenance.** The verifier walks every first-parent commit from
+`PRIOR_RELEASE_TAG` to the release and requires each to still have a successful
+main-push run for every required workflow. The anchors had been pinned at
+`v2.5.11` since 2026-07-17, so the chain reached 42 commits and the run for
+`fd8a3be` (2026-07-23) aged out of GitHub's retention window - burning `v2.6.10`
+after `v2.6.9` had passed the identical check hours earlier. Re-anchoring to
+`v2.6.10` and its post-release bridge cuts the chain to three. The check is not
+weakened; it verifies a window GitHub actually retains.
+
+The anchors went stale because four consecutive releases were tagged by hand
+rather than through `release.py --auto-finish`, which is what creates the bridge
+and advances them.
+
+**Scope reconciliation.** The refresh view called
+`enqueue_forward_job(ScopeReconciliationJob, ...)` - the class. Every other
+caller goes through `ForwardJobRunner.enqueue()`, which passes `cls.handle`, a
+function; RQ rejects a class outright. Dispatch happens on transaction commit,
+so the Job row was already written when it failed: the operator got a 500 *and*
+a queued job that never ran. Routed through `.enqueue()`, with a guard in
+`enqueue_forward_job` that rejects a class where the mistake is and names the
+fix.
+
+## Validation
+
+- Provenance anchors verified against the merged bridge commit `b907d03`, whose
+  parent is the `v2.6.10` release commit and which changes exactly one path
+  under `docs/03_Plans/completed/`.
+- Full local gate and exact-runtime artifact test, recorded below.
+
+## Rollback
+
+Revert the commits. The anchors return to `v2.5.11` (which reintroduces the
+expired-run failure), and the refresh action returns to raising `TypeError`. No
+migration or persisted state.
+
+## Decision Log
+
+- 2026-07-31: Re-anchored rather than relaxing the provenance check. Failing on
+  GitHub's retention policy is not a security property anyone chose, but the
+  answer is to verify a retained window, not to accept unverified commits.
+- 2026-07-31: Anchored at `v2.6.10` though it was never published. The anchor
+  needs an annotated tag with a documentation bridge as its direct child, which
+  `v2.6.10` has; publication is not what the check tests.
+- 2026-07-31: A guard in `enqueue_forward_job` as well as the call-site fix. The
+  call site was the bug, but the failure mode - 500 plus an orphaned Job row at
+  commit time - is bad enough that the next caller should not be able to repeat
+  it.
+
+## Evidence
+
+- `v2.6.10` failed at `Verify protected main-branch release provenance` with
+  `commit fd8a3be… has no exact main push run for .github/workflows/codeql.yml`;
+  build, publish and github-release were all skipped, so no partial artifact
+  exists.
+- The reporting customer's 2.6.10 run confirmed both headline 2.6.10 behaviours:
+  the merge failure named its rule (`violating primary-ip-reassignment-blocked`)
+  and the sync completed with one error rather than wedging baseline promotion.
+
+## Deferred
+
+- The root cause behind `primary-ip-reassignment-blocked` - an address that is
+  one device's primary being moved to an interface on another. Skipping keeps
+  the sync converging, but the row will be skipped every run until the stale
+  primary pointer is released as part of the same move.
+- `OwnershipConflictError` names no condition: five distinct causes in
+  `utilities/ownership.py` raise it bare and `safe_operation_failure` strips the
+  message, so the customer's failing auto reconciliation cannot be diagnosed.
+  Needs a reason slug and counts - never the source keys, which are device names.
+
+## Release Authorization
+
+Recorded after both gates run against the final tree.
+
+- Evidence base commit: _pending_
+- [ ] `final-tree-full-gate` - pending
+- [ ] `exact-runtime-artifact` - pending

--- a/forward_netbox/jobs.py
+++ b/forward_netbox/jobs.py
@@ -1079,12 +1079,24 @@ def _scope_reconciliation_work(job):
         job.save(update_fields=["data"])
     except Exception as exc:
         from .utilities.api_usage import record_forward_api_usage
+        from .utilities.ownership import OwnershipConflictError
+        from .utilities.ownership import ownership_conflict_reason
 
-        job.data = {
-            "error": safe_operation_failure("Forward scope reconciliation", exc),
+        message = safe_operation_failure("Forward scope reconciliation", exc)
+        data = {
             "error_type": exception_type(exc),
             "forward_api_usage": record_forward_api_usage(sync, client),
         }
+        # Eight causes raise OwnershipConflictError bare, and the message is
+        # stripped before it lands here - so the job record named the class and
+        # nothing else. The slug is ours; the source device keys in the original
+        # message are customer data and stay out.
+        if isinstance(exc, OwnershipConflictError):
+            reason = ownership_conflict_reason(exc)
+            data["conflict_reason"] = reason
+            message = f"{message[:-1]} ({reason})."
+        data["error"] = message
+        job.data = data
         job.save(update_fields=["data"])
         if type(exc) in (SyncError, JobTimeoutException):
             logger.error(

--- a/forward_netbox/utilities/job_queue.py
+++ b/forward_netbox/utilities/job_queue.py
@@ -68,6 +68,17 @@ def enqueue_forward_job(
             "enqueue_forward_job() cannot combine schedule_at and immediate."
         )
 
+    # RQ rejects a class outright, but only at dispatch - which happens on
+    # transaction commit, after the Job row is written. A caller that passed
+    # `SomeJob` instead of `SomeJob.handle` therefore produced a 500 *and* a
+    # background job that never ran, which is what an operator hit on the scope
+    # reconciliation page. Fail here, where the mistake is, and name the fix.
+    if isinstance(func, type):
+        raise TypeError(
+            "enqueue_forward_job() takes a callable, not a job class; pass "
+            f"{func.__name__}.handle or call {func.__name__}.enqueue()."
+        )
+
     with advisory_lock(ADVISORY_LOCK_KEYS["job-schedules"]):
         if instance is not None:
             object_type = ObjectType.objects.get_for_model(

--- a/forward_netbox/utilities/ownership.py
+++ b/forward_netbox/utilities/ownership.py
@@ -24,6 +24,32 @@ class OwnershipConflictError(RuntimeError):
     """Raised after durable claims expose incompatible desired relationships."""
 
 
+# Eight call sites raise this bare, and `safe_operation_failure` strips the
+# message before it reaches the job record - so a customer's failed scope
+# reconciliation read `Forward scope reconciliation failed
+# (OwnershipConflictError).` and nothing else, with eight possible causes.
+#
+# The messages cannot be persisted: they embed source device keys, which are
+# device names. Matching against an allowlist keeps the cause identifiable while
+# persisting only slugs this module defines - the same approach the merge and
+# sync recorders use for non-field validation rules.
+_CONFLICT_REASONS = (
+    ("identity-ambiguous", "forward device identity is ambiguous"),
+    ("identity-evidence-mismatch", "identity evidence does not match merged"),
+    ("source-key-multiple-devices", "maps to multiple live netbox devices"),
+    ("device-already-mapped", "is already mapped to forward source key"),
+)
+
+
+def ownership_conflict_reason(exc) -> str:
+    """A schema-safe slug for why ownership reconciliation refused, or ""."""
+    haystack = str(exc).casefold()
+    for slug, needle in _CONFLICT_REASONS:
+        if needle in haystack:
+            return slug
+    return "unrecognized-ownership-conflict"
+
+
 def _object_pk(value):
     try:
         return int(value)

--- a/forward_netbox/views.py
+++ b/forward_netbox/views.py
@@ -1189,11 +1189,14 @@ class ForwardSyncRefreshScopeReconciliationView(BaseObjectView):
 
     def post(self, request, pk):
         from .jobs import ScopeReconciliationJob
-        from .utilities.job_queue import enqueue_forward_job
 
         sync = get_object_or_404(self.queryset, pk=pk)
-        enqueue_forward_job(
-            ScopeReconciliationJob,
+        # Go through the runner's own `enqueue`, which passes `cls.handle` to
+        # RQ. Handing `enqueue_forward_job` the class instead reached
+        # `queue.enqueue()` as a class object, which RQ rejects outright -
+        # "Expected a callable or a string" - after the Job row was already
+        # written, so the work looked queued and the operator got a 500.
+        ScopeReconciliationJob.enqueue(
             instance=sync,
             user=request.user,
             name=f"{sync.name} - scope reconciliation",

--- a/scripts/check_harness.py
+++ b/scripts/check_harness.py
@@ -214,7 +214,7 @@ REQUIRED_TEXT = {
     ],
     ".github/workflows/release.yml": [
         "fetch-depth: 0",
-        "refs/tags/v2.5.11",
+        "refs/tags/v2.6.10",
         "verify_release_provenance.py",
         "--git-files",
         "--protected-history",
@@ -852,7 +852,7 @@ def _check_sensitive_guard_wiring(failures: list[str]) -> None:
         if fragment not in ci_commands:
             failures.append(f".github/workflows/ci.yml must execute {fragment}")
     for fragment in (
-        "refs/tags/v2.5.11",
+        "refs/tags/v2.6.10",
         "verify_release_provenance.py",
         "--tag",
         "check_sensitive_content.py --git-files --protected-history",
@@ -1061,7 +1061,7 @@ def _check_standard_release_tag_flow(failures: list[str]) -> None:
         if fragment not in texts["release"]:
             failures.append(f"standard release tag flow must contain: {fragment}")
     for fragment in (
-        'PRIOR_RELEASE_TAG = "v2.5.11"',
+        'PRIOR_RELEASE_TAG = "v2.6.10"',
         "BOOTSTRAP_REQUIRED_FILES",
         "BASE_REQUIRED_STATUS_CHECKS",
         "TRUSTED_STATUS_CONTEXT",

--- a/scripts/verify_release_provenance.py
+++ b/scripts/verify_release_provenance.py
@@ -17,8 +17,8 @@ GITHUB_API_URL = "https://api.github.com"
 TRUSTED_STATUS_CONTEXT = "Trusted sensitive-content scan"
 TRUSTED_STATUS_CREATOR = "github-actions[bot]"
 TRUSTED_SCANNER_WORKFLOW = ".github/workflows/trusted-sensitive-pr.yml"
-PRIOR_RELEASE_TAG = "v2.5.11"
-PRIOR_POST_RELEASE_DOC_COMMIT = "f9a8420a8bcc2d3afe338d0435a17df9e2bc01d0"
+PRIOR_RELEASE_TAG = "v2.6.10"
+PRIOR_POST_RELEASE_DOC_COMMIT = "b907d033dd0114201c752a7ee00296225a4fea17"
 BOOTSTRAP_REQUIRED_FILES = (
     TRUSTED_SCANNER_WORKFLOW,
     "scripts/check_sensitive_content.py",


### PR DESCRIPTION
Three fixes, all from the field on the 2.6.10 tree.

**Release provenance re-anchor.** The verifier walks every first-parent commit from `PRIOR_RELEASE_TAG` and requires each to still have a successful main-push run for every required workflow. The anchors had been pinned at `v2.5.11` since 2026-07-17, so the chain reached 42 commits and the run for one of them aged out of GitHub's retention window — burning `v2.6.10` after `v2.6.9` had passed the identical check hours earlier. This is progressive: left alone it fails every subsequent release, earlier each time. Re-anchoring to `v2.6.10` and its post-release bridge cuts the chain to three. The check is not weakened; it verifies a window GitHub actually retains.

**Scope reconciliation refresh 500.** The refresh view passed the job *class* to `enqueue_forward_job`. RQ rejects a class, but only at dispatch — which happens on transaction commit, after the Job row is written. The operator got a 500 *and* a queued job that never ran. Routed through `.enqueue()`, plus a guard in `enqueue_forward_job` that rejects a class where the mistake is and names the fix.

**Ownership conflict reasons.** Eight sites raise `OwnershipConflictError` bare and `safe_operation_failure` strips the message, so a failed automatic reconciliation named the exception class and nothing else — the same shape as the merge `__all__` failure that took a round-trip with a customer to diagnose. The messages embed device names, so an allowlist maps message to slug; an unmatched message records `unrecognized-ownership-conflict` rather than falling silent. All four identity conditions verified against their exact message text.

Plan: `docs/03_Plans/active/2026-07-31-release-2.6.11-tranche.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j2nbNXj1sfguLKeMvbmzK