### PR TITLE
docs: authorize the 2.6.11 release tree

### DIFF
--- a/docs/03_Plans/active/2026-07-31-release-2.6.11-tranche.md
+++ b/docs/03_Plans/active/2026-07-31-release-2.6.11-tranche.md
@@ -146,8 +146,9 @@ migration or persisted state.
 
 ## Release Authorization
 
-Recorded after both gates run against the final tree.
+Both gates ran against the final tree, whose parent is
+`5e2ada4c1e077361af9707a6be8269ea76279219`, on a clean working tree.
 
-- Evidence base commit: _pending_
-- [ ] `final-tree-full-gate` - pending
-- [ ] `exact-runtime-artifact` - pending
+- Evidence base commit: `5e2ada4c1e077361af9707a6be8269ea76279219`
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke ci` passed with status 0 across the whole fan-out: 257 harness tests, 66 scenario tests, 1833 plugin tests and the 1 UI harness test all reported OK, the strict sync release gate passed, and the 5 artifact-upgrade paths seeded under a previous release, migrated onto the built wheel, and the rows seeded under the previous release survived.
+- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke artifact-test` passed with status 0: the built `forward_netbox-2.6.11-py3-none-any.whl` installed into the exact runtime image on NetBox 4.6.6 with Branching 1.1.2 under Python 3.14.4, migrated, passed `manage.py check`, left no unmade migrations, served its installed routes, and the recorded runtime SBOM carries 156 components reporting forward_netbox 2.6.11, netbox 4.6.6, branching 1.1.2.


### PR DESCRIPTION
Records both required gates against the final tree, so `v2.6.11` can be tagged.

- **Evidence base commit** `5e2ada4c1e077361af9707a6be8269ea76279219` — the parent of this commit once squashed, which is what `release_evidence_commit_binding` requires so authorization cannot be transplanted onto a different tree.
- **`final-tree-full-gate`** — `invoke ci` under the release-gate environment, status 0: 257 harness, 66 scenario, 1833 plugin and 1 UI harness test all OK, strict sync release gate passed, 5 artifact-upgrade paths seeded under a previous release and migrated onto the built wheel with the seeded rows intact.
- **`exact-runtime-artifact`** — `invoke artifact-test` under the same environment, status 0: the built wheel installed into the exact runtime image on NetBox 4.6.6 with Branching 1.1.2 under Python 3.14.4, migrated, passed `manage.py check`, left no unmade migrations, served its installed routes. Runtime SBOM carries 156 components.

Both gates were first run under the default compose project, which is not what the evidence format attests to — the checker requires the exact release-gate environment. They were re-run under it rather than recording a command that had not been executed.

`check_release_authorization.py --version 2.6.11` validates offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j2nbNXj1sfguLKeMvbmzK