### PR TITLE
docs: authorize the 2.6.12 release tree

### DIFF
--- a/docs/03_Plans/active/2026-08-01-release-2.6.12-provenance-bootstrap.md
+++ b/docs/03_Plans/active/2026-08-01-release-2.6.12-provenance-bootstrap.md
@@ -124,8 +124,9 @@ decision about which of the two failure modes to accept.
 
 ## Release Authorization
 
-Recorded after both gates run against the final tree.
+Both gates ran against the final tree, whose parent is
+`0c139937f99fc9ff91a03ff659dd759c3f03aff3`, on a clean working tree.
 
-- Evidence base commit: _pending_
-- [ ] `final-tree-full-gate` - pending
-- [ ] `exact-runtime-artifact` - pending
+- Evidence base commit: `0c139937f99fc9ff91a03ff659dd759c3f03aff3`
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke ci` passed with status 0 across the whole fan-out: 258 harness tests, 66 scenario tests, 1833 plugin tests and the 1 UI harness test all reported OK, the strict sync release gate passed, and the 5 artifact-upgrade paths seeded under a previous release, migrated onto the built wheel, and the rows seeded under the previous release survived.
+- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke artifact-test` passed with status 0: the built `forward_netbox-2.6.12-py3-none-any.whl` installed into the exact runtime image on NetBox 4.6.6 with Branching 1.1.2 under Python 3.14.4, migrated through `forward_netbox.0045_forwardmergeattempt`, reported no unmade migrations, served its installed routes, and the recorded runtime SBOM carries 156 components reporting forward_netbox 2.6.12, netbox 4.6.6, branching 1.1.2.


### PR DESCRIPTION
Records both required gates against the final tree, so `v2.6.12` can be tagged.

- **Evidence base commit** `0c139937f99fc9ff91a03ff659dd759c3f03aff3` — the parent of this commit once squashed.
- **`final-tree-full-gate`** — `invoke ci` under the release-gate environment, status 0: 258 harness, 66 scenario, 1833 plugin and 1 UI harness test all OK, strict sync release gate passed, 5 artifact-upgrade paths migrated onto the built wheel with seeded rows intact.
- **`exact-runtime-artifact`** — `invoke artifact-test` under the same environment, status 0, run against this exact tree: the wheel installed into the runtime image on NetBox 4.6.6 with Branching 1.1.2 under Python 3.14.4, migrated through `forward_netbox.0045_forwardmergeattempt`, reported no unmade migrations, served its installed routes. Runtime SBOM carries 156 components reporting `forward_netbox 2.6.12`.

`check_release_authorization.py --version 2.6.12` validates offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j2nbNXj1sfguLKeMvbmzK