### PR TITLE
docs: authorize the 2.7.0 release tree

### DIFF
--- a/docs/03_Plans/active/2026-08-01-release-2.7.0.md
+++ b/docs/03_Plans/active/2026-08-01-release-2.7.0.md
@@ -93,8 +93,8 @@ its own.
 ## Release Authorization
 
 Both gates ran against the final tree, whose parent is
-`2c6a6cd563864ab9be33bacb7d6358c5168c56c0`, on a clean working tree.
+`02be3ddbd90e69592dce049639a86faf6d1ff131`, on a clean working tree.
 
-- Evidence base commit: `2c6a6cd563864ab9be33bacb7d6358c5168c56c0`
+- Evidence base commit: `02be3ddbd90e69592dce049639a86faf6d1ff131`
 - [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke ci` passed with status 0 across the whole fan-out: 258 harness tests, 66 scenario tests, 1854 plugin tests and the 1 UI harness test all reported OK, the strict sync release gate passed, and the 5 artifact-upgrade paths each seeded under a previous release, migrated onto the built wheel, and kept the rows seeded under that previous release.
 - [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke artifact-test` passed with status 0: the built `forward_netbox-2.7.0-py3-none-any.whl` installed into the exact runtime image on NetBox 4.6.6 with Branching 1.1.2 under Python 3.14.4, migrated through `forward_netbox.0046_alter_forwardnqemap_netbox_model`, reported no unmade migrations, served all 7 installed menu routes with status 200, and the recorded runtime SBOM carries 156 components reporting forward_netbox 2.7.0, netbox 4.6.6, branching 1.1.2.


### PR DESCRIPTION
Binds the recorded 2.7.0 evidence to the commit the release tranche landed as.

The full gate and exact-runtime artifact test both ran against this exact tree; squash-merging #118 rewrote the branch commits into a single commit, so the evidence base recorded on the branch no longer named a commit that exists on `main`.

The tagged commit must be single-parent on a clean tree with the plan's recorded evidence base equal to that parent, which is why the authorization lands as its own commit on top of the merged tree rather than inside it — the same shape `2.6.12` used.

`check_release_authorization.py --version 2.7.0` passes against this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j2nbNXj1sfguLKeMvbmzK