### PR TITLE
chore: re-anchor release provenance to v2.7.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git fetch --no-tags origin main:refs/remotes/origin/main
-          git fetch --force origin refs/tags/v2.6.10:refs/tags/v2.6.10
+          git fetch --force origin refs/tags/v2.7.0:refs/tags/v2.7.0
           set -o pipefail
           for attempt in $(seq 1 120); do
             provenance_log="$(mktemp)"

--- a/docs/03_Plans/active/2026-08-02-reanchor-provenance-to-2.7.0.md
+++ b/docs/03_Plans/active/2026-08-02-reanchor-provenance-to-2.7.0.md
@@ -1,0 +1,73 @@
+# Re-anchor Release Provenance To 2.7.0
+
+## Goal
+
+Advance the provenance anchor to the release that just shipped, so the reviewed
+commit range starts short again instead of growing until GitHub expires a run.
+
+## Contract
+
+- `verify_release_provenance.py` walks from `v2.7.0`, not `v2.6.10`.
+- The recorded post-release doc commit is the actual first commit after the tag.
+- No control is removed, relaxed, or made advisory.
+
+## Constraints
+
+- The anchor is pinned in more places than the constant: both the harness check
+  and the harness tests must pass, because they disagree about which they read.
+- `release.yml` stays tag-triggered; Trusted Publishing scoping is untouched.
+
+## Touched Surfaces
+
+- `scripts/verify_release_provenance.py` - `PRIOR_RELEASE_TAG`,
+  `PRIOR_POST_RELEASE_DOC_COMMIT`
+- `scripts/check_harness.py` - three assertions
+- `.github/workflows/release.yml` - the tag fetch
+- `scripts/tests/test_check_harness.py` - two fixtures
+- `scripts/tests/test_tasks.py` - one assertion
+- This plan.
+
+## Approach
+
+`_require_merged_main_pr` requires every first-parent commit from the anchor to
+still have successful main-push `ci.yml` and `codeql.yml` runs. GitHub expires
+runs, so a stale anchor is a slow failure: the range only grows, and one
+expiry burns a release at the tag. That is what happened to `v2.6.10`, whose
+anchor had been left at `v2.5.11` until the chain reached 42 commits.
+
+Advancing is a post-release step. `release.py --auto-finish` performs it;
+hand-tagging skips it, which is why it had not been done since `2.5.11`.
+
+`PRIOR_POST_RELEASE_DOC_COMMIT` must equal the first first-parent commit after
+the tag, and it is checked as `lineage[0]`. That commit is `bbebcaa`, the
+promotion of `v2.7.0` - which is why the promotion had to land first. Verified
+directly: `git rev-list --first-parent v2.7.0..HEAD | tail -1` returns exactly
+that commit.
+
+A blanket substitution also rewrote a docstring recording which release each
+historical failure mode burned, turning a true statement about `v2.6.10` into a
+false one about `v2.7.0`. Reverted; the diff is nine lines, all of them the
+intended pins.
+
+## Validation
+
+- `invoke harness-check` and `invoke harness-test` both pass. Both are needed:
+  a previous re-anchor passed the check while three test fixtures still carried
+  the old value.
+- The reviewed range drops from 8 commits to 0 at the anchor, so the next
+  release starts from a chain whose runs cannot already have expired.
+
+## Rollback
+
+Revert. The anchor returns to `v2.6.10` and the range resumes growing.
+
+## Decision Log
+
+- 2026-08-02: Anchored to `v2.7.0` rather than skipping a cycle. The failure
+  mode is progressive, so deferring it makes the next release more likely to
+  burn, not less.
+
+## Open
+
+- This is still a manual step after a hand-tagged release. Until releases go
+  through `--auto-finish`, the anchor will keep going stale.

--- a/scripts/check_harness.py
+++ b/scripts/check_harness.py
@@ -214,7 +214,7 @@ REQUIRED_TEXT = {
     ],
     ".github/workflows/release.yml": [
         "fetch-depth: 0",
-        "refs/tags/v2.6.10",
+        "refs/tags/v2.7.0",
         "verify_release_provenance.py",
         "--git-files",
         "--protected-history",
@@ -852,7 +852,7 @@ def _check_sensitive_guard_wiring(failures: list[str]) -> None:
         if fragment not in ci_commands:
             failures.append(f".github/workflows/ci.yml must execute {fragment}")
     for fragment in (
-        "refs/tags/v2.6.10",
+        "refs/tags/v2.7.0",
         "verify_release_provenance.py",
         "--tag",
         "check_sensitive_content.py --git-files --protected-history",
@@ -1061,7 +1061,7 @@ def _check_standard_release_tag_flow(failures: list[str]) -> None:
         if fragment not in texts["release"]:
             failures.append(f"standard release tag flow must contain: {fragment}")
     for fragment in (
-        'PRIOR_RELEASE_TAG = "v2.6.10"',
+        'PRIOR_RELEASE_TAG = "v2.7.0"',
         "BOOTSTRAP_REQUIRED_FILES",
         "BOOTSTRAP_FILE_DIGESTS",
         "BASE_REQUIRED_STATUS_CHECKS",

--- a/scripts/tests/test_check_harness.py
+++ b/scripts/tests/test_check_harness.py
@@ -602,7 +602,7 @@ jobs:
       - uses: actions/checkout@example
         with:
           fetch-depth: 0
-      - run: git fetch origin refs/tags/v2.6.10 && python scripts/verify_release_provenance.py --tag v2.6.0
+      - run: git fetch origin refs/tags/v2.7.0 && python scripts/verify_release_provenance.py --tag v2.6.0
       - env:
           FORWARD_SENSITIVE_PATTERNS: ${{ secrets.FORWARD_SENSITIVE_PATTERNS }}
           FORWARD_SENSITIVE_HISTORY_BASELINE: ${{ vars.FORWARD_SENSITIVE_HISTORY_BASELINE }}
@@ -825,7 +825,7 @@ _verify_live_release_controls()
 "ls-remote", "--tags", "origin", f"refs/tags/{tag}^{{}}"
 """
     PROVENANCE = """\
-PRIOR_RELEASE_TAG = "v2.6.10"
+PRIOR_RELEASE_TAG = "v2.7.0"
 BOOTSTRAP_REQUIRED_FILES
 BOOTSTRAP_FILE_DIGESTS
 BASE_REQUIRED_STATUS_CHECKS

--- a/scripts/tests/test_tasks.py
+++ b/scripts/tests/test_tasks.py
@@ -175,7 +175,7 @@ class ReleaseArtifactTaskTest(unittest.TestCase):
 
         self.assertIn("--require-hashes", workflow)
         self.assertIn("requirements-release.txt", workflow)
-        self.assertIn("refs/tags/v2.6.10", workflow)
+        self.assertIn("refs/tags/v2.7.0", workflow)
         self.assertIn("scripts/build_reproducible_distribution.py", workflow)
         self.assertIn("python -m invoke artifact-test", workflow)
         self.assertIn("sbom/", workflow)

--- a/scripts/verify_release_provenance.py
+++ b/scripts/verify_release_provenance.py
@@ -18,8 +18,8 @@ GITHUB_API_URL = "https://api.github.com"
 TRUSTED_STATUS_CONTEXT = "Trusted sensitive-content scan"
 TRUSTED_STATUS_CREATOR = "github-actions[bot]"
 TRUSTED_SCANNER_WORKFLOW = ".github/workflows/trusted-sensitive-pr.yml"
-PRIOR_RELEASE_TAG = "v2.6.10"
-PRIOR_POST_RELEASE_DOC_COMMIT = "b907d033dd0114201c752a7ee00296225a4fea17"
+PRIOR_RELEASE_TAG = "v2.7.0"
+PRIOR_POST_RELEASE_DOC_COMMIT = "bbebcaac063b4b35ca9da2287bb0fa06025224af"
 BOOTSTRAP_REQUIRED_FILES = (
     TRUSTED_SCANNER_WORKFLOW,
     "scripts/check_sensitive_content.py",


### PR DESCRIPTION
The provenance walk requires every first-parent commit from the anchor to still have successful main-push `ci.yml` and `codeql.yml` runs. GitHub expires runs, so a stale anchor is a *slow* failure: the range only grows, and one expiry burns a release at the tag.

That is what happened to `v2.6.10` — its anchor had been left at `v2.5.11` until the reviewed chain reached 42 commits and a CodeQL run aged out. Advancing the anchor is a post-release step that `release.py --auto-finish` performs and hand-tagging skips, which is why it had not moved since `2.5.11`.

This advances it to `v2.7.0`, taking the reviewed range from 8 commits back to 0.

**Ordering mattered.** `PRIOR_POST_RELEASE_DOC_COMMIT` is checked as `lineage[0]` — the first first-parent commit *after* the tag — so the `v2.7.0` promotion (#120) had to land before this could be anchored to it. Verified rather than assumed:

```
git rev-list --first-parent v2.7.0..HEAD | tail -1
bbebcaac063b4b35ca9da2287bb0fa06025224af
```

The anchor is pinned in five files. Both `invoke harness-check` and `invoke harness-test` pass — both are needed, because a previous re-anchor passed the check while three test fixtures still carried the old value.

One thing worth flagging from doing this: a blanket substitution also rewrote a docstring that records which release each historical failure mode burned, turning a true statement about `v2.6.10` into a false one about `v2.7.0`. Caught and reverted; the diff is nine lines, all of them intended pins.

**This will go stale again.** Until releases run through `--auto-finish`, the anchor needs advancing by hand after every release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j2nbNXj1sfguLKeMvbmzK