### PR TITLE
fix: predict merge deletes blocked by hidden PROTECT references

### DIFF
--- a/docs/03_Plans/active/2026-08-02-hidden-protect-merge-prediction.md
+++ b/docs/03_Plans/active/2026-08-02-hidden-protect-merge-prediction.md
@@ -1,0 +1,96 @@
+# Hidden PROTECT Merge Prediction
+
+## Goal
+
+Predict and report merge deletes held by hidden `PROTECT`/`RESTRICT`
+references before apply, without suppressing an authoritative Device delete
+whose current-sync identity the plugin releases in the same merge transaction.
+
+## Constraints
+
+- Keep NetBox Branching in the ingestion and merge path.
+- Preserve successful authoritative Device deletion and its ownership/relation
+  writer serialization contracts.
+- Exempt only an exact, documented plugin-owned relation and only rows the
+  current merge sync can release; peer-sync or other provenance remains
+  blocking.
+- Do not add or reorder dependency edges. This change classifies impossible
+  deletes as skips before the existing dependency sort, so it cannot create a
+  dependency cycle.
+- Keep `protecting_relations()` and ingestion-delete diagnostics unchanged.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/bulk_merge.py` - hidden relation prediction and the
+  explicit self-resolved relation contract
+- `forward_netbox/utilities/merge.py` - supply the current merge sync identity
+  to prediction
+- `forward_netbox/tests/test_bulk_merge.py` - hidden blocker and authoritative
+  Device-delete regression coverage
+- This plan
+
+## Approach
+
+1. Add a regression test in the production merge path: a Device delete held by
+   a hidden `ForwardDeviceTagClaim.device` reference must be skipped and named
+   before `ObjectChange.apply()` can fail it. Add a peer-sync identity case to
+   prove that rows of the allowlisted model remain blocking outside the current
+   merge sync.
+2. Change `protecting_reference_blocked_deletes()` to enumerate
+   `protecting_relations()`, including hidden relations.
+3. Define one immutable relation signature for plugin-resolved protection:
+   `dcim.Device <- ForwardDeviceIdentity.device`. For that signature only,
+   ignore a referencing row only when its `sync_id` matches the sync performing
+   the merge. That exemption holds because those rows live in main rather than
+   in the branch: `delete_dcim_device` collects the branch-local cascade with
+   `ForwardDeviceIdentity` in `ignored_related_models`, and the orphan is
+   removed afterwards by `finalize_device_identities_locked` in post-merge
+   bookkeeping. Nothing deletes them ahead of the device delete, and describing
+   it that way would invite an entry whose relation has no such split. A
+   peer-sync identity, tag claim, virtual-parent claim, or any other hidden
+   reference remains a blocker.
+4. Thread the ingestion's sync primary key from the production merge caller to
+   the predictor. Direct utility callers that provide no sync context receive
+   no exemption and therefore fail closed.
+
+This intentionally does not infer behavior from app labels, inheritance,
+`related_name`, or the presence of a `sync` field. Adding another exemption
+requires naming the exact target, referencing model, and FK, then proving the
+same-transaction cleanup path with tests.
+
+## Validation
+
+- `forward_netbox.tests.test_bulk_merge` fully green, including:
+  - `test_owned_device_delete_preserves_provenance_until_atomic_merge`
+  - `test_device_delete_serializes_concurrent_claim_writer`
+  - `test_device_delete_serializes_concurrent_generic_relation_writer`
+  - new hidden-PROTECT prediction/reporting regression
+- `forward_netbox.tests.test_protecting_relations` fully green
+- `invoke harness-check`
+- Run tests in isolated compose project `forward-netbox-codex-pred` on host port
+  `8139`, using a distinct `invoke test-isolated --project-name` value after
+  migrations finish, and retain literal unittest summaries.
+
+Evidence, 2026-08-02:
+
+- Final clean isolated combined run:
+  `Ran 99 tests in 511.834s` followed by `OK`.
+- `invoke lint`: all hooks passed, including Black, Flake8, and sensitive
+  content checks.
+- `invoke harness-check`: passed.
+
+## Rollback
+
+Revert the predictor, caller, test, and this plan together. Hidden protection
+would again reach apply as `ProtectedError`; no schema or persisted data cleanup
+is required.
+
+## Decision Log
+
+- 2026-08-02: Rejected exempting every plugin provenance model. Claims and
+  peer-sync identities are intentional blockers and must still be predicted.
+- 2026-08-02: Chose an exact relation signature plus current-sync row scope.
+  This mirrors the authoritative Device-delete guard's actual cleanup contract.
+- 2026-08-02: Added no dependency edge. Ordering cannot make a surviving
+  protected reference disappear, while a new edge would add cycle risk without
+  resolving the row.

--- a/forward_netbox/tests/test_bulk_merge.py
+++ b/forward_netbox/tests/test_bulk_merge.py
@@ -413,6 +413,107 @@ class BulkMergeIntegrationTest(CleanTransactionTestCase):
         self.assertFalse(Device.objects.filter(pk=device.pk).exists())
         self.assertFalse(ForwardDeviceIdentity.objects.filter(pk=identity.pk).exists())
 
+    def test_hidden_protect_blocker_is_predicted_and_reported_before_apply(self):
+        from extras.models import Tag
+
+        from forward_netbox.models import ForwardDeviceTagClaim
+        from forward_netbox.utilities import ownership as ownership_module
+
+        branch, ingestion, device, identity = self._stage_owned_device_delete(
+            "hidden-protect-blocker"
+        )
+        tag = Tag.objects.create(
+            name="Hidden Protect Blocker",
+            slug="hidden-protect-blocker",
+        )
+        claim = ForwardDeviceTagClaim.objects.create(
+            sync=ingestion.sync,
+            ingestion=ingestion,
+            device=device,
+            tag=tag,
+            claim_type=ForwardDeviceTagClaim.ClaimType.SCOPE,
+            snapshot_id=ingestion.snapshot_id,
+        )
+
+        with (
+            patch.object(
+                ownership_module,
+                "release_authoritative_device_delete_ownership",
+            ) as release_ownership,
+            self.assertLogs("forward_netbox.merge", level="WARNING") as captured,
+        ):
+            merge_branch(ingestion, user=self.user)
+
+        release_ownership.assert_not_called()
+        self.assertTrue(
+            any(
+                "still referenced by forward_netbox.ForwardDeviceTagClaim (1)"
+                in message
+                for message in captured.output
+            ),
+            captured.output,
+        )
+        branch.refresh_from_db()
+        self.assertEqual(branch.status, "merged")
+        self.assertTrue(Device.objects.filter(pk=device.pk).exists())
+        self.assertTrue(type(identity).objects.filter(pk=identity.pk).exists())
+        self.assertTrue(type(claim).objects.filter(pk=claim.pk).exists())
+        self.assertFalse(
+            ForwardIngestionIssue.objects.filter(ingestion=ingestion).exists()
+        )
+
+    def test_peer_identity_hidden_protect_remains_blocking(self):
+        from forward_netbox.models import ForwardDeviceIdentity
+        from forward_netbox.utilities import ownership as ownership_module
+
+        branch, ingestion, device, identity = self._stage_owned_device_delete(
+            "peer-identity-blocker"
+        )
+        peer_sync = ForwardSync.objects.create(
+            name="bulk-merge-sync-peer-identity-blocker-peer",
+            source=ingestion.sync.source,
+            user=self.user,
+            auto_merge=False,
+            parameters={"snapshot_id": "LATEST_PROCESSED", "dcim.site": True},
+        )
+        peer_ingestion = ForwardIngestion.objects.create(
+            sync=peer_sync,
+            snapshot_selector="LATEST_PROCESSED",
+            snapshot_id="snapshot-peer-identity-blocker",
+        )
+        peer_identity = ForwardDeviceIdentity.objects.create(
+            sync=peer_sync,
+            ingestion=peer_ingestion,
+            source_device_key=device.name,
+            device=device,
+        )
+
+        with (
+            patch.object(
+                ownership_module,
+                "release_authoritative_device_delete_ownership",
+            ) as release_ownership,
+            self.assertLogs("forward_netbox.merge", level="WARNING") as captured,
+        ):
+            merge_branch(ingestion, user=self.user)
+
+        release_ownership.assert_not_called()
+        self.assertTrue(
+            any(
+                "still referenced by forward_netbox.ForwardDeviceIdentity (1)"
+                in message
+                for message in captured.output
+            ),
+            captured.output,
+        )
+        branch.refresh_from_db()
+        self.assertEqual(branch.status, "merged")
+        self.assertTrue(Device.objects.filter(pk=device.pk).exists())
+        self.assertTrue(type(identity).objects.filter(pk=identity.pk).exists())
+        self.assertTrue(
+            type(peer_identity).objects.filter(pk=peer_identity.pk).exists()
+        )
+
     def test_device_delete_serializes_concurrent_claim_writer(self):
         from django.db import IntegrityError
         from extras.models import Tag

--- a/forward_netbox/utilities/bulk_merge.py
+++ b/forward_netbox/utilities/bulk_merge.py
@@ -64,6 +64,34 @@ BULK_MERGE_INPUT_CHUNK_SIZE = 2000
 RELATIONSHIP_LOCK_RETRY_ATTEMPTS = 20
 RELATIONSHIP_LOCK_RETRY_MAX_DELAY_SECONDS = 0.5
 
+# Protecting rows absent from Branching's collapsed changes are blockers unless
+# this plugin resolves the reference itself. Keep this list deliberately narrow.
+#
+# The one entry holds because `ForwardDeviceIdentity` rows live in main rather
+# than in the branch: `delete_dcim_device` collects the branch-local cascade
+# with that model in `ignored_related_models`, so the branch delete is not
+# refused by a row the branch cannot see, and the orphaned identity is removed
+# afterwards by `finalize_device_identities_locked` during post-merge
+# bookkeeping. It is resolved by that split, not by a deletion ordered ahead of
+# the device delete.
+#
+# Peer-sync identities, tag claims, virtual-parent claims and every other hidden
+# relation have no such path and must remain blockers.
+#
+# Each tuple is (protected target label, referencing model label, FK field).
+# Adding an entry requires a real production path that makes the reference stop
+# protecting the target by the time the delete applies, plus regression coverage
+# for both the exemption and a surviving row of the same model.
+MERGE_RESOLVED_PROTECTING_RELATIONS = frozenset(
+    {
+        (
+            "dcim.device",
+            "forward_netbox.forwarddeviceidentity",
+            "device",
+        ),
+    }
+)
+
 # NetBox serializes these read-only relationship summaries into ObjectChange
 # payloads. They can legitimately change when a later branch-owned child row is
 # applied, so they are not scalar provenance. The child objects retain their own
@@ -1237,7 +1265,12 @@ def _skip_updates_missing_in_main_batched(collapsed_changes, change_logger):
             )
 
 
-def _skip_protecting_reference_blocked_deletes(collapsed_changes, change_logger):
+def _skip_protecting_reference_blocked_deletes(
+    collapsed_changes,
+    change_logger,
+    *,
+    merge_sync_id=None,
+):
     """Skip deletes the database will refuse, instead of failing them at apply.
 
     `protecting_reference_blocked_deletes` identifies a delete whose PROTECT or
@@ -1247,12 +1280,13 @@ def _skip_protecting_reference_blocked_deletes(collapsed_changes, change_logger)
     So one operator-owned object the plugin does not manage could wedge an
     entire sync's convergence bookkeeping indefinitely.
 
-    The plugin cannot resolve these itself. The three PROTECT references into
-    `dcim.Device` are `dcim.VirtualChassis.master`,
-    `dcim.VirtualDeviceContext.device` and `virtualization.VirtualMachine.device`,
-    and only virtualchassis is a synced model — the other two are operator data.
-    Deleting them to clear the path would destroy records the operator owns, and
-    the sync has no mandate for that.
+    The plugin cannot resolve most of these itself. The one explicit exception
+    is the current sync's `ForwardDeviceIdentity.device` reference, which the
+    branch delete does not see and post-merge bookkeeping clears - see
+    `MERGE_RESOLVED_PROTECTING_RELATIONS` for why that holds. Peer-sync
+    identities and other hidden references remain protected operator or
+    ownership data; deleting them merely to clear the path would exceed the
+    sync's mandate.
 
     So report and skip: the delete intent stays exact and visible as an issue,
     the row stays in drift where an operator can act on it, and the merge is not
@@ -1261,7 +1295,10 @@ def _skip_protecting_reference_blocked_deletes(collapsed_changes, change_logger)
 
     Returns the skipped keys mapped to what holds them.
     """
-    blocked = protecting_reference_blocked_deletes(collapsed_changes)
+    blocked = protecting_reference_blocked_deletes(
+        collapsed_changes,
+        merge_sync_id=merge_sync_id,
+    )
     if not blocked:
         return {}
     for key, references in blocked.items():
@@ -1416,7 +1453,7 @@ def describe_protecting_references(model_class, pk):
     return sorted(found)
 
 
-def protecting_reference_blocked_deletes(collapsed_changes):
+def protecting_reference_blocked_deletes(collapsed_changes, *, merge_sync_id=None):
     """Deletes that a surviving PROTECT/RESTRICT reference would reject.
 
     Delete protection is otherwise plugin-ownership based, so a row that the
@@ -1425,7 +1462,7 @@ def protecting_reference_blocked_deletes(collapsed_changes):
     how a device kept two BGP peers and never converged.
 
     A reference only blocks when the referencing row is **not changing at all**
-    in this run. Two ways it can be changing, and both resolve the block:
+    in this run. Three ways it can be changing, and all resolve the block:
 
     * it is deleted here — ordering puts the child before the parent
       (`_add_protected_child_delete_dependencies`);
@@ -1436,6 +1473,12 @@ def protecting_reference_blocked_deletes(collapsed_changes):
       protects. Treating an updated referrer as blocking would skip a delete
       that in fact succeeds — which is how the DLM protected-version delete,
       the exact case that release-ordering exists for, regressed.
+    * it matches an exact entry in `MERGE_RESOLVED_PROTECTING_RELATIONS` and is
+      scoped to the sync performing this merge. These plugin-owned rows do not
+      appear in `collapsed_changes`; they live in main rather than the branch,
+      so the branch delete never sees them, and post-merge bookkeeping clears
+      the orphan. No sync context means no exemption, so standalone callers
+      fail closed.
 
     Erring this way is deliberate: wrongly skipping loses a real delete
     silently, while wrongly allowing one just restores the pre-existing
@@ -1457,33 +1500,39 @@ def protecting_reference_blocked_deletes(collapsed_changes):
     blocked = defaultdict(list)
     for model_class, deletes_by_pk in delete_pks_by_model.items():
         target_pks = list(deletes_by_pk)
-        # Deliberately the visible relations only, NOT `protecting_relations`.
-        # Widening this to hidden relations makes plugin provenance rows look
-        # like static blockers: `ForwardDeviceIdentity.device` is PROTECT, so an
-        # owned device delete is predicted blocked and skipped — but the identity
-        # is removed in the same atomic merge, so the delete would have
-        # succeeded. Measured: it silently kept a device that should have been
-        # deleted, which is the failure mode this function's docstring calls out
-        # as the worse one. Teaching the predictor which referencing rows this
-        # plugin cleans up in-transaction is a separate change.
-        for relation in model_class._meta.related_objects:
+        for relation in protecting_relations(model_class):
             field = relation.field
-            on_delete = getattr(field.remote_field, "on_delete", None)
-            if on_delete not in (models.PROTECT, models.RESTRICT):
-                continue
             referencing_model = relation.related_model
             changing = changing_pks_by_model.get(referencing_model, set())
+            relation_signature = (
+                model_class._meta.label_lower,
+                referencing_model._meta.label_lower,
+                field.name,
+            )
+            resolves_current_sync = bool(
+                merge_sync_id is not None
+                and relation_signature in MERGE_RESOLVED_PROTECTING_RELATIONS
+            )
             counts = defaultdict(int)
             for offset in range(0, len(target_pks), BULK_MERGE_FLUSH_THRESHOLD):
                 chunk = target_pks[offset : offset + BULK_MERGE_FLUSH_THRESHOLD]
+                value_fields = ["pk", field.attname]
+                if resolves_current_sync:
+                    value_fields.append("sync_id")
                 rows = (
                     referencing_model.objects.using(DEFAULT_DB_ALIAS)
                     .filter(**{f"{field.name}__in": chunk})
-                    .values_list("pk", field.attname)
+                    .values_list(*value_fields)
                 )
-                for referencing_pk, target_pk in rows:
+                for row in rows:
+                    referencing_pk, target_pk = row[:2]
                     if referencing_pk in changing:
                         # Deleted or updated in this run; ordering handles it.
+                        continue
+                    if resolves_current_sync and row[2] == merge_sync_id:
+                        # This exact current-sync identity lives in main, is
+                        # excluded from the branch delete's cascade, and is
+                        # cleared by post-merge bookkeeping.
                         continue
                     counts[target_pk] += 1
             for target_pk, count in counts.items():
@@ -1927,6 +1976,7 @@ def bulk_merge_changes(
     record_failed=None,
     result_metadata=None,
     set_based_decision=None,
+    merge_sync_id=None,
 ):
     """Merge branch changes into main regardless of caller branch context."""
     with deactivate_branch():
@@ -1941,6 +1991,7 @@ def bulk_merge_changes(
             record_failed=record_failed,
             result_metadata=result_metadata,
             set_based_decision=set_based_decision,
+            merge_sync_id=merge_sync_id,
         )
 
 
@@ -1956,6 +2007,7 @@ def _bulk_merge_changes_main(
     record_failed=None,
     result_metadata=None,
     set_based_decision=None,
+    merge_sync_id=None,
 ):
     """Merge ``changes`` (a branch's unmerged ObjectChanges) into main.
 
@@ -1995,7 +2047,9 @@ def _bulk_merge_changes_main(
         "skip_protected_blocked_deletes", owner="ours", rows=len(collapsed)
     ):
         protected_blocked_deletes = _skip_protecting_reference_blocked_deletes(
-            collapsed, change_logger
+            collapsed,
+            change_logger,
+            merge_sync_id=merge_sync_id,
         )
     ordered = _order_collapsed_changes_fast(collapsed, change_logger, "merge")
     affected_prefix_vrf_ids = _affected_prefix_vrf_ids(ordered)

--- a/forward_netbox/utilities/merge.py
+++ b/forward_netbox/utilities/merge.py
@@ -550,6 +550,7 @@ def merge_branch(
             record_failed=_record_failed,
             result_metadata=merge_metadata,
             set_based_decision=set_based_decision,
+            merge_sync_id=ingestion.sync_id,
         )
         failed += bulk_failed
         models_touched |= bulk_models


### PR DESCRIPTION
Closes the half of the hidden-`PROTECT` defect that 2.7.0 deliberately deferred.

`_meta.related_objects` omits relations declared `related_name="+"`, so four of the five `PROTECT` relations pointing at an ingestion were invisible to our protection checks. 2.7.0 fixed the delete-refusal side. The merge's delete predictor had the same blind spot and was left alone, because widening it naively **regressed**: an owned device delete was predicted blocked and skipped, so the device survived — silently losing a real delete, which that function's own docstring calls the worse failure.

Unfixed, a merge delete blocked by a hidden reference is never predicted, so it is scheduled, fails at apply with `ProtectedError`, and a failed row blocks baseline promotion.

## Approach

The predictor now reads hidden relations, with one exact exemption — `dcim.Device <- ForwardDeviceIdentity.device` — and only for identities belonging to the sync performing the merge. A peer sync's identity, a tag claim, a virtual-parent claim and every other hidden reference remain blockers. Callers supplying no sync context get no exemption and fail closed.

## Why that exemption is safe

Those rows live in **main**, not in the branch. `delete_dcim_device` collects the branch-local cascade with `ForwardDeviceIdentity` in `ignored_related_models`, so the branch delete is never refused by a row the branch cannot see, and the orphan is cleared afterwards by `finalize_device_identities_locked` during post-merge bookkeeping.

The comments originally described this as a guard that *deletes those rows immediately before the device delete*. No such guard exists — `ForwardDeviceIdentity` does not appear in `merge.py` at all. That mattered because the claim sat in the rule governing **what qualifies a relation for exemption**: a maintainer could add an entry believing "we delete it first" is the contract and get a silently-dropped delete. Corrected in all four places it appeared.

## Cycle safety

No dependency edge is added or reordered — a blocked delete becomes a skip before graph ordering.

## Verification

`Ran 99 tests in 518.066s / OK` (`test_bulk_merge` + `test_protecting_relations`), re-run independently rather than taken on report. The three tests that the naive widening broke are unchanged and passing; the test diff is purely additive, with new coverage proving a hidden claim and a peer-sync identity still block. Harness check and pre-commit pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j2nbNXj1sfguLKeMvbmzK