### PR TITLE
chore: fail when a post-release step is skipped

### DIFF
--- a/docs/03_Plans/active/2026-08-02-enforce-post-release-steps.md
+++ b/docs/03_Plans/active/2026-08-02-enforce-post-release-steps.md
@@ -1,0 +1,79 @@
+# Enforce The Post-Release Steps
+
+## Goal
+
+Make skipping a post-release step fail immediately, instead of months later at
+a tag.
+
+## Contract
+
+- The provenance anchor names the release the compatibility table calls current.
+- Skipping either the anchor advance or the table promotion fails the harness.
+- The anchor is not copied by hand into a second file.
+
+## Constraints
+
+- No release control is weakened; this only adds a check.
+- The check reads the canonical `README.md` table, which
+  `scripts/gen_changelog.py` already treats as the source of truth.
+
+## Touched Surfaces
+
+- `scripts/check_harness.py` - new `_check_release_anchor_tracks_current_release`,
+  and the literal anchor copy in `_check_standard_release_tag_flow` reduced to a
+  presence check
+- `scripts/tests/test_check_harness.py` - coverage
+- This plan.
+
+## Approach
+
+Two post-release steps are easy to skip because nothing fails when they are
+skipped:
+
+1. advancing `PRIOR_RELEASE_TAG`, and
+2. promoting the shipped release in the compatibility table.
+
+Both were skipped repeatedly. The anchor had sat at `v2.5.11` until the reviewed
+chain reached 42 commits and an expired run burned `v2.6.10`. The table told
+operators that `2.6.9` was current while `2.6.12` and `2.7.0` were both published
+and still marked release candidates. `release.py --auto-finish` performs both,
+and hand-tagging performs neither.
+
+The two facts are related: after a release, the anchor and the current release
+are the same version. Checking them against each other turns two independently
+forgettable steps into one enforced invariant, and it fails at the point of
+omission rather than at the next tag.
+
+This also deletes a hand-maintained copy. `_check_standard_release_tag_flow`
+asserted the literal `PRIOR_RELEASE_TAG = "v2.6.10"`, so the guard against a
+stale anchor itself had to be edited by hand whenever the anchor moved - it
+could never have caught staleness. It now asserts the constant is present and
+lets the derived check verify the value.
+
+**What this does not do.** It does not make releases run through
+`--auto-finish`. It makes the omission loud. Automating the release path is the
+real fix and remains open.
+
+## Validation
+
+- With the anchor set back to `v2.6.10` against a table naming `v2.7.0` current,
+  the check reports exactly that mismatch and names both remedies. Verified by
+  temporarily reverting the anchor.
+- Passes on the current tree.
+- A table with zero or several current releases is reported rather than silently
+  taking the first, because the promotion step edits that column and a botched
+  edit is the likely way it breaks.
+
+## Rollback
+
+Revert. Both post-release steps go back to being unenforced.
+
+## Decision Log
+
+- 2026-08-02: Derived the anchor check from the release table rather than adding
+  a second pinned constant. A pinned guard against staleness is itself stale.
+
+## Open
+
+- Releases still do not run through `release.py --auto-finish`, which is the
+  underlying reason these steps get skipped.

--- a/scripts/check_harness.py
+++ b/scripts/check_harness.py
@@ -1040,6 +1040,59 @@ def _check_release_toolchain_lock(failures: list[str]) -> None:
         failures.append("CI workflow must install the reviewed hash-locked toolchain")
 
 
+def _check_release_anchor_tracks_current_release(failures: list[str]) -> None:
+    """The provenance anchor must name the release the table calls current.
+
+    Two post-release steps are easy to skip because nothing failed when they
+    were: advancing `PRIOR_RELEASE_TAG`, and promoting the shipped release in
+    the compatibility table. Skipping either is silent at the time and expensive
+    later - a stale anchor grows the reviewed commit range until GitHub expires
+    a run and burns a release at the tag, which is what happened to `v2.6.10`,
+    and a stale table told operators for two releases that `2.6.9` was current
+    while `2.6.12` and `2.7.0` sat as candidates.
+
+    Both were previously pinned by hand, including a literal copy of the anchor
+    in this file, so the checks moved only when someone remembered to move them.
+    Tying the two together removes the hand-maintained copy and makes skipping
+    either step fail here instead of at a tag months later.
+    """
+    provenance_path = REPO_ROOT / "scripts/verify_release_provenance.py"
+    readme_path = REPO_ROOT / "README.md"
+    if not provenance_path.exists() or not readme_path.exists():
+        return
+
+    anchor_match = re.search(
+        r'^PRIOR_RELEASE_TAG = "(?P<tag>v[0-9]+\.[0-9]+\.[0-9]+)"$',
+        provenance_path.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    if anchor_match is None:
+        failures.append(
+            "release provenance must pin PRIOR_RELEASE_TAG to a vX.Y.Z release tag"
+        )
+        return
+
+    current = re.findall(
+        r"^\| `(?P<version>v[0-9]+\.[0-9]+\.[0-9]+)` \|[^|]*\| Current release;",
+        readme_path.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    if len(current) != 1:
+        failures.append(
+            "README release table must name exactly one current release, found "
+            f"{len(current)}"
+        )
+        return
+
+    if anchor_match.group("tag") != current[0]:
+        failures.append(
+            "release provenance anchor "
+            f"{anchor_match.group('tag')} does not match the current release "
+            f"{current[0]} in the README table: advance the anchor after a "
+            "release, or promote the shipped release in the table"
+        )
+
+
 def _check_standard_release_tag_flow(failures: list[str]) -> None:
     paths = {
         "release": REPO_ROOT / "scripts/release.py",
@@ -1061,7 +1114,7 @@ def _check_standard_release_tag_flow(failures: list[str]) -> None:
         if fragment not in texts["release"]:
             failures.append(f"standard release tag flow must contain: {fragment}")
     for fragment in (
-        'PRIOR_RELEASE_TAG = "v2.7.0"',
+        "PRIOR_RELEASE_TAG = ",
         "BOOTSTRAP_REQUIRED_FILES",
         "BOOTSTRAP_FILE_DIGESTS",
         "BASE_REQUIRED_STATUS_CHECKS",
@@ -1127,6 +1180,7 @@ def main() -> int:
     _check_harness_gardening_dependency(failures)
     _check_sensitive_guard_wiring(failures)
     _check_release_toolchain_lock(failures)
+    _check_release_anchor_tracks_current_release(failures)
     _check_standard_release_tag_flow(failures)
     _check_publish_gate_placement(failures)
     if args.base:

--- a/scripts/tests/test_check_harness.py
+++ b/scripts/tests/test_check_harness.py
@@ -986,3 +986,75 @@ class CheckHarnessTrustedPrivateFetchTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ReleaseAnchorTracksCurrentReleaseTest(unittest.TestCase):
+    """Two post-release steps that were repeatedly skipped, tied together.
+
+    Advancing `PRIOR_RELEASE_TAG` and promoting the shipped release in the
+    compatibility table are both silent when omitted. A stale anchor grows the
+    reviewed commit range until an expired run burns a release at the tag; a
+    stale table told operators `2.6.9` was current while two later releases were
+    already published. After a release the two name the same version, so they
+    can check each other.
+    """
+
+    PROVENANCE = 'PRIOR_RELEASE_TAG = "{tag}"\n'
+    TABLE = (
+        "| Plugin Release | NetBox Version | Status |\n"
+        "| --- | --- | --- |\n"
+        "| `{current}` | `4.6.x` | Current release; shipped. |\n"
+        "| `v2.6.9` | `4.6.x` | Superseded by `{current}`; shipped. |\n"
+    )
+
+    def _run(self, *, tag, current, table=None):
+        failures = []
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "scripts").mkdir()
+            (root / "scripts/verify_release_provenance.py").write_text(
+                self.PROVENANCE.format(tag=tag), encoding="utf-8"
+            )
+            (root / "README.md").write_text(
+                table if table is not None else self.TABLE.format(current=current),
+                encoding="utf-8",
+            )
+            with patch.object(check_harness, "REPO_ROOT", root):
+                check_harness._check_release_anchor_tracks_current_release(failures)
+        return failures
+
+    def test_anchor_matching_the_current_release_passes(self):
+        self.assertEqual(self._run(tag="v2.7.0", current="v2.7.0"), [])
+
+    def test_stale_anchor_is_reported_with_both_remedies(self):
+        # The exact shape that burned v2.6.10: the anchor left behind while the
+        # table moved on.
+        failures = self._run(tag="v2.6.10", current="v2.7.0")
+        self.assertEqual(len(failures), 1)
+        self.assertIn("v2.6.10", failures[0])
+        self.assertIn("v2.7.0", failures[0])
+        self.assertIn("advance the anchor", failures[0])
+        self.assertIn("promote the shipped release", failures[0])
+
+    def test_unpromoted_table_is_reported(self):
+        # The other direction: the anchor advanced but the release was never
+        # promoted, so the table still calls an older version current.
+        failures = self._run(tag="v2.7.0", current="v2.6.12")
+        self.assertEqual(len(failures), 1)
+        self.assertIn("does not match the current release", failures[0])
+
+    def test_a_table_without_exactly_one_current_release_is_reported(self):
+        # The promotion step edits this column, so a botched edit is the likely
+        # way it breaks; taking the first match would hide it.
+        table = (
+            "| `v2.7.0` | `4.6.x` | Current release; shipped. |\n"
+            "| `v2.6.12` | `4.6.x` | Current release; shipped. |\n"
+        )
+        failures = self._run(tag="v2.7.0", current="v2.7.0", table=table)
+        self.assertEqual(len(failures), 1)
+        self.assertIn("exactly one current release", failures[0])
+
+    def test_a_missing_anchor_constant_is_reported(self):
+        failures = self._run(tag="not-a-tag", current="v2.7.0")
+        self.assertEqual(len(failures), 1)
+        self.assertIn("PRIOR_RELEASE_TAG", failures[0])


### PR DESCRIPTION
Two post-release steps are silent when omitted, and both were omitted repeatedly:

1. advancing `PRIOR_RELEASE_TAG`, and
2. promoting the shipped release in the compatibility table.

The anchor sat at `v2.5.11` until the reviewed commit chain reached 42 commits and an expired workflow run burned `v2.6.10` at the tag. The table told operators `2.6.9` was the current release while `2.6.12` and `2.7.0` were both published to PyPI and still marked release candidates.

`release.py --auto-finish` performs both. Hand-tagging performs neither, and nothing failed at the time.

## Approach

After a release, the anchor and the current release name the same version — so they can check each other. That turns two independently forgettable steps into one enforced invariant which fails at the point of omission rather than at the next tag.

It also removes a hand-maintained copy. `_check_standard_release_tag_flow` asserted the literal `PRIOR_RELEASE_TAG = "v2.6.10"`, so the guard against a stale anchor had to be hand-edited whenever the anchor moved — it could never have caught staleness. It now asserts the constant exists and lets the derived check verify its value.

## Verification

Reverting the anchor to `v2.6.10` against a table naming `v2.7.0` current reports exactly:

```
release provenance anchor v2.6.10 does not match the current release v2.7.0
in the README table: advance the anchor after a release, or promote the
shipped release in the table
```

Five new tests cover: matching anchor passes; stale anchor names both remedies; the reverse case (anchor advanced, table not promoted); a table with zero or several current releases reported rather than silently taking the first; and a missing constant. `Ran 263 tests / OK`. Harness check and pre-commit pass.

## What this does not do

It does not make releases run through `--auto-finish`. It makes skipping loud. Automating the release path is the real fix and stays open — this is the guardrail until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j2nbNXj1sfguLKeMvbmzK