### PR TITLE
release: open 2.7.1 on main

### DIFF
--- a/docs/03_Plans/active/2026-08-02-open-next-2.7.1.md
+++ b/docs/03_Plans/active/2026-08-02-open-next-2.7.1.md
@@ -20,6 +20,8 @@ Make an install from `main` visibly not the published release.
 - `pyproject.toml`, `forward_netbox/__init__.py`,
   `forward_netbox/utilities/fast_baseline.py`,
   `forward_netbox/tests/test_runtime_dependency_check.py`
+- `tasks.py` - `_previous_released_version` version parsing
+- `scripts/tests/test_tasks.py` - dev-marker coverage
 - This plan.
 
 ## Approach
@@ -42,6 +44,24 @@ other two - promoting the release in the compatibility table, and advancing the
 provenance anchor - were repaired earlier today. Only promotion is automated
 (`stage_finish`); the anchor advance exists nowhere in `release.py`, and
 `--open-next` is a separate stage that `--finish` never invokes.
+
+**And it could not have been done.** Bumping `main` to `.dev0` red the upgrade
+gate immediately:
+
+    ValueError: invalid literal for int() with base 10: 'dev0'
+
+`_previous_released_version` resolved its upgrade source by splitting the tree's
+version on `.` and calling `int()` on every part, so the dev marker and the gate
+could not coexist. That is very likely why this step kept being skipped: doing
+it correctly broke CI on every pull request, and leaving `main` on the released
+version did not.
+
+The parser now takes the leading numeric components and stops at the first that
+is not, so `2.7.1.dev0` resolves to `(2, 7, 1)` and upgrades from the newest
+release below the version it is heading for. An unreadable version fails closed
+and asks for `--from-version` rather than guessing. Done without `packaging`
+deliberately: this runs from the pinned release toolchain and should not gain a
+dependency to read three integers.
 
 ## Validation
 

--- a/docs/03_Plans/active/2026-08-02-open-next-2.7.1.md
+++ b/docs/03_Plans/active/2026-08-02-open-next-2.7.1.md
@@ -1,0 +1,64 @@
+# Open 2.7.1 On Main
+
+## Goal
+
+Make an install from `main` visibly not the published release.
+
+## Contract
+
+- `main` carries `2.7.1.dev0` across every version surface.
+- The published `2.7.0` artifacts are untouched.
+
+## Constraints
+
+- All four version surfaces move together, including the fast-baseline runtime
+  pin.
+- The tag-only publish trigger is not touched.
+
+## Touched Surfaces
+
+- `pyproject.toml`, `forward_netbox/__init__.py`,
+  `forward_netbox/utilities/fast_baseline.py`,
+  `forward_netbox/tests/test_runtime_dependency_check.py`
+- This plan.
+
+## Approach
+
+`main` carries the release version from the moment the release PR merges -
+before the tag exists and before anything reaches PyPI. `stage_open_next`
+exists precisely because a customer installed from `main` inside that window
+and reported running a version PyPI did not have.
+
+After `2.7.0` shipped, `main` still read `2.7.0`, so that window was open again.
+This closes it by moving `main` to `2.7.1.dev0`.
+
+Applied through `release.py --open-next --write` rather than by hand, because
+the four surfaces must move together: bumping the fast-baseline runtime pin
+separately reverts the fast baseline from roughly six minutes to roughly fifteen
+hours with nothing an operator can see.
+
+**This is the third post-release step, and the third one that was skipped.** The
+other two - promoting the release in the compatibility table, and advancing the
+provenance anchor - were repaired earlier today. Only promotion is automated
+(`stage_finish`); the anchor advance exists nowhere in `release.py`, and
+`--open-next` is a separate stage that `--finish` never invokes.
+
+## Validation
+
+- `invoke harness-test` passes.
+- All four surfaces read `2.7.1.dev0`.
+
+## Rollback
+
+Revert. `main` reads `2.7.0` again and is indistinguishable from the published
+release.
+
+## Decision Log
+
+- 2026-08-02: Used the existing stage rather than editing four files by hand.
+  The hand edit is exactly how the fast-baseline pin gets left behind.
+
+## Open
+
+- `--finish` should perform all three post-release steps. Today it performs one,
+  which is why all three have been skipped at least once.

--- a/forward_netbox/__init__.py
+++ b/forward_netbox/__init__.py
@@ -5,7 +5,7 @@ class NetboxForwardConfig(PluginConfig):
     name = "forward_netbox"
     verbose_name = "Forward"
     description = "Sync Forward data into NetBox using built-in NQE queries."
-    version = "2.7.0"
+    version = "2.7.1.dev0"
     base_url = "forward"
     min_version = "4.6.5"
     max_version = "4.6.99"

--- a/forward_netbox/tests/test_runtime_dependency_check.py
+++ b/forward_netbox/tests/test_runtime_dependency_check.py
@@ -23,7 +23,7 @@ class RuntimeDependencyCheckTest(SimpleTestCase):
         self.assertIsNotNone(_resolved_branching_version())
 
     def test_plugin_config_version_matches_package_release(self):
-        self.assertEqual(NetboxForwardConfig.version, "2.7.0")
+        self.assertEqual(NetboxForwardConfig.version, "2.7.1.dev0")
 
     def test_exact_runtime_passes(self):
         _check_runtime_dependencies()

--- a/forward_netbox/utilities/fast_baseline.py
+++ b/forward_netbox/utilities/fast_baseline.py
@@ -200,7 +200,7 @@ def _runtime_decision():
     expected = {
         "netbox_series": "4.6",
         "branching_series": "1.1",
-        "forward_netbox": "2.7.0",
+        "forward_netbox": "2.7.1.dev0",
         # Each optional distribution lists every version validated against this
         # engine, not a single pin. An exact pin meant a customer upgrading one
         # optional plugin silently lost the fast baseline — no error, just a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "forward-netbox"
-version = "2.7.0"
+version = "2.7.1.dev0"
 description = "NetBox plugin to sync Forward data into NetBox via built-in NQE queries"
 authors = ["Craig Johnson <craigjohnson@forwardnetworks.com>"]
 license = "MIT"

--- a/scripts/tests/test_tasks.py
+++ b/scripts/tests/test_tasks.py
@@ -240,6 +240,26 @@ class PreviousReleasedVersionTest(unittest.TestCase):
         with patch("urllib.request.urlopen", fake_urlopen):
             return tasks._previous_released_version(Mock(), version)
 
+    def test_a_dev_marker_resolves_from_the_release_it_heads_for(self):
+        # `main` is deliberately moved onto a `.dev0` marker after a release so
+        # an install from it is not indistinguishable from the published one.
+        # Splitting on "." and calling int() crashed on exactly that
+        # (`invalid literal for int() with base 10: 'dev0'`), so the marker and
+        # this gate could not coexist and `main` kept being left on the released
+        # version. A dev tree upgrades from the newest release below the version
+        # it is heading for.
+        self.assertEqual(self._resolve("2.6.7.dev0"), "2.6.6")
+
+    def test_a_dev_marker_does_not_sort_lexicographically(self):
+        payload = {"releases": {"2.6.9": [{"yanked": False}], "2.6.10": [{"yanked": False}]}}
+        self.assertEqual(self._resolve("2.6.11.dev0", payload), "2.6.10")
+
+    def test_an_unparseable_version_fails_closed(self):
+        # Better to stop and ask for --from-version than to resolve an upgrade
+        # source from a version nobody can read.
+        with self.assertRaises(Exit):
+            self._resolve("not-a-version")
+
     def test_picks_the_highest_release_below_the_target(self):
         # 2.6.9 is published but above the target, so it is not what an
         # operator upgrading to 2.6.7 could be coming from.

--- a/scripts/tests/test_tasks.py
+++ b/scripts/tests/test_tasks.py
@@ -251,7 +251,9 @@ class PreviousReleasedVersionTest(unittest.TestCase):
         self.assertEqual(self._resolve("2.6.7.dev0"), "2.6.6")
 
     def test_a_dev_marker_does_not_sort_lexicographically(self):
-        payload = {"releases": {"2.6.9": [{"yanked": False}], "2.6.10": [{"yanked": False}]}}
+        payload = {
+            "releases": {"2.6.9": [{"yanked": False}], "2.6.10": [{"yanked": False}]}
+        }
         self.assertEqual(self._resolve("2.6.11.dev0", payload), "2.6.10")
 
     def test_an_unparseable_version_fails_closed(self):

--- a/tasks.py
+++ b/tasks.py
@@ -1094,13 +1094,38 @@ def _previous_released_version(context, version):
             code=2,
         ) from exc
 
-    current = tuple(int(part) for part in version.split("."))
+    # `version` is whatever the tree carries, and between releases that is a
+    # `.dev0` marker - `main` is deliberately moved onto one so an install from
+    # it is not indistinguishable from the published release. Splitting on "."
+    # and calling int() crashed on exactly that (`invalid literal for int() with
+    # base 10: 'dev0'`), which meant the dev marker could not coexist with this
+    # gate and `main` kept being left on the released version instead.
+    #
+    # Take the leading numeric components and stop at the first that is not,
+    # so `2.7.1.dev0` resolves to `(2, 7, 1)` and upgrades from the newest
+    # release below the version it is heading for. Done without `packaging`
+    # deliberately: this runs from the pinned release toolchain, and the gate
+    # should not gain a dependency to read three integers.
+    leading = []
+    for part in version.split("."):
+        if not part.isdigit():
+            break
+        leading.append(int(part))
+    if len(leading) != 3:
+        raise Exit(
+            f"Cannot resolve an upgrade source for unparseable version "
+            f"{version!r}. Pass --from-version explicitly.",
+            code=2,
+        )
+    current = tuple(leading)
     published = []
     for candidate, files in (payload.get("releases") or {}).items():
         # A yanked-only or file-less entry is not installable.
         if not files or all(item.get("yanked") for item in files):
             continue
         parts = candidate.split(".")
+        # Keep the released-only filter: a pre-release on the index is not an
+        # upgrade path an operator can be on.
         if len(parts) != 3 or not all(part.isdigit() for part in parts):
             continue
         entry = tuple(int(part) for part in parts)


### PR DESCRIPTION
`main` still reads `2.7.0` — the same version published to PyPI — so an install from `main` is indistinguishable from the release.

That is the exact problem `stage_open_next` was written for. From its docstring:

> `main` carries the release from the moment the release PR merges — before the tag exists and before anything reaches PyPI. A customer installed from `main` inside that window and reported running a version PyPI did not yet have.

After 2.7.0 shipped, the window reopened. This closes it by moving `main` to `2.7.1.dev0`.

Applied through `release.py --open-next --write` rather than by hand, because the four version surfaces must move together — bumping the fast-baseline runtime pin separately reverts the fast baseline from ~6 minutes to ~15 hours with nothing an operator can see.

## The wider point

This is the **third** post-release step, and the third one to be skipped:

| step | automated? |
| --- | --- |
| Promote the release in the compatibility table | yes — `_promote_release_candidate`, called by `stage_finish` |
| Advance the provenance anchor | **no — exists nowhere in `release.py`** |
| Open the next `.dev0` on `main` | partially — a stage `--finish` never invokes |

All three were repaired by hand today. I previously stated that `--auto-finish` performs the anchor advance; that was wrong — `PRIOR_RELEASE_TAG` appears nowhere in `release.py`, and the anchor has only ever been moved manually. #123's description carries that correction.

`invoke harness-test` passes; harness check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j2nbNXj1sfguLKeMvbmzK