### PR TITLE
fix: register the ingestion issue list route

### DIFF
--- a/docs/03_Plans/active/2026-08-02-ingestion-issue-list-route.md
+++ b/docs/03_Plans/active/2026-08-02-ingestion-issue-list-route.md
@@ -1,0 +1,73 @@
+# Ingestion Issue List Route
+
+## Goal
+
+Make opening an ingestion issue work instead of returning a 500.
+
+## Contract
+
+- Every model exposing a detail view can reverse its list route.
+- The issue list is read-only; issues are written by a sync, never by hand.
+
+## Constraints
+
+- No new navigation entry: an issue is reached from its ingestion.
+
+## Touched Surfaces
+
+- `forward_netbox/views.py` - `ForwardIngestionIssueListView`
+- `forward_netbox/urls.py` - the `detail=False` include
+- `forward_netbox/tests/test_model_view_routes.py` - new
+- This plan.
+
+## Approach
+
+A customer clicked an ingestion issue and got a Server Error:
+
+    NoReverseMatch: Reverse for 'forwardingestionissue_list' not found.
+
+NetBox's object view reverses `<app>:<model>_list` for its breadcrumb, so
+registering a detail view without a list view is a 500 rather than a missing
+page. It happened on the one page that exists to explain a failed merge.
+
+**Registering the view is not sufficient.** Every other model has two URL
+includes - a `detail=False` one for the list and a `<int:pk>` one for the
+detail - and `forwardingestionissue` only ever had the detail include, so a
+registered list view has no URL to attach to. The first attempt at this fix
+registered the view alone and the regression test still failed, which is how
+that was caught.
+
+**This class has shipped twice.** In 2.6.3 the Ingestions list raised
+`NoReverseMatch` for `forwardingestion_delete`, and the response was to remove
+the action pointing at the missing view rather than register it - which left
+ingestions undeletable until 2.6.6. Registering the route is the fix; deleting
+the caller is not.
+
+**Why the existing probe missed it.** The installed-route probe renders the
+plugin's *menu* lists. This model has no menu entry, so it was never in the
+population being checked. The guard therefore sweeps every registered model
+rather than every menu item.
+
+## Validation
+
+- A test reverses the list route for every plugin model that exposes a detail
+  route, and reports the offenders by name.
+- A second test pins `forwardingestionissue` explicitly, so the sweep passing
+  because the model stopped exposing a detail view would not hide a regression.
+- Both fail against the unfixed tree and pass against this one: 2 tests OK.
+
+## Rollback
+
+Revert. Opening an ingestion issue returns a 500 again.
+
+## Decision Log
+
+- 2026-08-02: Swept every registered model rather than adding one route test.
+  The defect is a missing pairing, and it has now occurred for two models.
+- 2026-08-02: Read-only list. Issues are diagnostic evidence written by a sync;
+  offering edit or delete actions would invite editing the record of a failure.
+
+## Open
+
+- The installed-route probe still only covers menu lists. Extending it to every
+  registered detail view would catch this at the artifact rather than in tests.

--- a/forward_netbox/tests/test_model_view_routes.py
+++ b/forward_netbox/tests/test_model_view_routes.py
@@ -12,7 +12,6 @@
 # The installed-route probe does not cover this: it renders the plugin's *menu*
 # lists, and a model reachable only from its parent has no menu entry. So the
 # guard belongs here, over every registered model rather than every menu item.
-
 from django.apps import apps
 from django.test import TestCase
 from django.urls import NoReverseMatch

--- a/forward_netbox/tests/test_model_view_routes.py
+++ b/forward_netbox/tests/test_model_view_routes.py
@@ -1,0 +1,50 @@
+# Registering a detail view without its list view is a 500, not a missing page:
+# NetBox reverses `<app>:<model>_list` from the object view, so opening the
+# object raises NoReverseMatch. A customer hit exactly that on
+# `forwardingestionissue` - the one page that exists to explain a failed merge -
+# and got a Server Error.
+#
+# This has now happened twice. In 2.6.3 the Ingestions list raised
+# NoReverseMatch for `forwardingestion_delete`, and it was resolved by removing
+# the action that pointed at the missing view, which left ingestions undeletable
+# for three releases.
+#
+# The installed-route probe does not cover this: it renders the plugin's *menu*
+# lists, and a model reachable only from its parent has no menu entry. So the
+# guard belongs here, over every registered model rather than every menu item.
+
+from django.apps import apps
+from django.test import TestCase
+from django.urls import NoReverseMatch
+from django.urls import reverse
+
+
+class EveryModelWithADetailViewCanReverseItsListTest(TestCase):
+    """The reverse the object view performs, for every model we register."""
+
+    def test_list_route_resolves_for_each_plugin_model(self):
+        missing = []
+        for model in apps.get_app_config("forward_netbox").get_models():
+            name = model._meta.model_name
+            # Only models that actually expose a detail route can trigger the
+            # breadcrumb reverse; a model with neither is not user-reachable.
+            try:
+                reverse(f"plugins:forward_netbox:{name}", kwargs={"pk": 1})
+            except NoReverseMatch:
+                continue
+            try:
+                reverse(f"plugins:forward_netbox:{name}_list")
+            except NoReverseMatch:
+                missing.append(name)
+        self.assertEqual(
+            missing,
+            [],
+            "these models expose a detail view whose breadcrumb reverse has no "
+            f"list route, which renders as a 500: {missing}",
+        )
+
+    def test_the_ingestion_issue_list_route_exists(self):
+        # Pinned by name as well as by the sweep above, because this is the one
+        # a customer reported and the sweep would also pass if the model stopped
+        # exposing a detail view entirely.
+        self.assertTrue(reverse("plugins:forward_netbox:forwardingestionissue_list"))

--- a/forward_netbox/urls.py
+++ b/forward_netbox/urls.py
@@ -30,6 +30,16 @@ urlpatterns = (
         "ingestion/<int:pk>/",
         include(get_model_urls("forward_netbox", "forwardingestion")),
     ),
+    # Both includes are required. Registering the view is not enough: without
+    # the `detail=False` include there is no URL for the list route to attach
+    # to, so the object view's breadcrumb reverse still raises NoReverseMatch
+    # and opening an issue is a 500.
+    path(
+        "ingestion-issue/",
+        include(
+            get_model_urls("forward_netbox", "forwardingestionissue", detail=False)
+        ),
+    ),
     path(
         "ingestion-issue/<int:pk>/",
         include(get_model_urls("forward_netbox", "forwardingestionissue")),

--- a/forward_netbox/views.py
+++ b/forward_netbox/views.py
@@ -2222,6 +2222,30 @@ class ForwardIngestionBulkDeleteView(generic.BulkDeleteView):
         return super().post(request, *args, **kwargs)
 
 
+@register_model_view(ForwardIngestionIssue, "list", path="", detail=False)
+class ForwardIngestionIssueListView(generic.ObjectListView):
+    """The list route the issue detail page reverses for its breadcrumb.
+
+    Registering a detail view without its list is a 500: NetBox reverses
+    `<app>:<model>_list` from the object view, so opening an issue raised
+    `NoReverseMatch: Reverse for 'forwardingestionissue_list' not found`. A
+    customer hit it on the one page that exists to explain a failed merge.
+
+    2.6.3 met the same class of bug on the Ingestions list and resolved it by
+    dropping the action that pointed at the missing view, which left ingestions
+    undeletable for three releases. Register the route instead.
+
+    The installed-route probe did not catch this because it renders menu lists,
+    and this model has no menu entry - it is reached only from an ingestion.
+    """
+
+    queryset = ForwardIngestionIssue.objects.all()
+    filterset = ForwardIngestionIssueFilterSet
+    table = ForwardIngestionIssueTable
+    # Read-only diagnostic evidence: written by a sync, never hand-edited.
+    actions = (BulkExport,)
+
+
 @register_model_view(ForwardIngestionIssue)
 class ForwardIngestionIssueView(generic.ObjectView):
     """Detail for one ingestion issue.


### PR DESCRIPTION
A customer clicked an ingestion issue on 2.7.0 and got a Server Error:

```
NoReverseMatch: Reverse for 'forwardingestionissue_list' not found.
GET /plugins/forward/ingestion-issue/8746/
```

NetBox's object view reverses `<app>:<model>_list` for its breadcrumb, so registering a detail view **without** a list view is a 500 rather than a missing page — and it landed on the one page that exists to explain a failed merge.

## Registering the view was not enough

Every other model has two URL includes:

```python
path("ingestion/",          include(get_model_urls(..., detail=False)))  # list
path("ingestion/<int:pk>/", include(get_model_urls(...)))                # detail
```

`forwardingestionissue` only ever had the detail include, so the list view I registered had no URL to attach to. My first attempt did exactly that and **the regression test still failed** — which is how it was caught before shipping a fix that changed nothing.

## This class has shipped twice

In 2.6.3 the Ingestions list raised `NoReverseMatch` for `forwardingestion_delete`. The response then was to remove the action pointing at the missing view rather than register it — which left ingestions undeletable until 2.6.6.

So the guard matters more than the fix: a test sweeps **every** plugin model exposing a detail route and asserts its list route reverses, reporting offenders by name.

**Why the existing protection missed it:** the installed-route probe renders the plugin's *menu* lists, and this model has no menu entry — it is reached only from its ingestion. The population it checks was never going to include this.

## Verification

`Ran 2 tests / OK`. Both fail against the unfixed tree. The list is read-only (`BulkExport` only) — issues are diagnostic evidence written by a sync, and offering edit or delete would invite editing the record of a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j2nbNXj1sfguLKeMvbmzK