### PR TITLE
fix: order M2M targets created in the same merge before their referrers

### DIFF
--- a/docs/03_Plans/active/2026-08-02-m2m-create-merge-dependencies.md
+++ b/docs/03_Plans/active/2026-08-02-m2m-create-merge-dependencies.md
@@ -1,0 +1,82 @@
+# M2M Create Merge Dependencies
+
+## Goal
+
+Make a branch merge succeed on its first attempt when an existing object update
+adds a writable many-to-many reference to an object created in the same branch.
+The incident reproduction is an existing DLM CVE whose
+`affected_software` update references a newly created SoftwareVersion.
+
+## Constraints
+
+- Preserve NetBox-native and Branching-native ObjectChange replay.
+- Model writable M2M dependencies generally; do not special-case DLM CVEs.
+- Add an edge only when the serialized M2M value resolves exactly to a
+  collapsed CREATE in the same merge. Ambiguous or unsupported values retain
+  today's ordering.
+- Reject candidate edges that would close a dependency cycle. A missing edge
+  retains the known row-isolated failure; a cyclic edge can stop the entire
+  merge.
+- Do not weaken existing merge, retry, DLM, or relationship tests.
+- No migration or persisted-state change.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/bulk_merge.py`: derive and admit M2M CREATE
+  dependency edges during merge graph construction.
+- `forward_netbox/tests/test_bulk_merge.py`: first-merge DLM regression and
+  multi-hop cycle-safety coverage.
+- This active plan records the high-risk merge-path mechanism and validation.
+
+## Approach
+
+1. Reproduce the latent defect: an existing CVE collapses to UPDATE, a new
+   SoftwareVersion collapses to CREATE, the CVE postchange M2M contains the new
+   primary key, and action priority otherwise schedules UPDATE before CREATE.
+2. Inspect only forward `ManyToManyField` values present in a collapsed CREATE
+   or UPDATE's `postchange_data`. Resolve dictionary values only through an
+   explicit `id`/`pk`; resolve scalar values only by an exact collapsed-change
+   key match. Add no edge for missing, ambiguous, non-CREATE, or absent targets.
+3. Submit candidate `(dependent, target-create)` edges through the existing
+   acyclic dependency admission path before mutating the graph.
+4. Make that admission path inspect the transitive closure of existing
+   dependencies, so a candidate cannot close a cycle through a multi-hop path.
+5. Prove the customer-visible contract with a real branch merge: the first
+   `merge_branch()` call succeeds and materializes both the SoftwareVersion and
+   CVE M2M relation in main.
+
+The M2M population path entered the product in `6db0596` and first shipped in
+v2.5.11. The missing merge dependency is therefore latent and is not a 2.7.0 or
+netbox-dlm 0.6.0 semantic regression.
+
+## Validation
+
+- New first-merge regression in `forward_netbox.tests.test_bulk_merge`.
+- New multi-hop cycle rejection test for the shared acyclic-edge admission
+  helper.
+- `forward_netbox.tests.test_bulk_merge` fully green in isolated Compose project
+  `forward-netbox-codex-m2m-tests`, with
+  `FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-codex-m2m`.
+- `forward_netbox.tests.test_dlm_integration` green in the same isolated project.
+- `invoke harness-check` passes.
+- Isolated web port is 8143; no shared runtime or customer data is used.
+
+## Rollback
+
+Revert the production helper, its call from dependency graph construction, and
+the paired tests. No migration, data rewrite, or branch cleanup is required.
+Branches that encountered the old ordering remain retryable after their target
+CREATEs have reached main.
+
+## Decision Log
+
+- Rejected a CVE/SoftwareVersion special case because the defect is the merge
+  graph's omission of writable M2M references.
+- Rejected global CREATE-before-UPDATE reordering because it broadens merge
+  behavior without relationship evidence and can disturb established release
+  ordering.
+- Rejected best-effort coercion of serialized values. Exact in-merge CREATE
+  identity is required before an edge is proposed.
+- Reused the acyclic edge admission precedent instead of adding edges directly;
+  the helper is strengthened to detect cycles through transitive existing
+  dependencies.

--- a/forward_netbox/tests/test_bulk_merge.py
+++ b/forward_netbox/tests/test_bulk_merge.py
@@ -1071,6 +1071,83 @@ class BulkMergeIntegrationTest(CleanTransactionTestCase):
             SoftwareVersion.objects.filter(pk=software_version.pk).exists()
         )
 
+    def test_m2m_target_create_precedes_existing_source_update_on_first_merge(self):
+        from django.apps import apps
+
+        SoftwareVersion = apps.get_model("netbox_dlm", "SoftwareVersion")
+        CVE = apps.get_model("netbox_dlm", "CVE")
+        platform = Platform.objects.create(
+            name="DLM M2M Dependency OS",
+            slug="dlm-m2m-dependency-os",
+        )
+        cve = CVE.objects.create(
+            cve_id="CVE-2026-22002",
+            description="before",
+        )
+        branch = provision_branch(user=self.user, name="DLM M2M Create Dependency")
+        ingestion = self._ingestion_for_branch(branch, "dlm-m2m-create-dependency")
+
+        with activate_branch(branch):
+            with event_tracking(self.request):
+                self.request.id = uuid.uuid4()
+                branch_cve = CVE.objects.get(pk=cve.pk)
+                branch_cve.description = "after"
+                branch_cve.save(update_fields=["description"])
+            with event_tracking(self.request):
+                self.request.id = uuid.uuid4()
+                software_version = SoftwareVersion.objects.create(
+                    platform=platform,
+                    version="1.0",
+                )
+                branch_cve = CVE.objects.get(pk=cve.pk)
+                branch_cve.affected_software.add(software_version)
+
+            self.assertTrue(
+                branch_cve.affected_software.filter(pk=software_version.pk).exists()
+            )
+
+        self.assertFalse(
+            SoftwareVersion.objects.filter(pk=software_version.pk).exists()
+        )
+
+        # This must succeed on the first call. Before the M2M dependency edge,
+        # UPDATE priority applied the CVE before the SoftwareVersion CREATE,
+        # failed its through-table FK, and only a second merge could converge.
+        merge_branch(ingestion, user=self.user)
+
+        self.assertTrue(
+            SoftwareVersion.objects.filter(pk=software_version.pk).exists()
+        )
+        cve.refresh_from_db()
+        self.assertEqual(cve.description, "after")
+        self.assertTrue(
+            cve.affected_software.filter(pk=software_version.pk).exists()
+        )
+        self.assertFalse(ingestion.issues.filter(phase="merge").exists())
+
+    def test_candidate_dependency_closing_a_multihop_cycle_is_rejected(self):
+        from forward_netbox.utilities.bulk_merge import _acyclic_delete_edges
+
+        dependent_key = ("test.dependent", 1)
+        target_key = ("test.target", 2)
+        intermediate_key = ("test.intermediate", 3)
+        tail_key = ("test.tail", 4)
+        collapsed_changes = {
+            dependent_key: Mock(depends_on=set()),
+            target_key: Mock(depends_on={intermediate_key}),
+            intermediate_key: Mock(depends_on={tail_key}),
+            tail_key: Mock(depends_on={dependent_key}),
+        }
+
+        accepted = _acyclic_delete_edges(
+            collapsed_changes,
+            [(dependent_key, target_key)],
+            self.logger,
+            edge_label="test",
+        )
+
+        self.assertEqual(accepted, [])
+
     def test_dlm_protected_version_delete_follows_destination_fk_reassignment(self):
         from django.apps import apps
         from netbox_branching.merge_strategies.squash import SquashMergeStrategy

--- a/forward_netbox/tests/test_bulk_merge.py
+++ b/forward_netbox/tests/test_bulk_merge.py
@@ -1115,14 +1115,10 @@ class BulkMergeIntegrationTest(CleanTransactionTestCase):
         # failed its through-table FK, and only a second merge could converge.
         merge_branch(ingestion, user=self.user)
 
-        self.assertTrue(
-            SoftwareVersion.objects.filter(pk=software_version.pk).exists()
-        )
+        self.assertTrue(SoftwareVersion.objects.filter(pk=software_version.pk).exists())
         cve.refresh_from_db()
         self.assertEqual(cve.description, "after")
-        self.assertTrue(
-            cve.affected_software.filter(pk=software_version.pk).exists()
-        )
+        self.assertTrue(cve.affected_software.filter(pk=software_version.pk).exists())
         self.assertFalse(ingestion.issues.filter(phase="merge").exists())
 
     def test_candidate_dependency_closing_a_multihop_cycle_is_rejected(self):

--- a/forward_netbox/utilities/bulk_merge.py
+++ b/forward_netbox/utilities/bulk_merge.py
@@ -1604,10 +1604,14 @@ def _acyclic_delete_edges(
     to deletes; `edge_label` only names the edge class in the warning.
     """
     nodes = {key for edge in candidate_edges for key in edge}
-    for key in list(nodes):
-        nodes.update(
-            dep for dep in collapsed_changes[key].depends_on if dep in collapsed_changes
-        )
+    pending = list(nodes)
+    while pending:
+        key = pending.pop()
+        for dependency in collapsed_changes[key].depends_on:
+            if dependency not in collapsed_changes or dependency in nodes:
+                continue
+            nodes.add(dependency)
+            pending.append(dependency)
     existing = {
         key: {
             dep
@@ -1645,8 +1649,8 @@ def _acyclic_delete_edges(
             return []
         change_logger.warning(
             "Bulk merge: dropped %d %s ordering edge(s) that would "
-            "have made the change graph unsortable; those rows stay mutually "
-            "protected and their deletes are reported rather than reordered.",
+            "have made the change graph unsortable; those changes retain "
+            "status-quo ordering and may be rejected individually instead.",
             len(accepted) - len(kept),
             edge_label,
         )
@@ -1654,6 +1658,80 @@ def _acyclic_delete_edges(
         if not accepted:
             return []
     return []
+
+
+def _add_m2m_create_dependencies(collapsed_changes, change_logger):
+    """Order branch-created M2M targets before changes that reference them.
+
+    Branching's dependency graph models scalar ForeignKey and GenericForeignKey
+    values, but not writable ManyToManyField values. An existing object's UPDATE
+    can therefore replay before a referenced target's CREATE and fail when the
+    M2M manager writes its through-table FK.
+
+    Only exact serialized ids which identify an in-merge CREATE are candidates.
+    Unknown shapes, absent targets, and non-CREATE targets retain existing
+    ordering. Every candidate is admitted through the shared acyclic-edge guard;
+    a relationship which would close a direct or transitive cycle is dropped.
+    """
+    candidate_edges = set()
+    for dependent_key, dependent in collapsed_changes.items():
+        if dependent.final_action not in {ActionType.CREATE, ActionType.UPDATE}:
+            continue
+        postchange_data = getattr(dependent, "postchange_data", None) or {}
+        if not isinstance(postchange_data, dict) or not postchange_data:
+            continue
+        model_class = getattr(dependent, "model_class", None)
+        model_meta = getattr(model_class, "_meta", None)
+        if model_meta is None:
+            continue
+        for field in model_meta.get_fields():
+            if not isinstance(field, models.ManyToManyField):
+                continue
+            if field.name not in postchange_data:
+                continue
+            serialized_values = postchange_data.get(field.name)
+            if not isinstance(serialized_values, (list, tuple, set)):
+                continue
+            target_label = field.related_model._meta.label_lower
+            for serialized_value in serialized_values:
+                target_pk = _serialized_fk_id(serialized_value)
+                if target_pk in (None, "") or isinstance(target_pk, bool):
+                    continue
+                try:
+                    hash(target_pk)
+                except TypeError:
+                    continue
+                target_key = (target_label, target_pk)
+                target = collapsed_changes.get(target_key)
+                if target is None or target.final_action != ActionType.CREATE:
+                    continue
+                if target_key in dependent.depends_on:
+                    continue
+                candidate_edges.add((dependent_key, target_key))
+
+    if not candidate_edges:
+        return 0
+    accepted = _acyclic_delete_edges(
+        collapsed_changes,
+        sorted(candidate_edges, key=repr),
+        change_logger,
+        edge_label="M2M CREATE-reference",
+    )
+    added = 0
+    for dependent_key, target_key in accepted:
+        dependent = collapsed_changes[dependent_key]
+        if target_key in dependent.depends_on:
+            continue
+        dependent.depends_on.add(target_key)
+        collapsed_changes[target_key].depended_by.add(dependent_key)
+        added += 1
+    if added:
+        change_logger.debug(
+            "Ordered %d writable M2M reference(s) after their branch-created "
+            "targets.",
+            added,
+        )
+    return added
 
 
 def _add_protected_child_delete_dependencies(collapsed_changes, change_logger):
@@ -1894,6 +1972,7 @@ def _order_collapsed_changes_fast(collapsed_changes, change_logger, operation):
         # receiver sees the completed graph.
         _add_destination_fk_release_dependencies(to_process, change_logger)
         _add_protected_child_delete_dependencies(to_process, change_logger)
+        _add_m2m_create_dependencies(to_process, change_logger)
         # UPDATE->UPDATE ordering, which the framework graph has no case for.
         _add_primary_ip_reassignment_release_dependencies(to_process, change_logger)
         _add_ip_adoption_dependencies(to_process, change_logger)


### PR DESCRIPTION
A customer's sync failed with ~10 `netbox_dlm.cve` IntegrityErrors on `netbox_dlm_cve_affec_softwareversion_id_…`, ending in `ForwardPartialMergeError`.

## Mechanism

The merge dependency graph models scalar foreign keys but **not many-to-many references**.

1. A CVE already in main collapses to `UPDATE`
2. A branch introduces a new `SoftwareVersion` as `CREATE`
3. The adapter adds that version to `cve.affected_software`
4. No edge exists between them, and `_ACTION_PRIORITY` runs `UPDATE` (1) before `CREATE` (2)
5. The CVE update calls `.set()` with a primary key that does not exist in main yet
6. The through-row insert violates the foreign key

The *next* merge succeeds, because the failed attempt had since created the row — which is exactly what made this look intermittent to the customer.

**Latent since v2.5.11, not a 2.7.0 regression.** The M2M population arrived in `6db0596`; the priority and the missing ordering are unchanged in 2.6.12. Rolling back would not have helped. The customer's DLM 0.6.0 upgrade was the occasion, not the cause — upstream leaves `CVE` and `affected_software` untouched.

Reproduced under an isolated stack with `netbox-dlm==0.6.0`: same model, exception, constraint name, and final `ForwardPartialMergeError`.

## The fix

General rather than CVE-specific — the defect is that M2M references are not modelled at all:

- writable forward M2M values add a `dependent → target CREATE` edge on an exact `(model label, primary key)` match in the same merge
- unknown, malformed, unhashable, absent or non-`CREATE` targets add **no** edge

An unresolvable value therefore keeps today's behaviour rather than guessing. A missing edge reproduces a known failure; a wrong edge risks a cycle.

## Cycle safety

Enforced at admission, in the highest-risk area of the codebase:

- candidate endpoints carry their full transitive dependency closure
- existing **plus** candidate edges must topologically sort *before* the graph is mutated
- self, mutual and multi-hop cycles are rejected; only accepted edges update `depends_on`/`depended_by`
- later custom dependency additions use the same guard and see admitted M2M edges

A rejected edge preserves the current row-level failure instead of reordering into a cycle. No global `CREATE`/`UPDATE` priority changed.

## Verification

```
Ran 5 tests    OK   regressions, including first-merge success
Ran 128 tests  OK   full test_bulk_merge + test_dlm_integration, netbox-dlm 0.6.0
Harness check passed
```

The regression proves main lacks the `SoftwareVersion` before a single `merge_branch()` call, then asserts that same call creates it and writes the CVE M2M relation. **First-merge success is the assertion that matters** — today the second merge passes, which is what disguised this as flakiness. No existing tests were weakened or removed.

An initial full run surfaced two synthetic objects lacking serialized change metadata; those now take the fail-safe add-no-edge path, and the complete modules were re-run to the green result above.

## Review note

This is merge-path code. The diff deserves a careful read rather than a rubber stamp — particularly the cycle-admission logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j2nbNXj1sfguLKeMvbmzK