### PR TITLE
fix: let an ingestion take its own reconciliation rows with it

### DIFF
--- a/docs/03_Plans/active/2026-08-03-reconciliation-cascades-with-its-ingestion.md
+++ b/docs/03_Plans/active/2026-08-03-reconciliation-cascades-with-its-ingestion.md
@@ -1,0 +1,146 @@
+# Reconciliation Cascades With Its Ingestion
+
+## Goal
+
+Make an ingestion held only by ownership reconciliation rows deletable, so the
+refusal message stops instructing an action the product does not offer.
+
+## Contract
+
+- An ingestion whose only remaining references are `ForwardOwnershipReconciliation`
+  rows deletes, and those rows go with it.
+- The ingestion whose reconciliation currently proves ownership complete for its
+  sync is refused, as an expected warning, naming a step the operator can take.
+- The baseline ingestion is still refused, with the baseline message.
+- Device identities, device tag claims and virtual parent claims still protect.
+
+## Constraints
+
+- Schema change on live customer data; the migration must be reversible.
+- Baseline protection must not be weakened.
+- Ownership state must not be silently lost. A wrong refusal is a support
+  question; a wrong delete is unrecoverable.
+
+## Touched Surfaces
+
+- `forward_netbox/models.py` - `ForwardOwnershipReconciliation.ingestion`
+  overrides the mixin field to CASCADE
+- `forward_netbox/migrations/0047_ownership_reconciliation_cascade.py` - new,
+  `fake_on_branch = True` like every ownership control-plane migration
+- `forward_netbox/views.py` - new `_ingestion_holds_current_ownership`, checked
+  first in `_ingestion_delete_refusal_detail`
+- `forward_netbox/utilities/bulk_merge.py` - corrected docstring
+- `forward_netbox/tests/test_ingestion_delete.py`,
+  `forward_netbox/tests/test_protecting_relations.py`
+- This plan.
+
+## Approach
+
+2.7.0 made the refusal honest: it named every PROTECT reference instead of only
+the baseline. That exposed the real defect. The message named
+`ForwardOwnershipReconciliation`, and nothing in the product deletes those rows -
+no UI, no API (the ingestion viewset is read-only), no management command. The
+operator was told to remove records they could not reach.
+
+**Correction to the diagnosis this work started from.** Reconciliation rows do
+not accrue per ingestion. `Meta.constraints` makes them unique per
+`(sync, domain)` and every writer is `update_or_create`, so a sync holds at most
+three, and they re-point. Verified in `utilities/ownership.py`: `_mark_reconciled`,
+`_mark_ownership_pending_locked`, and the virtual-parent path all rewrite
+`ingestion_id` in place. The three sibling provenance models re-point too
+(`finalize_device_identities_locked`, `reconcile_source_device_tag_claims`,
+`reconcile_virtual_parent_claims`), so the general shape is "the newest ingestion
+holds everything".
+
+What actually pins an *old* ingestion is narrower and worse. A row re-points only
+when its own domain reconciles again. A domain that stops running - scope tags
+switched off, virtual parents disabled - freezes its row on the ingestion where
+it last ran and pins that ingestion forever. And `required_ownership_domains`
+treats the existence of a row as proof the domain is still required, so the same
+frozen row also holds ownership permanently incomplete. One row, two dead ends,
+and no way to remove it. Cascading clears both at once.
+
+**Why only this one of the four.** `ForwardDeviceIdentity`, `ForwardDeviceTagClaim`
+and `ForwardVirtualParentClaim` each describe a live NetBox object that outlives
+any single ingestion, and their provenance is the record of which ingestion last
+asserted it. A reconciliation row describes no NetBox object: it says only "this
+sync finished this domain at this ingestion", which is a statement about nothing
+once the ingestion is gone, and which nothing can repair afterwards.
+
+**The risk, and where it is handled.** With CASCADE alone, a sync with no virtual
+parents could have its ingestion held *only* by reconciliation rows - and
+deleting it would discard the proof that ownership converged, regressing the sync
+to Incomplete. The database cannot express "protect only the newest", so
+`_ingestion_holds_current_ownership` refuses that one explicitly, defined as
+`ownership_generation_complete(sync, ingestion.pk)` rather than as anything
+invented here: a COMPLETED row at this generation for every domain
+`required_ownership_domains` names. `required_ownership_domains` always appends
+STATUS_TAGS, so the required set is never empty and the check can never refuse
+every ingestion; one row per `(sync, domain)` means at most one ingestion per
+sync satisfies it. The refusal is a wait, not a wall - it lifts as soon as a
+newer ingestion reconciles, which is what the message tells the operator to do,
+and a test asserts that actually happens.
+
+Deleting an ingestion that holds a *stale* row is safe by the same definition:
+`_domain_is_current` already requires the reconciled generation to equal the
+latest baseline generation, so such a sync is not current before the delete
+either. It cannot regress something already false, and it releases the frozen
+row that was keeping the domain required.
+
+An unprovable check refuses. `_ingestion_holds_current_ownership` returns True if
+it raises, inverting the house rule for diagnostics, because here a failed check
+that permits the delete destroys evidence no reverse migration can restore.
+
+## What This Deliberately Does Not Do
+
+- **The three sibling PROTECT relations stay.** They are the reason the customer's
+  newest ingestion is usually undeletable anyway (one identity per synced device),
+  and this change does not make that ingestion deletable. It makes the *stale*
+  ones deletable and replaces an impossible instruction with a possible one.
+- **No new way to delete reconciliation rows by hand.** Adding a UI or command for
+  ownership evidence is a larger decision about who may discard convergence state.
+  Cascading with the parent needs no new authority.
+- **`ForwardContributorBaseline` is untouched**, so the baseline ingestion remains
+  undeletable and reports the baseline message even when it also holds current
+  ownership evidence - the baseline branch is checked first.
+- **A PENDING reconciliation row does not protect.** Only COMPLETED evidence is
+  worth refusing for; a pending row would otherwise pin exactly as before. If an
+  operator deletes an ingestion while its post-merge ownership work is still in
+  flight, that work's marker goes with it and the next sync re-creates it. Not
+  defended further: such an ingestion is in practice still held by its device
+  identities.
+
+## Validation
+
+- `forward_netbox.tests.test_ingestion_delete` and
+  `forward_netbox.tests.test_protecting_relations`: the four bar cases, plus one
+  asserting the refusal lifts once a newer ingestion reconciles, plus one pinning
+  the CASCADE/PROTECT split across the four provenance models so a future edit to
+  the shared mixin cannot take the other three with it.
+- `forward_netbox.tests.test_ownership` for the ownership control plane.
+- `invoke harness-check`.
+
+## Rollback
+
+Revert, then reverse migration 0047 to restore PROTECT. Rows cascaded away while
+0047 was applied are not recoverable, which is the intent of applying it; nothing
+else in the schema changes.
+
+## Decision Log
+
+- 2026-08-03: Verified the starting diagnosis before acting on it and corrected
+  it. The rows do re-point; the pin is a domain that stops reconciling. The fix
+  is unchanged, the reasoning for it is not.
+- 2026-08-03: Put the newest-completed guard at the delete path rather than in
+  the model, because it is a policy about one row that the database has no way
+  to name.
+- 2026-08-03: Left the three sibling PROTECT relations alone. Only one of the
+  four models is meaningless without its ingestion.
+
+## Open
+
+- The newest ingestion of an actively syncing sync remains undeletable via
+  `ForwardDeviceIdentity` (one row per synced device). That is intended -
+  identities are live-object provenance - but the refusal for it reads as an
+  error rather than as the expected "this is the current ingestion". Worth
+  revisiting if the customer reports it.

--- a/forward_netbox/migrations/0047_ownership_reconciliation_cascade.py
+++ b/forward_netbox/migrations/0047_ownership_reconciliation_cascade.py
@@ -1,0 +1,42 @@
+import django.db.models.deletion
+from django.db import migrations
+from django.db import models
+
+
+# Ownership is a main-schema control plane. Branch schemas must never receive
+# independent claim constraints or foreign keys.
+fake_on_branch = True
+
+
+class Migration(migrations.Migration):
+    """Let an ingestion take its own reconciliation rows with it.
+
+    `ForwardOwnershipReconciliation.ingestion` was PROTECT, like the three
+    sibling provenance models. Those three describe live NetBox objects and must
+    outlive an ingestion; a reconciliation row describes only "this sync
+    finished this domain at this ingestion" and means nothing without it. No UI,
+    API, or management command deletes these rows, so the protection refused a
+    delete while naming records the operator had no way to remove.
+
+    Reversible: the reverse restores PROTECT. It can fail only if an ingestion
+    was deleted while this migration was applied and its rows went with it -
+    which is the point of applying it - and no reverse can resurrect those rows.
+    Nothing else in the schema changes, so downgrading is otherwise safe.
+    """
+
+    dependencies = [
+        ("forward_netbox", "0046_alter_forwardnqemap_netbox_model"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="forwardownershipreconciliation",
+            name="ingestion",
+            field=models.ForeignKey(
+                db_column="generation",
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="+",
+                to="forward_netbox.forwardingestion",
+            ),
+        ),
+    ]

--- a/forward_netbox/models.py
+++ b/forward_netbox/models.py
@@ -1370,7 +1370,12 @@ class ForwardPreservedDeviceTagAssignment(ForwardPluginModelDocsMixin, models.Mo
 
 
 class ForwardIngestionProvenanceMixin(models.Model):
-    """Protected ownership evidence tied to one exact merged ingestion."""
+    """Protected ownership evidence tied to one exact merged ingestion.
+
+    `ForwardOwnershipReconciliation` overrides ``ingestion`` to cascade; it is a
+    child record of the ingestion rather than evidence held against it. See that
+    model for why.
+    """
 
     ingestion = models.ForeignKey(
         ForwardIngestion,
@@ -1567,7 +1572,40 @@ class ForwardOwnershipReconciliation(
     ForwardIngestionProvenanceMixin,
     ForwardPluginModelDocsMixin,
 ):
-    """Latest baseline generation reconciled for one ownership domain."""
+    """Latest baseline generation reconciled for one ownership domain.
+
+    Unlike its three sibling provenance models, this one cascades with the
+    ingestion it names rather than protecting it. Those three describe a live
+    NetBox object - a device identity, a tag assignment, a virtual parent - so
+    they outlive any single ingestion and must keep their provenance intact.
+    A reconciliation row describes no NetBox object at all: it records only
+    that this sync finished this domain at this exact ingestion. Once that
+    ingestion is gone the row is a statement about nothing, and it can never be
+    repaired, because the only thing that rewrites it is the next reconciliation
+    of the same domain.
+
+    Holding it as PROTECT made a sequence of ingestions permanently undeletable
+    with no supported way out: no UI, API, or command deletes these rows, so the
+    refusal named records an operator could not reach. Two conditions produce
+    that. The row re-points only when its domain reconciles again, so a domain
+    that stops running - scope tags switched off, virtual parents disabled -
+    freezes its row on an old ingestion and pins it forever. And because
+    `required_ownership_domains` treats the row's existence as proof the domain
+    is required, that same frozen row also keeps ownership permanently
+    incomplete. Cascading clears both together.
+
+    What must not be lost is the *current* evidence: the ingestion whose rows
+    prove ownership complete right now. The database cannot express "protect
+    only the newest", so that one is refused explicitly at the delete path
+    instead - see `_ingestion_delete_refusal_detail`.
+    """
+
+    ingestion = models.ForeignKey(
+        ForwardIngestion,
+        db_column="generation",
+        on_delete=models.CASCADE,
+        related_name="+",
+    )
 
     class Domain(models.TextChoices):
         SCOPE_TAGS = "scope_tags", _("Managed scope tags")

--- a/forward_netbox/tests/test_ingestion_delete.py
+++ b/forward_netbox/tests/test_ingestion_delete.py
@@ -22,6 +22,7 @@ from forward_netbox.models import ForwardSource
 from forward_netbox.models import ForwardSync
 from forward_netbox.utilities.forward_api import LATEST_PROCESSED_SNAPSHOT
 from forward_netbox.views import _ingestion_delete_refusal
+from forward_netbox.views import _ingestion_delete_refusal_detail
 
 
 class IngestionDeleteRouteTest(TestCase):
@@ -209,3 +210,242 @@ class BaselineDeleteRefusesOnConfirmationTest(TestCase):
             response = client.get(url)
 
         self.assertEqual(response.status_code, 200)
+
+
+class ReconciliationNoLongerPinsAnIngestionTest(TestCase):
+    """Reconciliation rows are children of an ingestion, not a lock on it.
+
+    On 2.7.0 the refusal became honest and named every PROTECT reference, which
+    exposed the real problem: it named `ForwardOwnershipReconciliation`, and no
+    UI, API, or management command can delete those rows. The message asked for
+    an action the product does not offer, so the ingestion was undeletable
+    forever.
+
+    A reconciliation row records only "this sync finished this domain at this
+    ingestion". It re-points when its domain reconciles again — but a domain
+    that stops running freezes its row on an old ingestion, and
+    `required_ownership_domains` then treats that frozen row as proof the domain
+    is still required, so the same row also keeps ownership permanently
+    incomplete. Cascading clears both.
+    """
+
+    def setUp(self):
+        self.source = ForwardSource.objects.create(
+            name="cascade-source",
+            type="saas",
+            url="https://fwd.example.invalid",
+            parameters={"network_id": "net-cascade"},
+        )
+        self.sync = ForwardSync.objects.create(
+            name="cascade-sync",
+            source=self.source,
+            parameters={"snapshot_id": LATEST_PROCESSED_SNAPSHOT},
+        )
+        self.older = ForwardIngestion.objects.create(
+            sync=self.sync,
+            snapshot_id="snapshot-older",
+            baseline_ready=True,
+        )
+        self.newer = ForwardIngestion.objects.create(
+            sync=self.sync,
+            snapshot_id="snapshot-newer",
+            baseline_ready=True,
+        )
+
+    def _reconcile(self, ingestion, domain, status=None):
+        from forward_netbox.models import ForwardOwnershipReconciliation
+
+        return ForwardOwnershipReconciliation.objects.update_or_create(
+            sync=self.sync,
+            domain=domain,
+            defaults={
+                "ingestion_id": ingestion.pk,
+                "snapshot_id": ingestion.snapshot_id,
+                "status": status or ForwardOwnershipReconciliation.Status.COMPLETED,
+            },
+        )[0]
+
+    def test_the_reconciliation_fk_cascades_and_its_siblings_still_protect(self):
+        # The whole fix rests on exactly one of the four provenance models
+        # cascading. Pin that split so a future edit to the shared mixin cannot
+        # quietly take the other three with it — those describe live NetBox
+        # rows and must keep protecting their provenance.
+        from django.db import models as django_models
+
+        from forward_netbox.models import ForwardDeviceIdentity
+        from forward_netbox.models import ForwardDeviceTagClaim
+        from forward_netbox.models import ForwardOwnershipReconciliation
+        from forward_netbox.models import ForwardVirtualParentClaim
+
+        self.assertIs(
+            ForwardOwnershipReconciliation._meta.get_field(
+                "ingestion"
+            ).remote_field.on_delete,
+            django_models.CASCADE,
+        )
+        for model in (
+            ForwardDeviceIdentity,
+            ForwardDeviceTagClaim,
+            ForwardVirtualParentClaim,
+        ):
+            with self.subTest(model=model._meta.label):
+                self.assertIs(
+                    model._meta.get_field("ingestion").remote_field.on_delete,
+                    django_models.PROTECT,
+                )
+
+    def test_an_ingestion_held_only_by_reconciliation_rows_is_deletable(self):
+        # The customer's shape: a domain reconciled at an old ingestion and
+        # never again, so its row froze there and pinned it.
+        from forward_netbox.models import ForwardOwnershipReconciliation
+
+        stale = self._reconcile(
+            self.older,
+            ForwardOwnershipReconciliation.Domain.VIRTUAL_PARENTS,
+        )
+        self._reconcile(
+            self.newer,
+            ForwardOwnershipReconciliation.Domain.STATUS_TAGS,
+        )
+
+        self.assertEqual(_ingestion_delete_refusal(self.older), "")
+
+        self.older.delete()
+
+        self.assertFalse(ForwardIngestion.objects.filter(pk=self.older.pk).exists())
+        self.assertFalse(
+            ForwardOwnershipReconciliation.objects.filter(pk=stale.pk).exists(),
+            "the reconciliation row must go with the ingestion it describes",
+        )
+
+    def test_the_newest_completed_ingestion_is_refused_and_says_why(self):
+        # Cascading alone would let an operator delete the evidence that
+        # ownership has converged and regress the sync to Incomplete. That is
+        # the one case the database can no longer refuse for us.
+        from forward_netbox.models import ForwardOwnershipReconciliation
+
+        for domain in (
+            ForwardOwnershipReconciliation.Domain.STATUS_TAGS,
+            ForwardOwnershipReconciliation.Domain.VIRTUAL_PARENTS,
+        ):
+            self._reconcile(self.newer, domain)
+
+        refusal, expected = _ingestion_delete_refusal_detail(self.newer)
+
+        self.assertTrue(refusal)
+        self.assertIn("ownership reconciliation is currently complete", refusal)
+        # Names an action the product actually offers, which is precisely what
+        # the old "remove them first" message did not.
+        self.assertIn("Run the sync again", refusal)
+        self.assertTrue(expected, "an intact ownership record is not a fault")
+
+    def test_a_pending_reconciliation_does_not_make_an_ingestion_current(self):
+        # Only COMPLETED evidence is worth protecting; a pending row is a note
+        # that work is outstanding, and it would otherwise pin forever.
+        from forward_netbox.models import ForwardOwnershipReconciliation
+
+        self._reconcile(
+            self.newer,
+            ForwardOwnershipReconciliation.Domain.STATUS_TAGS,
+            status=ForwardOwnershipReconciliation.Status.PENDING,
+        )
+
+        self.assertEqual(_ingestion_delete_refusal(self.newer), "")
+
+    def test_the_refusal_lifts_once_a_newer_ingestion_reconciles(self):
+        # The refusal must be a wait, not a wall: what the message promises has
+        # to actually happen.
+        from forward_netbox.models import ForwardOwnershipReconciliation
+
+        domains = (
+            ForwardOwnershipReconciliation.Domain.STATUS_TAGS,
+            ForwardOwnershipReconciliation.Domain.VIRTUAL_PARENTS,
+        )
+        for domain in domains:
+            self._reconcile(self.older, domain)
+        self.assertTrue(_ingestion_delete_refusal(self.older))
+
+        for domain in domains:
+            self._reconcile(self.newer, domain)
+
+        self.assertEqual(_ingestion_delete_refusal(self.older), "")
+        self.older.delete()
+        self.assertFalse(ForwardIngestion.objects.filter(pk=self.older.pk).exists())
+        self.assertEqual(
+            ForwardOwnershipReconciliation.objects.filter(sync=self.sync).count(),
+            len(domains),
+            "the surviving rows belong to the newer ingestion and must remain",
+        )
+
+    def test_virtual_parent_claims_still_pin_their_ingestion(self):
+        # Unchanged on purpose: a claim describes a live NetBox device, so its
+        # provenance must survive.
+        from dcim.models import Device
+        from dcim.models import DeviceRole
+        from dcim.models import DeviceType
+        from dcim.models import Manufacturer
+        from dcim.models import Site
+        from django.db.models.deletion import ProtectedError
+
+        from forward_netbox.models import ForwardVirtualParentClaim
+
+        manufacturer = Manufacturer.objects.create(
+            name="Cascade Manufacturer", slug="cascade-manufacturer"
+        )
+        device_type = DeviceType.objects.create(
+            manufacturer=manufacturer, model="Cascade Model", slug="cascade-model"
+        )
+        role = DeviceRole.objects.create(name="Cascade Role", slug="cascade-role")
+        site = Site.objects.create(name="Cascade Site", slug="cascade-site")
+        child = Device.objects.create(
+            name="cascade-child", device_type=device_type, role=role, site=site
+        )
+        parent = Device.objects.create(
+            name="cascade-parent", device_type=device_type, role=role, site=site
+        )
+        ForwardVirtualParentClaim.objects.create(
+            sync=self.sync,
+            device=child,
+            parent_device=parent,
+            ingestion=self.newer,
+            snapshot_id=self.newer.snapshot_id,
+        )
+
+        refusal, expected = _ingestion_delete_refusal_detail(self.newer)
+
+        self.assertIn("ForwardVirtualParentClaim", refusal)
+        self.assertFalse(expected)
+        with self.assertRaises(ProtectedError):
+            self.newer.delete()
+
+    def test_the_baseline_ingestion_is_still_refused_and_still_protected(self):
+        # The baseline protection must not be weakened by any of this, and its
+        # message must stay the baseline one even when the ingestion also holds
+        # current ownership evidence.
+        from django.db.models.deletion import ProtectedError
+
+        from forward_netbox.models import ForwardContributorBaseline
+        from forward_netbox.models import ForwardOwnershipReconciliation
+
+        for domain in (
+            ForwardOwnershipReconciliation.Domain.STATUS_TAGS,
+            ForwardOwnershipReconciliation.Domain.VIRTUAL_PARENTS,
+        ):
+            self._reconcile(self.newer, domain)
+        ForwardContributorBaseline.objects.create(
+            sync=self.sync,
+            ingestion=self.newer,
+            snapshot_id=self.newer.snapshot_id,
+            network_fingerprint="nf",
+            map_set_fingerprint="mf",
+            scope_config_fingerprint="cf",
+            scope_membership_fingerprint="sf",
+            scope_payload_checksum="pc",
+        )
+
+        refusal, expected = _ingestion_delete_refusal_detail(self.newer)
+
+        self.assertIn("is the baseline for this sync", refusal)
+        self.assertTrue(expected)
+        with self.assertRaises(ProtectedError):
+            self.newer.delete()

--- a/forward_netbox/tests/test_ownership.py
+++ b/forward_netbox/tests/test_ownership.py
@@ -121,6 +121,11 @@ class OwnershipControlPlaneTest(TestCase):
                 "forward_netbox.migrations.0036_protect_ownership_provenance"
             ).fake_on_branch
         )
+        self.assertTrue(
+            importlib.import_module(
+                "forward_netbox.migrations.0047_ownership_reconciliation_cascade"
+            ).fake_on_branch
+        )
 
     def test_generation_claim_materializes_and_sync_delete_releases(self):
         result = reconcile_sync_scope_tag_claims(

--- a/forward_netbox/tests/test_protecting_relations.py
+++ b/forward_netbox/tests/test_protecting_relations.py
@@ -21,10 +21,18 @@ from forward_netbox.utilities.bulk_merge import protecting_relations
 
 
 class ProtectingRelationsSeesHiddenRelationsTest(TestCase):
+    # `ForwardOwnershipReconciliation` was the fourth entry here. It now
+    # cascades: it is a child record of the ingestion rather than evidence held
+    # against it, and holding it as PROTECT made ingestions undeletable while
+    # naming rows no supported action could remove. It is still hidden, so it
+    # still belongs in HIDDEN_MODELS below — discovery must keep seeing it, it
+    # just must not be reported as protecting.
     OWNERSHIP_MODELS = {
         "forward_netbox.ForwardDeviceIdentity",
         "forward_netbox.ForwardDeviceTagClaim",
         "forward_netbox.ForwardVirtualParentClaim",
+    }
+    HIDDEN_MODELS = OWNERSHIP_MODELS | {
         "forward_netbox.ForwardOwnershipReconciliation",
     }
 
@@ -60,6 +68,18 @@ class ProtectingRelationsSeesHiddenRelationsTest(TestCase):
                     (models.PROTECT, models.RESTRICT),
                 )
 
+    def test_reconciliation_is_not_reported_as_protecting(self):
+        # A reconciliation row records only that a sync finished a domain at an
+        # ingestion, so it means nothing once that ingestion is gone and it
+        # cascades. Reporting it would refuse a delete the database allows —
+        # and name rows the operator has no supported way to remove, which is
+        # exactly the dead end this replaced.
+        found = {
+            relation.related_model._meta.label
+            for relation in protecting_relations(ForwardIngestion)
+        }
+        self.assertNotIn("forward_netbox.ForwardOwnershipReconciliation", found)
+
     def test_related_objects_alone_would_have_missed_them(self):
         # Pins the reason this helper exists. If a future Django release starts
         # including hidden relations in related_objects, this test fails and the
@@ -69,6 +89,6 @@ class ProtectingRelationsSeesHiddenRelationsTest(TestCase):
             for relation in ForwardIngestion._meta.related_objects
         }
         self.assertFalse(
-            self.OWNERSHIP_MODELS & visible,
+            self.HIDDEN_MODELS & visible,
             "related_objects now exposes hidden relations; revisit protecting_relations",
         )

--- a/forward_netbox/utilities/bulk_merge.py
+++ b/forward_netbox/utilities/bulk_merge.py
@@ -1400,10 +1400,12 @@ def protecting_relations(model_class):
     and Django calls those hidden. Reading protection from it therefore misses
     exactly the relations this plugin uses for ownership evidence:
     `ForwardIngestionProvenanceMixin` declares its ingestion FK as PROTECT with
-    ``related_name="+"``, so `ForwardDeviceIdentity`, `ForwardDeviceTagClaim`,
-    `ForwardVirtualParentClaim` and `ForwardOwnershipReconciliation` were all
-    invisible to protection checks while still refusing the delete in the
-    database.
+    ``related_name="+"``, so `ForwardDeviceIdentity`, `ForwardDeviceTagClaim`
+    and `ForwardVirtualParentClaim` were all invisible to protection checks
+    while still refusing the delete in the database. (The fourth,
+    `ForwardOwnershipReconciliation`, later became CASCADE - it is a child
+    record of the ingestion, not evidence held against it - so discovery still
+    sees it and correctly declines to report it.)
 
     That gap had two customer-visible faces. An ingestion held only by device
     identities reported no refusal at all, so the delete view rendered its wall

--- a/forward_netbox/views.py
+++ b/forward_netbox/views.py
@@ -2113,16 +2113,47 @@ class ForwardIngestionIssuesView(generic.ObjectChildrenView):
 def _ingestion_delete_refusal(ingestion) -> str:
     """Why the database will refuse this delete, or "" when it will not.
 
-    Five relations to an ingestion are PROTECT, not one. `ForwardContributorBaseline`
-    holds durable convergence evidence, and the four ownership models carried by
-    `ForwardIngestionProvenanceMixin` hold identity and claim evidence. This
+    Four relations to an ingestion are PROTECT, not one. `ForwardContributorBaseline`
+    holds durable convergence evidence, and three of the four ownership models
+    carried by `ForwardIngestionProvenanceMixin` hold identity and claim
+    evidence. (The fourth, `ForwardOwnershipReconciliation`, cascades - see
+    `_ingestion_holds_current_ownership` for what guards it instead.) This
     docstring previously named only the baseline, and the check behind it could
-    only see the baseline, because the other four declare ``related_name="+"``
-    and Django hides those from `_meta.related_objects` — see
+    only see the baseline, because every provenance relation declares
+    ``related_name="+"`` and Django hides those from `_meta.related_objects` — see
     `protecting_relations`. Reporting all of them up front turns an unhandled
     `ProtectedError` into something an operator can act on.
     """
     return _ingestion_delete_refusal_detail(ingestion)[0]
+
+
+def _ingestion_holds_current_ownership(ingestion) -> bool:
+    """Whether this ingestion is the one proving ownership complete right now.
+
+    `ForwardOwnershipReconciliation` rows cascade with their ingestion, which is
+    what makes a stale ingestion deletable at all. That leaves one case the
+    database can no longer refuse on its own: a sync whose ingestion is held
+    *only* by reconciliation rows, where deleting it would discard the very
+    evidence that ownership has converged and silently regress the sync to
+    Incomplete. "Currently complete" is not a guess here - it is exactly
+    `ownership_generation_complete`, which requires a COMPLETED row at this
+    generation for every domain `required_ownership_domains` names. Since there
+    is one row per (sync, domain) and STATUS_TAGS is always required, at most
+    one ingestion per sync can satisfy it.
+
+    A check that cannot complete refuses. A wrong refusal costs a support
+    question; a wrong delete costs evidence that no reverse migration can bring
+    back.
+    """
+    from .utilities.ownership import ownership_generation_complete
+
+    sync = getattr(ingestion, "sync", None)
+    if sync is None or not ingestion.pk:
+        return False
+    try:
+        return bool(ownership_generation_complete(sync, ingestion.pk))
+    except Exception:  # noqa: BLE001 - unprovable safety is not safety
+        return True
 
 
 def _ingestion_delete_refusal_detail(ingestion) -> tuple[str, bool]:
@@ -2134,15 +2165,34 @@ def _ingestion_delete_refusal_detail(ingestion) -> tuple[str, bool]:
     baseline, the record of what has already converged, and NetBox protects it
     on purpose. Saying so plainly is the difference between a support ticket and
     a shrug.
+
+    Two refusals are expected rather than faults, and both name a way forward
+    that the product actually offers. The baseline is permanent. Current
+    ownership evidence is not: it moves to the next ingestion as soon as one
+    reconciles, so the answer is "sync again, then delete this" rather than
+    "remove these records", which was the instruction that had no supported
+    action behind it.
     """
     references = describe_protecting_references(type(ingestion), ingestion.pk)
+    baseline_reference = any(
+        "baseline" in str(label).casefold() for label, _count in references
+    )
+    if not baseline_reference and _ingestion_holds_current_ownership(ingestion):
+        return (
+            f"{ingestion} is the ingestion whose ownership reconciliation is "
+            "currently complete for this sync, so it is the record that proves "
+            "every ownership domain this sync reconciles - status tags, and "
+            "scope tags and virtual parents where enabled - has converged. "
+            "Deleting it would discard that proof and report this sync's "
+            "ownership as incomplete until a later ingestion reconciles. This "
+            "is expected, not a failure. Run the sync again; once a newer "
+            "ingestion has taken over the reconciliation, this one deletes "
+            "normally."
+        ), True
     if not references:
         return "", False
     held_by = ", ".join(f"{label} ({count})" for label, count in references)
-    baseline_held = any(
-        "baseline" in str(label).casefold() for label, _count in references
-    )
-    if baseline_held:
+    if baseline_reference:
         return (
             f"{ingestion} is the baseline for this sync - the durable record of "
             "what has already converged - so NetBox protects it from deletion. "


### PR DESCRIPTION
A customer cannot delete old ingestion logs. On 2.7.0 the refusal became honest — it names the holding models — but it instructs an action the product does not offer:

> …still referenced by `ForwardOwnershipReconciliation` (3), `ForwardVirtualParentClaim` (339). Those records are convergence evidence; **remove them first** if you genuinely intend to discard it.

Nothing in the UI, API, or any management command can remove them.

## Correction to the original diagnosis

This was briefed as "every ingestion permanently accrues ~3 reconciliation rows." **That is not what happens.** `ForwardOwnershipReconciliation` has `UniqueConstraint(sync, domain)` and every writer is `update_or_create`, so a sync holds at most three rows and they re-point like the other provenance models.

The real mechanism is narrower: a row re-points only when **its own domain** reconciles again. A domain that stops running — scope tags switched off, virtual parents disabled — freezes its row on the ingestion where it last ran and pins that one forever. And `required_ownership_domains` treats the row's existence as proof the domain is still required, so the same frozen row **also keeps ownership permanently Incomplete**. One row, two dead ends.

## The change

`ForwardOwnershipReconciliation.ingestion` becomes `CASCADE` — it is a child record of the ingestion, meaningless once it is gone. The other three provenance models stay `PROTECT`; they describe live NetBox objects. `ForwardContributorBaseline` is untouched.

Migration `0047` is reversible and `fake_on_branch = True`, matching every other ownership control-plane migration.

## The risk, handled

Cascading alone could let someone delete the ingestion whose reconciliation proves ownership is complete. So `_ingestion_delete_refusal_detail` now checks `_ingestion_holds_current_ownership` first — exactly `ownership_generation_complete(sync, ingestion.pk)`, not an invented definition.

- `required_ownership_domains` always appends `STATUS_TAGS`, so the required set is never empty and this can never refuse *every* ingestion
- one row per `(sync, domain)` means at most one ingestion per sync qualifies
- a check that raises **refuses**: a wrong refusal is a support question, a wrong delete is unrecoverable
- the baseline branch is evaluated first, so a baseline ingestion still gets the baseline message
- the message names a step that exists — "run the sync again" — replacing "remove them first"

Deleting a stale-row ingestion cannot regress anything: `_domain_is_current` already requires the reconciled generation to equal the latest baseline generation, so such a sync was not current beforehand either.

## Honest limitation

**This does not make the customer's newest ingestion deletable.** That one is typically also held by `ForwardDeviceIdentity` — one row per synced device, still `PROTECT` by design. What this fixes is the stale ones, and it replaces an impossible instruction with a possible one. Recorded in the plan's Open section rather than widening scope unasked.

## Verification

```
Ran 1864 tests   OK (skipped=4)    full suite
Ran 50 tests     OK                affected modules, final code
Harness check passed
makemigrations --check --dry-run → No changes detected
0047 applied → reversed to 0046 → re-applied, on a real database
```

Tests cover: reconciliation-only ingestion deletes and its row goes with it; newest completed ingestion refused with an explaining message; the refusal **lifts** once a newer ingestion reconciles, so the message's promise is real; virtual-parent and baseline ingestions still refused via `ProtectedError`; plus a guard pinning the CASCADE/PROTECT split so a future edit to the shared mixin cannot take the other three with it.

`test_protecting_relations.py` was deliberately updated — it asserted reconciliation was among the PROTECT relations. It now asserts the opposite with the reason, and still asserts reconciliation remains hidden from `_meta.related_objects`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j2nbNXj1sfguLKeMvbmzK