### PR TITLE
test: assert alias-variant coverage is complete and intentional

### DIFF
--- a/docs/03_Plans/active/2026-08-03-alias-variant-coverage-guard.md
+++ b/docs/03_Plans/active/2026-08-03-alias-variant-coverage-guard.md
@@ -1,0 +1,152 @@
+# Alias-Variant Coverage Guard
+
+## Goal
+
+Make the set of `*_with_netbox_aliases` query variants *provably* complete and
+intentional, so the 2.4.2 defect class — behaviour implemented in a base query
+and never ported to the variant operators actually run — fails a check instead
+of shipping as a silent omission.
+
+Prompted by a field report of `netbox_dlm.softwareversion` rows failing with
+`ForwardDependencySkipError` on every sync at a site running the alias variant
+of every device query, with the hypothesis that the two DLM platform maps needed
+alias variants of their own.
+
+## Contract
+
+- Every built-in base query that names a NetBox object the alias-aware device
+  query owns either ships a registered `*_with_netbox_aliases` variant, or is
+  listed as an exemption with a written reason.
+- Every registered alias variant resolves back to a base map *name*, so
+  `_collapse_alias_variant_duplicates` can supersede its base. A variant that
+  cannot be resolved would run alongside its base and flip the shared object
+  between two spellings on every sync.
+- Exemptions cannot rot: an exemption whose query file is gone, whose query no
+  longer names an alias-sensitive object, or which contradicts a variant that
+  has since been registered, fails the check.
+- No behavioural change to any shipped query. Nothing an operator has enabled
+  changes meaning.
+
+## Constraints
+
+- The local NQE validator binary is the wrong architecture and cannot
+  syntax-check query files, so a query change carries unusual risk. This work
+  therefore adds no query file.
+- `forward_netbox/utilities/` is a high-risk path; this plan accompanies the
+  diff.
+- No customer identifiers in code, tests, plans, or commit messages.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/query_registry.py` — the rule, the exemption table,
+  and `alias_variant_coverage_violations()`.
+- `forward_netbox/tests/test_query_registry.py` — coverage, including negative
+  cases that demonstrate the check failing.
+- This plan.
+
+## Approach
+
+**The rule.** A base query is *alias-sensitive* when it emits a row field naming
+an object the alias-aware device query creates (`device_type`,
+`device_type_slug`, `platform`, `platform_slug`), or when it *produces* one of
+those identities (`dcim.devicetype`, `dcim.platform`). Alias-sensitive base
+queries must have a variant or an exemption. Detection reads the shipped query
+source rather than a hand-maintained list, so a new map is classified by what it
+actually emits.
+
+**Why the two DLM platform maps are exemptions rather than new variants.** The
+reported hypothesis was that `forward_dlm_software_versions.nqe` and
+`forward_dlm_device_software.nqe` derive the platform with
+`normalizeDevicePlatformName(device)` — the un-aliased name — and so cannot match
+platforms created under alias-mapped names. Reading the queries does not support
+that:
+
+- `forward_devices_with_netbox_aliases.nqe:36` derives its platform with
+  `let platform_name = normalizeDevicePlatformName(device)` — character for
+  character what `forward_devices.nqe:32`, `forward_dlm_software_versions.nqe:21`,
+  `forward_dlm_device_software.nqe:20` and `forward_dlm_vulnerabilities.nqe:21`
+  use. The alias variant of the device query does not rename platforms.
+- The alias data file carries only `device_type_alias` and
+  `manufacturer_override` records (`scripts/build_netbox_device_type_aliases.py`).
+  There is no platform record type, so there is nothing for a platform-scoped
+  alias variant to map through.
+- `device_type` — the only alias-mapped identity — is emitted by exactly four
+  query files: the two device queries and the two hardware-notice queries. Both
+  base/variant pairs already exist. That is why 2.5.3 needed a hardware-notice
+  variant and why the same transformation has no counterpart here.
+
+An alias variant of either DLM platform map would therefore be semantically
+identical to its base: a catalogue entry an operator could enable expecting a
+fix, and get none, in a catalogue that already carries a consolidation backlog.
+The exemption table records that reasoning where the next person to ask the
+question will find it, and a test asserts the premise (the shared helper) still
+holds, so the exemption cannot quietly become wrong.
+
+`forward_dlm_inventory_item_software.nqe` is exempt for a different and simpler
+reason, recorded separately: it emits the hardcoded Platform `"CIMC"` that its
+own apply adapter creates.
+
+**What this does not do.** It does not explain the reported
+`ForwardDependencySkipError`. That diagnosis is still open and is recorded below
+rather than papered over with a no-op query.
+
+## Validation
+
+- `forward_netbox.tests.test_query_registry` — the check passes against the
+  shipped registry; two negative tests drive it with synthetic map sets and
+  assert it reports (a) an alias-sensitive base map with no variant and no
+  exemption, and (b) a variant whose display name resolves to no base map.
+- A test asserts every exemption is registered, has no variant, and carries a
+  reason of substance.
+- A test asserts the shared `normalizeDevicePlatformName(device)` expression is
+  present in the alias device query and in all three DLM platform maps, so the
+  exemptions' premise is checked rather than assumed.
+- `invoke harness-check`, `invoke harness-test`.
+
+## Rollback
+
+Revert. The change is a registry-level assertion plus tests; no query, adapter,
+or seeded map row changes, so nothing an operator has enabled behaves
+differently.
+
+## Decision Log
+
+- 2026-08-03: Did not add
+  `forward_dlm_software_versions_with_netbox_aliases.nqe` or
+  `forward_dlm_device_software_with_netbox_aliases.nqe`. Diffing the
+  hardware-notice pair shows the alias transformation is entirely
+  `device_type`/`device_type_slug`; neither DLM platform map emits either field,
+  and the platform value they do emit already matches the alias-aware device
+  query verbatim. The files would have been placebos for a live customer-facing
+  error.
+- 2026-08-03: Scoped the rule to *emitted identity fields* rather than to
+  "queries importing the alias data file". The latter would only ever recognise
+  maps that were already fixed — it cannot detect the gap it exists to detect.
+- 2026-08-03: Included `forward_dlm_vulnerabilities.nqe` in the exemption table.
+  It emits exactly the same platform identity as the two maps under discussion;
+  leaving it out would have made the table read as a list of two special cases
+  instead of a rule.
+- 2026-08-03: Added the variant-name resolution check alongside the coverage
+  check. `_collapse_alias_variant_duplicates` matches on display name, and the
+  one existing variant already needs a hand-written entry in
+  `_EXPLICIT_ALIAS_VARIANT_BASE_NAMES` because its name does not follow the
+  suffix convention. A second such variant added without that entry would cause
+  perpetual churn with no test failure.
+
+## Open
+
+- The reported `netbox_dlm.softwareversion` `ForwardDependencySkipError` is
+  **not** diagnosed. `_lookup_platform` fails only when no `dcim.Platform`
+  matches the emitted slug or name, and alias mapping is now ruled out as the
+  cause. One code-verifiable inconsistency found while looking, not yet tied to
+  the report and not changed here: `forward_platforms.nqe` — the sole producer
+  of `dcim.platform` — is the only query using `normalizePlatformName(os,
+  version)`, while every consumer uses `normalizeDevicePlatformName(device)`.
+  The latter additionally resolves APIC controllers and ACI devices from command
+  outputs, so a device whose ACI/APIC identity is only visible in its command
+  outputs is written by the device map under a platform name the platform map
+  never emits. Whether that can leave the lookup without a match depends on
+  prune behaviour and has not been established.
+- Next diagnostic step should be the failing rows' `platform` / `platform_slug`
+  values from the skip context against the site's `dcim.Platform` table, which
+  settles it in one comparison.

--- a/forward_netbox/tests/test_query_registry.py
+++ b/forward_netbox/tests/test_query_registry.py
@@ -13,6 +13,10 @@ from forward_netbox.utilities.query_execution_contract import query_source_sha25
 from forward_netbox.utilities.query_execution_contract import resolve_execution_contract
 from forward_netbox.utilities.query_registry import _collapse_alias_variant_duplicates
 from forward_netbox.utilities.query_registry import _query_contract_gap_remediation
+from forward_netbox.utilities.query_registry import alias_variant_coverage_violations
+from forward_netbox.utilities.query_registry import (
+    ALIAS_VARIANT_EXEMPT_QUERY_FILENAMES,
+)
 from forward_netbox.utilities.query_registry import builtin_nqe_map_rows
 from forward_netbox.utilities.query_registry import BUILTIN_OPTIONAL_QUERY_MAPS
 from forward_netbox.utilities.query_registry import builtin_query_contract_summary
@@ -2061,6 +2065,128 @@ select {name: "vendor", slug: "vendor"}
             "Forward Device Feature Tags with Rules",
             {query_default["name"] for query_default in BUILTIN_QUERY_MAPS},
         )
+
+    def test_alias_variant_coverage_is_complete_and_intentional(self):
+        """No alias-sensitive base map may ship without a variant or a reason."""
+        self.assertEqual(alias_variant_coverage_violations(), [])
+
+    def test_alias_variant_coverage_flags_a_missing_variant(self):
+        """The check fails when a base map that needs a variant lacks one.
+
+        Registering the alias-sensitive hardware-notice base map on its own --
+        exactly the state the catalogue was in before 2.5.3 -- must be reported,
+        not tolerated.
+        """
+        violations = alias_variant_coverage_violations(
+            [
+                {
+                    "model_string": "netbox_dlm.hardwarenotice",
+                    "name": "Forward DLM Hardware Notices",
+                    "filename": "forward_dlm_hardware_notices.nqe",
+                }
+            ]
+        )
+
+        self.assertTrue(
+            any(
+                "forward_dlm_hardware_notices.nqe" in violation
+                and "ALIAS_VARIANT_EXEMPT_QUERY_FILENAMES" in violation
+                for violation in violations
+            ),
+            violations,
+        )
+
+    def test_alias_variant_coverage_flags_an_unresolvable_variant_name(self):
+        """A variant whose display name has no base map would double-apply.
+
+        ``_collapse_alias_variant_duplicates`` supersedes a base map by name. A
+        variant named outside the " with NetBox Device Type Aliases" convention
+        and missing from _EXPLICIT_ALIAS_VARIANT_BASE_NAMES silently runs
+        alongside its base and flips the shared object every sync.
+        """
+        violations = alias_variant_coverage_violations(
+            [
+                {
+                    "model_string": "netbox_dlm.hardwarenotice",
+                    "name": "Forward DLM Hardware Notices",
+                    "filename": "forward_dlm_hardware_notices.nqe",
+                },
+                {
+                    "model_string": "netbox_dlm.hardwarenotice",
+                    "name": "Forward DLM Hardware Notices (aliased)",
+                    "filename": (
+                        "forward_dlm_hardware_notices_with_netbox_aliases.nqe"
+                    ),
+                },
+            ]
+        )
+
+        self.assertTrue(
+            any(
+                "does not resolve to a registered base map name" in violation
+                for violation in violations
+            ),
+            violations,
+        )
+
+    def test_alias_variant_exemptions_are_live_and_reasoned(self):
+        registered = {
+            query_default["filename"]
+            for query_default in BUILTIN_QUERY_MAPS + BUILTIN_OPTIONAL_QUERY_MAPS
+        }
+
+        self.assertTrue(ALIAS_VARIANT_EXEMPT_QUERY_FILENAMES)
+        for filename, reason in ALIAS_VARIANT_EXEMPT_QUERY_FILENAMES.items():
+            self.assertIn(filename, registered)
+            self.assertNotIn(
+                filename.removesuffix(".nqe") + "_with_netbox_aliases.nqe",
+                registered,
+            )
+            # A reason has to explain, not label.
+            self.assertGreater(len(reason.split()), 12, filename)
+
+        # The CIMC firmware map is exempt by design, not by oversight: it emits
+        # a hardcoded Platform its own adapter creates.
+        self.assertIn(
+            "forward_dlm_inventory_item_software.nqe",
+            ALIAS_VARIANT_EXEMPT_QUERY_FILENAMES,
+        )
+        self.assertIn(
+            "CIMC",
+            ALIAS_VARIANT_EXEMPT_QUERY_FILENAMES[
+                "forward_dlm_inventory_item_software.nqe"
+            ],
+        )
+
+    def test_dlm_platform_maps_match_the_alias_device_query_verbatim(self):
+        """Why the DLM platform maps need no alias variant, asserted not assumed.
+
+        The alias-aware device query creates the Platform rows these maps look
+        up, and it derives the platform name with the same shared helper as the
+        base device query. If that ever diverges, the exemptions above stop
+        being true and this test says so.
+        """
+        alias_device_query = read_builtin_query_source(
+            "forward_devices_with_netbox_aliases.nqe"
+        )
+        base_device_query = read_builtin_query_source("forward_devices.nqe")
+        platform_expression = "let platform_name = normalizeDevicePlatformName(device)"
+
+        self.assertIn(platform_expression, alias_device_query)
+        self.assertIn(platform_expression, base_device_query)
+        # The alias data file has no platform record type to map through.
+        self.assertNotIn("platform_alias", alias_device_query)
+
+        for filename in (
+            "forward_dlm_software_versions.nqe",
+            "forward_dlm_device_software.nqe",
+            "forward_dlm_vulnerabilities.nqe",
+        ):
+            self.assertIn(
+                platform_expression,
+                read_builtin_query_source(filename),
+                filename,
+            )
 
     def test_optional_module_maps_are_seeded_enabled(self):
         rows = {

--- a/forward_netbox/utilities/query_registry.py
+++ b/forward_netbox/utilities/query_registry.py
@@ -1706,6 +1706,171 @@ def _collapse_alias_variant_duplicates(builtin_maps):
     ]
 
 
+# --- Alias-variant coverage -------------------------------------------------
+#
+# Recurrence guard for the 2.4.2 defect class: behavior added to a base query and
+# never ported to the variant operators actually run. A base query that resolves
+# (or produces) a NetBox identity the alias-aware device query owns must either
+# ship its own ``*_with_netbox_aliases`` variant or say, in writing, why it does
+# not. Silence is the failure mode we are removing.
+
+# Row fields naming an object the alias-aware device query created. A query
+# emitting one of these has to spell that object exactly as the device query did,
+# or its dependency lookup misses and every row is skipped.
+_ALIAS_SENSITIVE_IDENTITY_FIELDS = (
+    "device_type",
+    "device_type_slug",
+    "platform",
+    "platform_slug",
+)
+# Maps that *produce* one of those identities rather than resolving it: whatever
+# spelling they write is the spelling every consumer must reproduce, so they are
+# candidates for the same reason.
+_ALIAS_SENSITIVE_IDENTITY_MODELS = ("dcim.devicetype", "dcim.platform")
+
+# Base queries that are alias-sensitive by the rule above and deliberately have
+# no alias variant. Each entry records the reason; an unexplained omission is a
+# check failure, not a default.
+ALIAS_VARIANT_EXEMPT_QUERY_FILENAMES = {
+    "forward_platforms.nqe": (
+        "Produces dcim.platform. The netbox_device_type_aliases data file "
+        "carries only `device_type_alias` and `manufacturer_override` records "
+        "-- there is no platform record type -- so an alias variant would have "
+        "nothing to map. Platform naming is instead kept consistent by every "
+        "device-scoped query using the shared normalizeDevicePlatformName "
+        "helper."
+    ),
+    "forward_dlm_software_versions.nqe": (
+        "Resolves dcim.platform, not dcim.devicetype. Its platform value comes "
+        "from normalizeDevicePlatformName(device), which is verbatim what "
+        "forward_devices_with_netbox_aliases.nqe writes -- the alias variant of "
+        "the device query does not rename platforms. An alias variant would be "
+        "semantically identical to this file, so it would add a catalogue entry "
+        "an operator could enable expecting a fix and get none."
+    ),
+    "forward_dlm_device_software.nqe": (
+        "Resolves dcim.device and dcim.platform. Same reasoning as "
+        "forward_dlm_software_versions.nqe: device names are never aliased and "
+        "the platform value already matches the alias-aware device query "
+        "verbatim."
+    ),
+    "forward_dlm_vulnerabilities.nqe": (
+        "Resolves dcim.device and dcim.platform via the same "
+        "normalizeDevicePlatformName(device) value as the alias-aware device "
+        "query. Nothing on this row is alias-mapped."
+    ),
+    "forward_dlm_inventory_item_software.nqe": (
+        'Emits the hardcoded Platform "CIMC", which its own apply adapter '
+        "creates alongside the InventoryItemRolePlatform mapping. The value "
+        "never comes from Forward's device model, so no alias mapping applies."
+    ),
+}
+
+
+def _alias_variant_filename(base_filename: str) -> str:
+    return base_filename.removesuffix(".nqe") + "_with_netbox_aliases.nqe"
+
+
+def _alias_variant_base_filename(alias_filename: str) -> str:
+    return alias_filename.replace("_with_netbox_aliases.nqe", ".nqe")
+
+
+def _query_resolves_alias_sensitive_identity(filename: str, model_string: str) -> bool:
+    """Whether a query names a NetBox object the alias-aware device query owns."""
+    if model_string in _ALIAS_SENSITIVE_IDENTITY_MODELS:
+        return True
+    source = _read_query_source(filename)
+    return any(
+        re.search(rf"^[ \t]*{field}:", source, flags=re.MULTILINE)
+        for field in _ALIAS_SENSITIVE_IDENTITY_FIELDS
+    )
+
+
+def alias_variant_coverage_violations(query_defaults=None) -> list[str]:
+    """Report every alias-variant coverage gap in a set of builtin map defaults.
+
+    An empty list means the shipped set of alias variants is complete *and*
+    intentional: every alias-sensitive base query either has a variant or an
+    exemption with a recorded reason, every exemption is still live, and every
+    variant resolves back to a base map name so
+    :func:`_collapse_alias_variant_duplicates` can supersede it.
+    """
+    query_defaults = list(
+        BUILTIN_SEEDED_QUERY_MAPS if query_defaults is None else query_defaults
+    )
+    filenames = {query_default["filename"] for query_default in query_defaults}
+    names = {query_default["name"] for query_default in query_defaults}
+    violations: list[str] = []
+
+    for query_default in query_defaults:
+        filename = query_default["filename"]
+        name = query_default["name"]
+        if _query_contract_variant(filename) == "aliases":
+            base_filename = _alias_variant_base_filename(filename)
+            if base_filename not in filenames:
+                violations.append(
+                    f"alias variant `{filename}` has no registered base query "
+                    f"`{base_filename}`"
+                )
+            if name.endswith(_ALIAS_VARIANT_NAME_SUFFIX):
+                base_name = name[: -len(_ALIAS_VARIANT_NAME_SUFFIX)]
+            else:
+                base_name = _EXPLICIT_ALIAS_VARIANT_BASE_NAMES.get(name)
+            if not base_name or base_name not in names:
+                violations.append(
+                    f"alias variant map `{name}` does not resolve to a "
+                    "registered base map name; "
+                    "_collapse_alias_variant_duplicates would let both run and "
+                    "flip the shared object between the two spellings every "
+                    "sync. Add it to _EXPLICIT_ALIAS_VARIANT_BASE_NAMES."
+                )
+            continue
+
+        if not _query_resolves_alias_sensitive_identity(
+            filename, query_default["model_string"]
+        ):
+            continue
+        if _alias_variant_filename(filename) in filenames:
+            continue
+        if filename in ALIAS_VARIANT_EXEMPT_QUERY_FILENAMES:
+            continue
+        violations.append(
+            f"base query `{filename}` (map `{name}`) names a NetBox object the "
+            "alias-aware device query owns but has neither a registered "
+            f"`{_alias_variant_filename(filename)}` variant nor an entry in "
+            "ALIAS_VARIANT_EXEMPT_QUERY_FILENAMES recording why it needs none"
+        )
+
+    for filename, reason in ALIAS_VARIANT_EXEMPT_QUERY_FILENAMES.items():
+        if not (QUERY_DIR / filename).exists():
+            violations.append(
+                f"alias-variant exemption `{filename}` names a query file that "
+                "no longer exists"
+            )
+            continue
+        if not str(reason).strip():
+            violations.append(f"alias-variant exemption `{filename}` records no reason")
+        if filename not in filenames:
+            continue
+        exempt_model_string = next(
+            query_default["model_string"]
+            for query_default in query_defaults
+            if query_default["filename"] == filename
+        )
+        if not _query_resolves_alias_sensitive_identity(filename, exempt_model_string):
+            violations.append(
+                f"alias-variant exemption `{filename}` is stale: the query no "
+                "longer names an alias-sensitive NetBox object"
+            )
+        if _alias_variant_filename(filename) in filenames:
+            violations.append(
+                f"alias-variant exemption `{filename}` contradicts the "
+                f"registered `{_alias_variant_filename(filename)}` variant"
+            )
+
+    return violations
+
+
 def _resolve_map_query_specs(model_string: str, maps) -> list[QuerySpec]:
     selected_maps = [
         query_map


### PR DESCRIPTION
## This started as the wrong task, and the disagreement is the useful part

I briefed this as: a customer hits `netbox_dlm.softwareversion row processing failed (ForwardDependencySkipError)`, they run the NetBox-alias device query, and the DLM software maps have no alias variant — so build the two missing variants.

**That root cause does not hold.** The alias variant of the device query does not rename platforms:

```
forward_devices_with_netbox_aliases.nqe:36  → normalizeDevicePlatformName(device)
forward_devices.nqe:32                      → the identical line
forward_dlm_software_versions.nqe:21        → the same line again
```

Diffing the hardware-notices pair shows the alias transformation is *entirely* `device_type` / `device_type_slug`. Exactly four query files emit those fields — the two device queries and the two hardware-notice queries — and both pairs are already complete. `scripts/build_netbox_device_type_aliases.py` emits only `manufacturer_override` and `device_type_alias` records; there is no platform record type for a platform-scoped variant to map through.

So `forward_dlm_software_versions_with_netbox_aliases.nqe` would have been byte-for-byte its base plus a header. An operator hitting the skip would enable it expecting a fix and get nothing.

## What this adds instead

`alias_variant_coverage_violations()` in `forward_netbox/utilities/query_registry.py`.

A base map is alias-sensitive if its **query source** emits `device_type`/`device_type_slug`/`platform`/`platform_slug`, or produces `dcim.devicetype`/`dcim.platform`. Each must have a registered variant, or an entry in `ALIAS_VARIANT_EXEMPT_QUERY_FILENAMES` with a written reason.

Classification reads the shipped `.nqe` rather than a hand-kept list, so a **new** map is judged on its actual contract — a list-based rule could only ever recognise maps already fixed.

Exemptions cannot rot: a missing file, a query that is no longer alias-sensitive, an empty reason, or a variant registered after the fact all fail.

It also asserts every variant resolves back to a base map **name**. `_collapse_alias_variant_duplicates` matches on display name, and the one existing variant already needs a hand-written `_EXPLICIT_ALIAS_VARIANT_BASE_NAMES` entry because its name breaks the suffix convention. A second such variant added without that entry would run alongside its base and flip the object every sync, with no test failure today.

Five exemptions recorded, including `forward_dlm_inventory_item_software.nqe` — it emits a hardcoded `"CIMC"` platform its own adapter creates. A separate test asserts `normalizeDevicePlatformName(device)` is still shared by the alias device query and all three DLM platform maps, so if that ever diverges the exemptions' premise fails loudly.

## Demonstrated failing, not just passing

Two negative unit tests drive the real function with synthetic map sets. Beyond that, the hardware-notices alias variant was temporarily unregistered — reproducing the pre-2.5.3 catalogue state — and the full-registry check failed:

```
AssertionError: base query `forward_dlm_hardware_notices.nqe` (map `Forward DLM Hardware
Notices`) names a NetBox object the alias-aware device query owns but has neither a
registered `forward_dlm_hardware_notices_with_netbox_aliases.nqe` variant nor an entry in
ALIAS_VARIANT_EXEMPT_QUERY_FILENAMES recording why it needs none
```

Restored afterwards.

## Results

```
test_query_registry         Ran 85 tests    OK
forward_netbox.tests        Ran 1861 tests  OK (skipped=4)
invoke harness-check        passed (also with --base origin/main)
invoke harness-test         Ran 263 tests   OK
invoke lint                 all hooks pass
```

## The customer's error remains undiagnosed

Stated plainly: a cause was ruled out, not found. `_lookup_platform` fails only when no `Platform` matches the emitted slug or name.

One code-verifiable inconsistency was found and deliberately **not** changed: `forward_platforms.nqe:14` is the sole producer of `dcim.platform` and the only query using `normalizePlatformName(os, version)`, while every consumer uses `normalizeDevicePlatformName(device)` — which additionally resolves APIC and ACI devices from *command outputs*. A device whose ACI/APIC identity is only visible there gets written by the device map under a platform name the platform map never emits. Whether that can actually leave the lookup unmatched depends on prune behaviour, which was not established. Changing a required map's query on an unverified theory, with the NQE validator broken, is the worse error. Recorded in the plan's Open section.

The cheapest next step is one comparison: the failing rows' `platform`/`platform_slug` from the skip context against the site's `dcim.Platform` table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j2nbNXj1sfguLKeMvbmzK