### PR TITLE
chore: take the cryptography fix for CVE-2026-69247

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -5,7 +5,7 @@
 #   '^(httpx|netboxlabs-netbox-branching|pyzipper|cryptography|netbox-(cisco-aci|dlm|peering-manager|routing))=='
 # cryptography backs at-rest credential encryption (Fernet); it ships with NetBox
 # but is pinned here for audit/reproducibility.
-cryptography==49.0.0
+cryptography==50.0.0
 httpx==0.28.1
 netbox-cisco-aci==0.4.0
 netbox-dlm==0.6.0

--- a/development/constraints-upgrade-from.txt
+++ b/development/constraints-upgrade-from.txt
@@ -14,7 +14,7 @@
 #
 # Branching is deliberately absent: the previous release's own metadata pins it,
 # and letting that resolve is the point.
-cryptography==49.0.0
+cryptography==50.0.0
 httpx==0.28.1
 netbox-cisco-aci==0.4.0
 netbox-dlm==0.6.0


### PR DESCRIPTION
`pip-audit` started failing **every** pull request in under a minute:

```
Found 1 known vulnerability in 1 package
Name          Version  ID              Fix Versions
cryptography  49.0.0   CVE-2026-69247  50.0.0
```

Nothing in this repository changed. The advisory was published against the version we already pinned, so branches that passed CI hours earlier went red on a step that never reached a test. Both `ci.yml` and `release.yml` audit `constraints.txt`, so this blocks merging **and** releasing.

## The change

`cryptography` 49.0.0 → 50.0.0 in **both** constraint files.

`development/constraints-upgrade-from.txt` must differ from `constraints.txt` only in the branching pin — `UpgradeFromConstraintsTests.test_every_other_pin_is_identical` asserts exactly that — so bumping one alone would trade this failure for a different one. (That test caught the same mistake during the 2.7.0 release when `netbox-dlm` was bumped on one side only.)

`cryptography` backs at-rest credential encryption (Fernet) and ships with NetBox, so it is a pinned direct dependency rather than an incidental one.

## Deliberately not included

`requirements-release.txt` still carries `cryptography==49.0.0` as a transitive pin of the release toolchain. Neither workflow audits that file, and regenerating it correctly needs `pip-compile` with hashes rather than a hand edit. Left as a follow-up rather than half-done here.

## Verification

```
invoke harness-test    Ran 266 tests  OK
invoke harness-check   passed
pre-commit             0 failures
```

## Merge first

This unblocks #130 and #125, which are currently failing on this and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j2nbNXj1sfguLKeMvbmzK