### PR TITLE
chore: fail when the post-release bridge is not documentation-only

### DIFF
--- a/docs/03_Plans/active/2026-08-04-enforce-doc-only-bridge.md
+++ b/docs/03_Plans/active/2026-08-04-enforce-doc-only-bridge.md
@@ -1,0 +1,92 @@
+# Enforce a documentation-only post-release bridge
+
+## Goal
+
+Fail the harness while the pinned `PRIOR_RELEASE_TAG` /
+`PRIOR_POST_RELEASE_DOC_COMMIT` pairing has a bridge that is not
+documentation-only, so a bad bridge is caught while it can still be fixed
+rather than at a tag that cannot be moved.
+
+## Contract
+
+- The bridge rule has exactly one owner. The harness loads
+  `_is_documentation_path` from `scripts/verify_release_provenance.py` rather
+  than restating it; a second copy would drift, and a harness that passes while
+  the verifier fails is worse than no harness check.
+- The check fails closed. An unreadable diff, a missing anchor constant, and an
+  empty bridge are failures, not silence — `all()` is vacuously true on an empty
+  sequence and `_git_names` returns nothing when git fails.
+- The failure names the disqualifying paths and states that the slot cannot be
+  reclaimed, so the message rules out the wrong remedy as well as naming the
+  right one.
+
+## Constraints
+
+- This adds a check. No existing release control is relaxed, and the widened
+  bridge rule from `#134` is not touched.
+- The anchor constants are not moved by this change.
+- No customer identifiers.
+
+## Touched Surfaces
+
+- `scripts/check_harness.py`
+- `scripts/tests/test_check_harness.py`
+
+## Approach
+
+`_check_post_release_bridge_is_documentation_only` reads both anchor constants
+out of `scripts/verify_release_provenance.py`, runs the same
+`git diff --name-only <tag> <bridge>` the verifier runs, and applies the
+verifier's own path rule to the result. The failure names the exact paths that
+disqualified the bridge and states that the slot cannot be reclaimed, because
+that is the part operators get wrong: the instinct on seeing this failure is to
+re-point the anchor, and the bridge is *defined* as the first first-parent
+commit after the tag, so there is nothing to re-point it to.
+
+The gap this closes: `_check_release_anchor_tracks_current_release` asserts only
+that the anchor names the release the README calls current. It says nothing
+about what the bridge commit contains, which is why `#121` could re-anchor onto
+a commit that could never satisfy the verifier, with nothing re-running the
+verifier until the next tag.
+
+## Validation
+
+`python -m unittest discover -s scripts/tests -p 'test_check_harness.py'` — 60
+tests, OK. Five new cases: a documentation-only bridge passes (and the git
+invocation is asserted), a bridge carrying plugin code fails, a bridge carrying
+a workflow fails, an empty or unreadable diff fails closed, and a missing
+`PRIOR_POST_RELEASE_DOC_COMMIT` is reported.
+
+`python scripts/check_harness.py` — the new check passes against the current
+pairing (`v2.7.0` / `bbebcaac`), whose bridge changes `CHANGELOG.md`,
+`README.md`, `docs/01_User_Guide/README.md`, and `docs/README.md`.
+
+## Rollback
+
+Revert this commit. Nothing else depends on the check; reverting restores the
+prior state in which a non-documentation bridge is discovered only at the next
+release tag.
+
+## Decision Log
+
+- The rule is imported by file path rather than by `import scripts....`. The
+  harness runs both as `python scripts/check_harness.py` (where the repository
+  root is not on `sys.path`) and as `scripts.check_harness` under unittest, and
+  only a file-path load works in both.
+- The check diffs the tag against the pinned commit rather than re-deriving the
+  bridge from `rev-list --first-parent`. Using the verifier's exact comparison
+  is what guarantees the harness cannot pass while the verifier fails; a
+  mis-pinned anchor still fails here, because the diff then carries everything
+  between the two commits.
+- Ordering is still not enforced at the source. `scripts/release.py` never
+  archives plans, so archive-before-promote remains a human step; this check
+  makes a wrong bridge loud, not impossible. See Open.
+
+## Open
+
+- `stage_finish` promotes the candidate *before* the tag and never archives, so
+  which commit lands in the bridge slot is still decided by hand after the tag.
+  Making the close-out own the archival commit — one branch, archive committed
+  first, promotion second — would make the bridge correct by construction rather
+  than merely checked. That is a change to `stage_post_release`, not to the
+  two-PR flow, and it is not made here.

--- a/scripts/check_harness.py
+++ b/scripts/check_harness.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import re
@@ -1093,6 +1094,107 @@ def _check_release_anchor_tracks_current_release(failures: list[str]) -> None:
         )
 
 
+def _documentation_bridge_rule():
+    """Return the release verifier's own post-release bridge path rule.
+
+    The rule is loaded from the module beside this one rather than restated
+    here. A second copy drifts the moment either side moves, and a harness
+    check that passes while the verifier fails is worse than no check at all -
+    the entire value of checking early is that the two agree.
+    """
+    path = Path(__file__).resolve().parent / "verify_release_provenance.py"
+    spec = importlib.util.spec_from_file_location(
+        "forward_netbox_release_provenance_rule",
+        path,
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load release provenance rule from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module._is_documentation_path
+
+
+def _check_post_release_bridge_is_documentation_only(failures: list[str]) -> None:
+    """The commit the anchor pins must be a documentation-only bridge.
+
+    `_require_prior_release_bridge` requires the first first-parent commit after
+    `PRIOR_RELEASE_TAG` - the bridge - to touch documentation only. That slot is
+    fixed by definition: the bridge *is* the first commit after the tag, so once
+    a commit carrying anything else lands there no later commit can reclaim it,
+    and the anchor cannot be re-pointed past it without reintroducing the
+    expiring-review-range problem that spent `v2.6.10` and `v2.6.11`.
+
+    `v2.7.0` was promoted without first being archived, so the promotion commit
+    took the slot. Every release after it became unverifiable and `2.7.1` was
+    blocked until the rule was widened - and widening made that ordering
+    non-fatal, not correct. Nothing caught it at the time:
+    `_check_release_anchor_tracks_current_release` asserts only that the anchor
+    names the current release, never what the bridge contains, and the
+    re-anchoring pull request pinned a commit that could never satisfy the
+    check with nothing re-running the verifier.
+
+    Running the verifier's own rule against the pinned pairing on every harness
+    run moves that failure to where it is still one commit away from being
+    fixed, instead of to a tag that cannot be moved or deleted.
+    """
+    provenance_path = REPO_ROOT / "scripts/verify_release_provenance.py"
+    if not provenance_path.exists():
+        return
+
+    text = provenance_path.read_text(encoding="utf-8")
+    tag_match = re.search(
+        r'^PRIOR_RELEASE_TAG = "(?P<tag>v[0-9]+\.[0-9]+\.[0-9]+)"$',
+        text,
+        re.MULTILINE,
+    )
+    bridge_match = re.search(
+        r'^PRIOR_POST_RELEASE_DOC_COMMIT = "(?P<commit>[0-9a-f]{40})"$',
+        text,
+        re.MULTILINE,
+    )
+    if tag_match is None or bridge_match is None:
+        failures.append(
+            "release provenance must pin PRIOR_RELEASE_TAG and a 40-character "
+            "PRIOR_POST_RELEASE_DOC_COMMIT so the post-release bridge shape can "
+            "be checked before a tag depends on it"
+        )
+        return
+
+    tag = tag_match.group("tag")
+    bridge = bridge_match.group("commit")
+
+    try:
+        is_documentation_path = _documentation_bridge_rule()
+    except Exception as exc:
+        failures.append(
+            "release provenance bridge rule is not loadable, so the post-release "
+            f"bridge cannot be checked: {exc}"
+        )
+        return
+
+    changed = _git_names("diff", "--name-only", tag, bridge)
+    if not changed:
+        failures.append(
+            f"post-release bridge {bridge[:10]} against {tag} lists no changed "
+            "paths: check out the full history and tags (fetch-depth: 0) or "
+            "correct the anchor. An unreadable or empty bridge is not evidence "
+            "that the bridge is documentation-only"
+        )
+        return
+
+    disqualifying = sorted(path for path in changed if not is_documentation_path(path))
+    if disqualifying:
+        failures.append(
+            f"post-release bridge {bridge[:10]} after {tag} is not "
+            "documentation-only; these paths disqualify it: "
+            f"{', '.join(disqualifying)}. The bridge is the first first-parent "
+            "commit after the tag, so this slot cannot be reclaimed by a later "
+            "commit and the anchor cannot be re-pointed past it: the close-out "
+            "must land its documentation commit (archive, then promote) as the "
+            "first commit after the tag"
+        )
+
+
 def _check_standard_release_tag_flow(failures: list[str]) -> None:
     paths = {
         "release": REPO_ROOT / "scripts/release.py",
@@ -1181,6 +1283,7 @@ def main() -> int:
     _check_sensitive_guard_wiring(failures)
     _check_release_toolchain_lock(failures)
     _check_release_anchor_tracks_current_release(failures)
+    _check_post_release_bridge_is_documentation_only(failures)
     _check_standard_release_tag_flow(failures)
     _check_publish_gate_placement(failures)
     if args.base:

--- a/scripts/tests/test_check_harness.py
+++ b/scripts/tests/test_check_harness.py
@@ -1058,3 +1058,94 @@ class ReleaseAnchorTracksCurrentReleaseTest(unittest.TestCase):
         failures = self._run(tag="not-a-tag", current="v2.7.0")
         self.assertEqual(len(failures), 1)
         self.assertIn("PRIOR_RELEASE_TAG", failures[0])
+
+
+class PostReleaseBridgeIsDocumentationOnlyTest(unittest.TestCase):
+    """The bridge slot is not reclaimable, so its shape is checked before a tag.
+
+    `v2.7.0` was promoted without being archived first, so the promotion commit
+    took the slot the verifier reserves for a documentation-only bridge. The
+    bridge is defined as the first first-parent commit after the tag, so no
+    later commit could reclaim it: every release after `v2.7.0` was unverifiable
+    until the rule was widened. Nothing failed at the time because the harness
+    only checked which release the anchor named, never what the bridge changed.
+
+    The rule itself is deliberately not restated here - these cases exercise the
+    verifier's own `_is_documentation_path` through the harness check.
+    """
+
+    BRIDGE = "b" * 40
+    PROVENANCE = (
+        'PRIOR_RELEASE_TAG = "v2.7.0"\n' f'PRIOR_POST_RELEASE_DOC_COMMIT = "{BRIDGE}"\n'
+    )
+
+    def _run(self, changed, *, provenance=None):
+        failures = []
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "scripts").mkdir()
+            (root / "scripts/verify_release_provenance.py").write_text(
+                self.PROVENANCE if provenance is None else provenance,
+                encoding="utf-8",
+            )
+            with (
+                patch.object(check_harness, "REPO_ROOT", root),
+                patch.object(
+                    check_harness,
+                    "_git_names",
+                    return_value=list(changed),
+                ) as git_names,
+            ):
+                check_harness._check_post_release_bridge_is_documentation_only(failures)
+                self.calls = git_names.call_args_list
+        return failures
+
+    def test_documentation_only_bridge_passes(self):
+        failures = self._run(
+            [
+                "CHANGELOG.md",
+                "README.md",
+                "docs/01_User_Guide/README.md",
+                "docs/03_Plans/completed/2026-08-03-release-2.7.1.md",
+            ]
+        )
+
+        self.assertEqual(failures, [])
+        self.assertEqual(
+            self.calls[0].args,
+            ("diff", "--name-only", "v2.7.0", self.BRIDGE),
+        )
+
+    def test_bridge_carrying_plugin_code_fails(self):
+        failures = self._run(["CHANGELOG.md", "forward_netbox/utilities/sync.py"])
+
+        self.assertEqual(len(failures), 1)
+        self.assertIn("forward_netbox/utilities/sync.py", failures[0])
+        # Only the disqualifying paths are named; the documentation it also
+        # carried is not what has to be removed.
+        self.assertNotIn("CHANGELOG.md", failures[0])
+        self.assertIn("cannot be reclaimed", failures[0])
+
+    def test_bridge_carrying_a_workflow_fails(self):
+        failures = self._run([".github/workflows/release.yml"])
+
+        self.assertEqual(len(failures), 1)
+        self.assertIn(".github/workflows/release.yml", failures[0])
+        self.assertIn("cannot be reclaimed", failures[0])
+
+    def test_an_unreadable_or_empty_bridge_fails_closed(self):
+        # `all()` is vacuously true on an empty sequence, and `_git_names`
+        # returns nothing when git fails, so silence must not read as a pass.
+        failures = self._run([])
+
+        self.assertEqual(len(failures), 1)
+        self.assertIn("no changed paths", failures[0])
+
+    def test_a_missing_bridge_constant_is_reported(self):
+        failures = self._run(
+            ["CHANGELOG.md"],
+            provenance='PRIOR_RELEASE_TAG = "v2.7.0"\n',
+        )
+
+        self.assertEqual(len(failures), 1)
+        self.assertIn("PRIOR_POST_RELEASE_DOC_COMMIT", failures[0])


### PR DESCRIPTION
Task #38. Makes the defect that blocked 2.7.1 impossible to introduce silently.

**The defect.** Provenance defines the post-release bridge as the first first-parent commit after the prior release tag, and requires it to carry no executable content. `v2.7.0` was promoted without first being archived, so a code-adjacent commit took that slot. Because the slot is *defined* as the first commit after the tag, it cannot be reclaimed by a later commit and the anchor cannot be re-pointed past it — every release after `v2.7.0` became unverifiable, and it was only discovered at the 2.7.1 tag.

**Why nothing caught it.** `_check_release_anchor_tracks_current_release` asserts the anchor *tag* tracks the current release. It never looks at the bridge's *shape*. So #121 re-anchored onto a commit that could never satisfy the check, and nothing re-ran the verifier.

**The check.** `_check_post_release_bridge_is_documentation_only` runs the verifier's own `git diff --name-only <tag> <bridge>` and applies the verifier's own `_is_documentation_path`, loaded by file path rather than copied — a second copy of the rule would drift. Fails closed on missing or unparseable constants, an unloadable rule, and an empty diff (`all()` is vacuously true on empty). The message names only the disqualifying paths and states that the slot cannot be reclaimed.

**Verified, not asserted.** 282 harness tests pass. Against the live anchor (`v2.7.1` / `8480bdc`) it passes. Negative control: pointed at the close-out commit `d00517e`, it rejects 9 paths including `release.yml`, `forward_netbox/__init__.py` and the fast-baseline pin — which is precisely the poisoning it exists to prevent, and precisely what would have happened had the close-out merged before the archival commit.

**Not fixed here, still tracked in #38:** `stage_post_release` opens the `.dev0` bump as the only post-tag PR, so the ordering must still be driven by hand. This check turns that into a loud harness failure at anchor-advance time instead of a dead release at tag time. The recommended follow-up is two sequential PRs inside `stage_post_release` — archive-only, wait for merge, then the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166CtWtsA6qbWz32TZ6zgny