### PR TITLE
fix: execute query-ID maps at latest instead of refusing without a commit

### DIFF
--- a/docs/03_Plans/active/2026-08-04-contract-preflight-severity.md
+++ b/docs/03_Plans/active/2026-08-04-contract-preflight-severity.md
@@ -1,0 +1,156 @@
+# Query-ID Maps Execute Without A Commit; Health Severity Follows Consequence
+
+## Goal
+
+Two operator-visible outcomes.
+
+1. A map bound to a Forward query ID runs its full query by ID, with no commit
+   involved at any stage. Forward resolves the latest commit server-side. The
+   plugin no longer refuses such a map as `unresolved_full_commit`, so a
+   repository reorganisation, a permissions gap, or one failed history lookup
+   can no longer empty an entire sync.
+2. The health page stops describing a dead run as informational. A run in which
+   every enabled model failed to fetch is reported as a blocking check that
+   names the consequence and the remedy; a partial failure warns and names the
+   models; a clean run says nothing.
+
+## Contract
+
+- A `QuerySpec` with a direct `query_id` yields `full_reason_code == "eligible"`
+  and `full_eligible is True` when `commit_id` is `None`, `""`, or `"head"`,
+  and reports `full_unpinned_head is True`.
+- A path-bound spec with no commit still yields `unresolved_full_commit` and
+  `full_eligible is False`.
+- Dropping the commit does not drop the shape checks: `unverified_full_source`,
+  `unverified_full_declarations`, and `unsupported_full_parameters` continue to
+  close the full contract for an ID-bound map.
+- `diff_reason_code` and `diff_eligible` are unchanged in every case.
+- `_persisted_query_contract_preflight` reports no issue for a query-ID map with
+  an empty commit; it still reports one for a path-bound map.
+- `_fetch_failure_check` returns `fail` when every attempted model failed,
+  `warn` when some did, and `None` when none did or when there is no ingestion.
+
+## Constraints
+
+- No NetBox/Branching behaviour change, no migration, no model field change.
+- `ResolvedExecutionContract.fingerprint` must not change. Contributor
+  baselines, diff baseline selection, and expected-contributor matching are keyed
+  by it, so `full_unpinned_head` is deliberately excluded from the fingerprint
+  (`commit_id` already participates through `full_revision.fingerprint`).
+- Diff execution is out of scope and must not be relaxed. `run_nqe_diff` POSTs to
+  `/nqe-diffs/{before}/{after}`, where the two commits are path segments rather
+  than optional body fields, so a diff genuinely cannot run without concrete
+  commits.
+- The Docker stack was not used. Django tests that need `netbox.settings` were
+  not run in this change.
+- No customer identifiers in code, comments, tests, or docs.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/query_execution_contract.py` — the commit
+  requirement for direct-query-ID full contracts; new `full_unpinned_head`.
+- `forward_netbox/utilities/query_fetch_execution.py` — `validate_rows` accepts
+  the contract and names the map on a row-shape failure.
+- `forward_netbox/utilities/health.py` — persisted preflight scope, reworded
+  messages, new `_fetch_failure_check`.
+- `forward_netbox/tests/test_query_execution_contract.py` — updated matrix and
+  new eligibility/shape tests.
+- `forward_netbox/tests/test_contract_preflight_message.py` — updated wording
+  assertions, new persisted-scope and fetch-failure tests.
+
+## Approach
+
+1. In `resolve_execution_contract`, compute `runs_by_direct_query_id` from
+   `spec.query_id` and guard the `unresolved_full_commit` branch with it. The
+   branch order is otherwise untouched, so an ID-bound map that fails a later
+   check reports that later reason instead of being masked by the commit one.
+2. Add `full_unpinned_head` to `ResolvedExecutionContract`, set when an ID-bound
+   map runs with no commit. It is reporting only; it is not part of the
+   fingerprint and does not affect eligibility.
+3. Carry the map identity into the fetch-time row-shape failure. The row check
+   already exists and already runs per model, but its message named only the
+   model. `validate_rows` now takes the contract and re-raises with the map name,
+   map id, and whether it ran at unpinned head.
+4. In `health.py`, stop listing query-ID maps in the persisted preflight, reword
+   the remaining path-bound case truthfully, and give the blocking variant the
+   consequence and the remedy.
+5. Add `_fetch_failure_check`, which reads `latest_ingestion.model_results` —
+   what the last run actually did — and sets severity from the consequence.
+
+## Validation
+
+- `python3 -m unittest discover -s scripts/tests` — 312 tests, OK.
+- `python3 scripts/check_harness.py` and `--base origin/main`.
+- `pre-commit run --all-files`, twice.
+- Contract behaviour exercised directly against the real module source, which is
+  pure stdlib and loads without NetBox: ID-bound map with `None`/`""`/`"head"`
+  becomes eligible with `full_unpinned_head`; path-bound map still reports
+  `unresolved_full_commit`; oversupplied parameters still report
+  `unsupported_full_parameters`; source drift still reports
+  `unverified_full_source`.
+- Health functions exercised by extracting them from the real `health.py` by AST
+  and executing them with a stub `_check`, since the module imports NetBox.
+- NOT RUN, needs the stack: the Django suites
+  `forward_netbox/tests/test_query_execution_contract.py` and
+  `forward_netbox/tests/test_contract_preflight_message.py`, and any live sync.
+
+## Rollback
+
+Revert the commit. No migration, no persisted state, no data cleanup. Reverting
+restores the commit requirement for ID-bound maps and the previous health
+wording. Any ingestion rows written while the change was live remain valid;
+`_fetch_failure_check` only reads them.
+
+## Decision Log
+
+- **Rejected: making the persisted health check blocking.** The first framing of
+  this work was that the health page's `unresolved_full_commit` was killing every
+  sync and should therefore be a failure. It is a different computation from the
+  runtime contract that happens to share the reason-code name:
+  `_persisted_query_contract_preflight` reads `ForwardNQEMap.commit_id` at page
+  render, while the runtime code reads the resolved spec. The existing comment in
+  `health.py` records a support bundle where 32 of 32 maps reported it both while
+  a sync applied nothing and while the same sync applied 24,748 changes. Making
+  it blocking would have fired a failure on every healthy query-ID install.
+- **Rejected: relaxing the whole reason-code family.** Only the commit
+  requirement is removed, and only for direct-ID bindings. `unverified_full_source`,
+  `unverified_full_declarations`, and `unsupported_full_parameters` are the
+  protection the commit requirement was standing in front of: the plugin injects
+  parameters (shard keys, device-tag selection, endpoint opt-ins), and a query
+  that no longer declares them would silently return the wrong row set rather
+  than the wrong row shape. Those checks are kept.
+- **Rejected: relaxing the commit for path-bound maps too.** A path is not an
+  identity. `QuerySpec.resolve` deliberately refuses to adopt a head commit when
+  the path now resolves to a different query, because that would execute another
+  query's revision. Execution never sends a path, so an ID binding has no
+  equivalent hazard.
+- **Excluded `full_unpinned_head` from the contract fingerprint** so baseline and
+  contributor matching are unaffected.
+- **Left `_build_workload_jobs`'s all-or-nothing behaviour in place.** One
+  ineligible map still returns zero jobs for the whole sync. Removing the commit
+  requirement removes the condition that was making that fire across every map at
+  once, but the amplifier itself is a deliberate fail-closed with its own tests
+  and is out of scope here. See Open.
+
+## Open
+
+- **A custom (non-built-in) map bound by query ID with no commit still cannot
+  run.** It carries no query source, so `full_query_source` is `None`,
+  `source_verified` is `False`, and the contract closes on
+  `unverified_full_source` rather than on the commit. Source hydration is keyed
+  by commit (`_hydrate_diff_contract_sources` returns early when the commit is
+  empty), so there is currently no path that verifies a custom ID-bound query's
+  source without one. Built-in maps are unaffected because they carry their
+  bundled source and hash. Closing this needs a way to read a query's source by
+  ID at head, which is a separate change.
+- **One ineligible map still zeroes the whole run.** `_build_workload_jobs` sets
+  `contract_preflight_blocked` and returns `[]`, so a single refused model still
+  stops every other model. A per-model skip would be the honest behaviour and
+  would make the new warn-level fetch check the normal reporting path.
+- **Row-shape validation cannot detect an ignored parameter.** It checks that
+  required fields are present, not that a parameter was honoured. A query that
+  silently stopped accepting a shard key would return correctly shaped rows, just
+  too many of them. This is why the declaration checks were kept rather than
+  replaced by the fetch-time check.
+- The health-page `warn`/`fail` split for fetch failures has not been seen
+  against a live run.

--- a/forward_netbox/tests/test_contract_preflight_message.py
+++ b/forward_netbox/tests/test_contract_preflight_message.py
@@ -6,8 +6,12 @@ said the same thing, with no indication of which maps, what was wrong, or what
 would fix it. The sync applied nothing and the message explained none of it.
 """
 
+from types import SimpleNamespace
+
 from django.test import SimpleTestCase
 
+from forward_netbox.utilities.health import _fetch_failure_check
+from forward_netbox.utilities.health import _persisted_query_contract_preflight
 from forward_netbox.utilities.health import _query_contract_preflight_message
 from forward_netbox.utilities.health import _query_contract_preflight_status
 
@@ -59,11 +63,22 @@ class ContractPreflightMessageTest(SimpleTestCase):
 
     def test_a_missing_stored_commit_explains_why_it_is_normal(self):
         # It must not tell an operator to go fix something that is not broken.
+        # Only path-bound maps reach this issue now; an ID-bound map needs no
+        # commit at all and is never listed.
         message = _query_contract_preflight_message(
             _issues("unresolved_full_commit", "dcim.site")
         )
-        self.assertIn("resolved at sync time", message)
+        self.assertIn("at sync time", message)
+        self.assertIn("path-bound", message.lower())
         self.assertNotIn("Publish Bundled Queries", message)
+
+    def test_a_blocking_message_states_the_consequence_and_the_remedy(self):
+        message = _query_contract_preflight_message(
+            _issues("missing_diff_source_hash", "dcim.site")
+        )
+        self.assertIn("will not sync", message)
+        self.assertIn("Refresh Query IDs", message)
+        self.assertIn("org query repository", message)
 
     def test_distinct_problems_are_reported_separately(self):
         message = _query_contract_preflight_message(
@@ -90,3 +105,92 @@ class ContractPreflightMessageTest(SimpleTestCase):
             [{"map_id": 1, "model": "", "type": "unresolved_full_commit"}]
         )
         self.assertIn("1 map(s)", message)
+
+
+def _map(pk, model_string, *, query_id="", query_path="", commit_id=""):
+    return SimpleNamespace(
+        pk=pk,
+        model_string=model_string,
+        query_id=query_id,
+        query_path=query_path,
+        commit_id=commit_id,
+        diff_commit_id="",
+        diff_source_sha256="",
+        execution_mode=(
+            "query_id" if query_id else ("query_path" if query_path else "query")
+        ),
+    )
+
+
+class PersistedPreflightScopeTest(SimpleTestCase):
+    """A query-ID map needs no commit, so an empty one is not an issue."""
+
+    def test_query_id_maps_without_a_commit_are_not_reported(self):
+        maps = [_map(index, f"app.model{index}", query_id="Q") for index in range(32)]
+
+        preflight = _persisted_query_contract_preflight(maps)
+
+        self.assertEqual(preflight["issues"], [])
+        self.assertTrue(preflight["consistent"])
+
+    def test_path_bound_maps_without_a_commit_are_still_reported(self):
+        preflight = _persisted_query_contract_preflight(
+            [_map(1, "dcim.site", query_path="/Forward/sites")]
+        )
+
+        self.assertEqual(
+            [issue["type"] for issue in preflight["issues"]],
+            ["unresolved_full_commit"],
+        )
+
+
+class FetchFailureCheckTest(SimpleTestCase):
+    """Severity follows what the run did, not what the maps look like at rest.
+
+    The health page reported a run that fetched nothing as one `warn` row
+    saying "1 issue(s)" next to an "informational" contract line, so five dead
+    runs read as healthy.
+    """
+
+    @staticmethod
+    def _ingestion(rows):
+        return SimpleNamespace(pk=7, model_results=rows)
+
+    def test_every_model_failing_is_blocking_and_names_the_consequence(self):
+        rows = [
+            {"model": f"app.model{index}", "failure_count": 1} for index in range(32)
+        ]
+
+        check = _fetch_failure_check(self._ingestion(rows))
+
+        self.assertEqual(check["status"], "fail")
+        self.assertIn("applied nothing", check["message"])
+        self.assertIn("nothing will sync", check["message"])
+        self.assertIn("Refresh Query IDs", check["message"])
+        self.assertIn("unresolved_full_commit", check["message"])
+        self.assertIn("unsupported_full_parameters", check["message"])
+
+    def test_a_partial_failure_warns_and_names_the_models(self):
+        rows = [
+            {"model": "dcim.site", "failure_count": 1},
+            {"model": "dcim.device", "failure_count": 0},
+            {"model": "dcim.interface", "failure_count": 0},
+        ]
+
+        check = _fetch_failure_check(self._ingestion(rows))
+
+        self.assertEqual(check["status"], "warn")
+        self.assertIn("dcim.site", check["message"])
+        self.assertIn("1 of 3", check["message"])
+
+    def test_a_clean_run_reports_nothing_at_all(self):
+        rows = [
+            {"model": "dcim.site", "failure_count": 0},
+            {"model": "dcim.device", "failure_count": 0},
+        ]
+
+        self.assertIsNone(_fetch_failure_check(self._ingestion(rows)))
+
+    def test_no_ingestion_and_no_rows_report_nothing(self):
+        self.assertIsNone(_fetch_failure_check(None))
+        self.assertIsNone(_fetch_failure_check(self._ingestion([])))

--- a/forward_netbox/tests/test_query_execution_contract.py
+++ b/forward_netbox/tests/test_query_execution_contract.py
@@ -284,8 +284,17 @@ select {endpoint: endpoint.name}
                 "unsupported_diff_ownership",
                 True,
             ),
-            "unpinned_full": (
-                replace(_eligible_spec(), commit_id=None),
+            # Only a PATH-bound map still needs a commit: its revision is
+            # resolved from the repository path. An ID-bound map runs by ID and
+            # Forward resolves head, so it is covered by the eligibility tests
+            # below rather than here.
+            "unpinned_full_path_bound": (
+                replace(
+                    _eligible_spec(),
+                    query_id=None,
+                    query_path="/Forward/forward_locations",
+                    commit_id=None,
+                ),
                 "unresolved_full_commit",
                 False,
             ),
@@ -392,14 +401,62 @@ select {name: x}
         self.assertFalse(contract.full_eligible)
         self.assertEqual(contract.full_reason_code, "unsupported_full_parameters")
 
-    def test_map_without_full_commit_is_unresolved_full(self):
+    def test_path_bound_map_without_full_commit_is_unresolved_full(self):
         contract = _contract(
-            replace(_eligible_spec(), commit_id=""),
+            replace(
+                _eligible_spec(),
+                query_id=None,
+                query_path="/Forward/forward_locations",
+                commit_id="",
+            ),
             effective_parameters={"scope": []},
         )
 
         self.assertEqual(contract.full_reason_code, "unresolved_full_commit")
         self.assertFalse(contract.full_eligible)
+
+    def test_query_id_bound_map_runs_full_without_any_commit(self):
+        """Forward resolves the latest commit for a query ID server-side.
+
+        Requiring a pre-read commit here is what turned one repository move or
+        one failed history lookup into `unresolved_full_commit` on every enabled
+        map, and the preflight in `_build_workload_jobs` then planned zero jobs
+        for the whole sync. There is nothing to resolve on this path.
+        """
+        for commit_id in (None, "", "head"):
+            with self.subTest(commit_id=commit_id):
+                contract = _contract(
+                    replace(_eligible_spec(), commit_id=commit_id),
+                    effective_parameters={"scope": []},
+                )
+
+                self.assertEqual(contract.full_reason_code, "eligible")
+                self.assertTrue(contract.full_eligible)
+                self.assertTrue(contract.full_unpinned_head)
+
+    def test_a_pinned_query_id_map_is_not_reported_as_unpinned_head(self):
+        self.assertFalse(_contract().full_unpinned_head)
+
+    def test_dropping_the_commit_does_not_drop_the_shape_checks(self):
+        """The commit went away; the declaration and source checks did not.
+
+        This is the protection the commit requirement was standing in for, and
+        it still runs for an ID-bound map because a built-in carries its bundled
+        source and hash.
+        """
+        oversupplied = _contract(
+            replace(_eligible_spec(), commit_id=None),
+            effective_parameters={"scope": [], "extra": True},
+        )
+        self.assertEqual(oversupplied.full_reason_code, "unsupported_full_parameters")
+        self.assertFalse(oversupplied.full_eligible)
+
+        drifted = _contract(
+            replace(_eligible_spec(), commit_id=None, full_source_sha256="deadbeef"),
+            effective_parameters={"scope": []},
+        )
+        self.assertEqual(drifted.full_reason_code, "unverified_full_source")
+        self.assertFalse(drifted.full_eligible)
 
     def test_full_parameter_set_must_match_exactly(self):
         contract = _contract(
@@ -640,8 +697,15 @@ select {name: x}
                 {"scope": [], "extra": True},
                 "unsupported_full_parameters",
             ),
-            "query_id_without_pinned_full_commit": (
-                replace(_eligible_spec(), commit_id=""),
+            # A query-ID map without a commit is no longer a rejection: it runs
+            # by ID at head. A PATH-bound map without one still is.
+            "path_bound_without_resolved_commit": (
+                replace(
+                    _eligible_spec(),
+                    query_id=None,
+                    query_path="/Forward/forward_locations",
+                    commit_id="",
+                ),
                 {"scope": []},
                 "unresolved_full_commit",
             ),

--- a/forward_netbox/utilities/health.py
+++ b/forward_netbox/utilities/health.py
@@ -376,6 +376,9 @@ def sync_health_summary(sync):
                 ),
             )
         )
+    fetch_failure_check = _fetch_failure_check(latest_ingestion)
+    if fetch_failure_check is not None:
+        checks.append(fetch_failure_check)
     if ownership_finalization["required_domains"]:
         if ownership_finalization["complete"]:
             ownership_status = "pass"
@@ -455,10 +458,10 @@ def sync_health_summary(sync):
 
 _CONTRACT_ISSUE_REMEDIATION = {
     "unresolved_full_commit": (
-        "no commit is stored on the map. This is the normal state for a map "
-        "bound by query ID or repository path, because head is resolved at "
-        "sync time and not persisted, so it does not by itself mean the model "
-        "will be skipped. Pin a commit only if you need the revision frozen"
+        "no commit is stored on the path-bound map. Its commit is resolved from "
+        "the repository path at sync time and not persisted, so this alone does "
+        "not skip the model. Bind the map to a query ID (Resolve to Query ID) if "
+        "you want it to run without depending on the path resolving"
     ),
     "identical_full_diff_commit": (
         "the full and diff contracts point at the same commit, so a diff would "
@@ -471,15 +474,17 @@ _CONTRACT_ISSUE_REMEDIATION = {
 }
 
 
-# `unresolved_full_commit` here means "no commit stored on the map", which is the
-# normal resting state for a query-ID or path binding: head is resolved during
-# the sync and never written back. It is NOT the runtime execution contract's
-# reason code of the same name, which does mean the model was refused.
+# `unresolved_full_commit` here means "no commit stored on a path-bound map",
+# which is the normal resting state for that binding: the commit is resolved
+# during the sync and never written back. It is NOT the runtime execution
+# contract's reason code of the same name.
 #
 # Proven by a customer bundle: 32 of 32 maps reported this both while the sync
 # applied nothing AND after the same sync applied 24,748 changes. A signal that
 # is identical when broken and when healthy cannot gate a sync, and reporting it
-# as a failure sent an investigation down the wrong path.
+# as a failure sent an investigation down the wrong path. Whether a run actually
+# fetched nothing is answered by `_fetch_failure_check`, which reads what the
+# last run really did instead of inferring it from persisted map state.
 _NON_BLOCKING_CONTRACT_ISSUES = {"unresolved_full_commit"}
 
 
@@ -521,12 +526,89 @@ def _query_contract_preflight_message(issues):
     blocking = _query_contract_preflight_status(issues) == "fail"
     lead = (
         "Enabled NQE maps have persisted execution contract issues that will "
-        "skip those models. "
+        "skip those models, so those models will not sync until this is "
+        "resolved. Re-resolve the affected maps (Refresh Query IDs, or "
+        "republish the bundled queries) and confirm the Forward account can "
+        "read the org query repository. "
         if blocking
-        else "Enabled NQE maps have no stored commit. This is informational: "
-        "head is resolved at sync time. "
+        else "Path-bound NQE maps have no stored commit. This is "
+        "informational: their commit is resolved from the repository path at "
+        "sync time. Maps bound to a query ID are not listed here because they "
+        "need no commit. "
     )
     return lead + " ".join(parts)
+
+
+# The refusal codes the execution contract can report per map. Support needs the
+# family named on the page, because the code itself only reaches the job log.
+_FETCH_CONTRACT_REASON_CODES = (
+    "unresolved_query_id",
+    "unresolved_full_commit",
+    "unverified_full_source",
+    "unverified_full_declarations",
+    "unsupported_full_parameters",
+)
+
+
+def _fetch_failure_check(latest_ingestion):
+    """What the last run actually fetched, not what the maps look like at rest.
+
+    A run in which every model failed to fetch applies nothing. That outcome was
+    reported only as a `warn` row saying "1 issue(s)", beside a contract check
+    that said "informational" - so consecutive dead runs read as healthy and a
+    human skipped the line that mattered. Severity here follows the consequence:
+    nothing fetched is blocking, some models fetched is a warning that names
+    them.
+    """
+    if latest_ingestion is None:
+        return None
+    rows = [
+        row
+        for row in (getattr(latest_ingestion, "model_results", None) or [])
+        if isinstance(row, dict)
+    ]
+    if not rows:
+        return None
+    attempted = {str(row.get("model") or "") for row in rows} - {""}
+    failed = sorted(
+        {
+            str(row.get("model") or "")
+            for row in rows
+            if int(row.get("failure_count") or 0) > 0
+        }
+        - {""}
+    )
+    if not failed:
+        return None
+    sample = ", ".join(failed[:3])
+    if len(failed) > 3:
+        sample += f", +{len(failed) - 3} more"
+    remedy = (
+        "Re-resolve the affected maps (Refresh Query IDs, or republish the "
+        "bundled queries) and confirm the Forward account can read the org "
+        "query repository, then re-run. The job log names the refusal for each "
+        f"map ({', '.join(_FETCH_CONTRACT_REASON_CODES)})."
+    )
+    if len(failed) >= len(attempted):
+        return _check(
+            name="Latest run fetch",
+            status="fail",
+            message=(
+                f"Every enabled model failed to fetch on ingestion "
+                f"{latest_ingestion.pk} ({len(failed)} of {len(attempted)}) "
+                f"[{sample}]. That run applied nothing, and nothing will sync "
+                f"while this persists. {remedy}"
+            ),
+        )
+    return _check(
+        name="Latest run fetch",
+        status="warn",
+        message=(
+            f"{len(failed)} of {len(attempted)} model(s) failed to fetch on "
+            f"ingestion {latest_ingestion.pk} [{sample}], so those models did "
+            f"not sync. {remedy}"
+        ),
+    )
 
 
 def _persisted_query_contract_preflight(maps):
@@ -534,7 +616,14 @@ def _persisted_query_contract_preflight(maps):
     for query_map in maps:
         full_commit_id = str(getattr(query_map, "commit_id", "") or "").strip()
         diff_commit_id = str(getattr(query_map, "diff_commit_id", "") or "").strip()
-        if query_map.execution_mode != "query" and (
+        # A map bound to a query ID needs no commit at all: the full query runs
+        # by ID and Forward resolves the latest commit server-side, so an empty
+        # `commit_id` is the intended resting state and not an issue to report.
+        # Reporting it produced one indistinguishable row per enabled map - 32
+        # of them on one support bundle - which buried the rows that mattered.
+        # A path-bound map is different: its commit is resolved from the path at
+        # sync time, so an empty commit there is still worth stating.
+        if query_map.execution_mode == "query_path" and (
             not full_commit_id or full_commit_id == "head"
         ):
             issues.append(

--- a/forward_netbox/utilities/query_execution_contract.py
+++ b/forward_netbox/utilities/query_execution_contract.py
@@ -204,6 +204,11 @@ class ResolvedExecutionContract:
     diff_revision: ResolvedQueryRevision | None
     full_eligible: bool
     full_reason_code: str
+    # True when this map runs a full query by ID with no commit pinned, letting
+    # Forward resolve the latest commit. Not a defect - it is the intended path
+    # for an ID-bound map - but the executed revision is whatever is at head, so
+    # reporting says so instead of implying a pinned revision.
+    full_unpinned_head: bool
     diff_reason_code: str
     coalesce_fields: tuple[tuple[str, ...], ...]
     variant: str
@@ -373,6 +378,29 @@ def resolve_execution_contract(
     is_raw_query = getattr(spec, "query", None) is not None and not getattr(
         spec, "run_query_id", None
     )
+    # A map bound directly to a query ID needs no commit to run a FULL query.
+    # Forward's execution endpoint takes `queryId` and resolves the latest
+    # commit server-side; `_commit_id_for_nqe_execution` already omits an empty
+    # or "head" `commitId` from the POST body, and execution never sends a path,
+    # so the bound ID always runs the query the operator chose.
+    #
+    # Requiring us to pre-read a commit first is what turned a repository
+    # reorganisation, a permissions gap, or one transient history lookup into
+    # `unresolved_full_commit` on every enabled map - and, via the preflight in
+    # `_build_workload_jobs`, into a sync that planned zero jobs and applied
+    # nothing. There is nothing for us to resolve on this path, so the
+    # requirement is removed rather than made lenient.
+    #
+    # This relaxes ONLY the full contract. Diff execution is not comparable:
+    # `run_nqe_diff` POSTs to `/nqe-diffs/{before}/{after}`, where the two
+    # commits are path segments, not optional body fields, so a diff genuinely
+    # cannot run without concrete commits. `diff_reason_code` below is unchanged.
+    #
+    # The shape protection is NOT dropped with the commit: the source, declared
+    # parameter, and data-file checks below still run. A built-in map carries its
+    # bundled query source and hash, so its declarations are still parsed and
+    # still matched against the parameters this plugin injects.
+    runs_by_direct_query_id = bool(getattr(spec, "query_id", None))
     full_reason_code = "eligible"
     if is_raw_query:
         if full_declarations is None:
@@ -383,7 +411,9 @@ def resolve_execution_contract(
             full_reason_code = "raw_query"
     elif not full_revision.query_id:
         full_reason_code = "unresolved_query_id"
-    elif not full_revision.commit_id or full_revision.commit_id == "head":
+    elif not runs_by_direct_query_id and (
+        not full_revision.commit_id or full_revision.commit_id == "head"
+    ):
         full_reason_code = "unresolved_full_commit"
     elif not full_revision.source_verified:
         full_reason_code = "unverified_full_source"
@@ -432,6 +462,10 @@ def resolve_execution_contract(
             "missing_variant_data_hash",
         },
         full_reason_code=full_reason_code,
+        full_unpinned_head=bool(
+            runs_by_direct_query_id
+            and (not full_revision.commit_id or full_revision.commit_id == "head")
+        ),
         diff_reason_code=diff_reason_code,
         diff_revision=diff_revision,
         coalesce_fields=tuple(

--- a/forward_netbox/utilities/query_fetch_execution.py
+++ b/forward_netbox/utilities/query_fetch_execution.py
@@ -1883,6 +1883,7 @@ class ForwardQueryFetcher:
                         rows,
                         delete_rows,
                         coalesce_fields,
+                        contract=contract,
                     )
                 break
             except (
@@ -2205,13 +2206,40 @@ class ForwardQueryFetcher:
         rows: list[dict],
         delete_rows: list[dict],
         coalesce_fields: list[list[str]],
+        contract=None,
     ) -> None:
+        # A map bound to a query ID runs at whatever Forward has at head, so the
+        # row shape is confirmed here, against the rows actually returned, not
+        # by pre-reading a commit. Name the map when it fails: a bare
+        # "Row for `dcim.device` is missing required fields" does not say which
+        # of several enabled maps produced it, and this failure stops one model
+        # rather than the whole run.
         for row in rows:
-            validate_row_shape_for_model(model_string, row, coalesce_fields)
+            self._validate_row_shape(model_string, row, coalesce_fields, contract)
         for row in delete_rows:
-            validate_row_shape_for_model(model_string, row, coalesce_fields)
+            self._validate_row_shape(model_string, row, coalesce_fields, contract)
         if model_string == "dcim.virtualchassis":
             self._validate_virtual_chassis_positions(rows)
+
+    def _validate_row_shape(self, model_string, row, coalesce_fields, contract) -> None:
+        try:
+            validate_row_shape_for_model(model_string, row, coalesce_fields)
+        except ForwardQueryError as exc:
+            if contract is None:
+                raise
+            query_name = getattr(contract, "query_name", "") or model_string
+            map_id = getattr(contract, "map_id", None)
+            revision = (
+                "unpinned head"
+                if getattr(contract, "full_unpinned_head", False)
+                else "the pinned commit"
+            )
+            raise ForwardQueryError(
+                f"{exc} Returned by map `{query_name}`"
+                f"{f' [{map_id}]' if map_id is not None else ''} running at "
+                f"{revision}. The query no longer returns the fields "
+                f"{model_string} requires; re-resolve or republish that query."
+            ) from exc
 
     def _validate_virtual_chassis_positions(self, rows: list[dict]) -> None:
         seen_positions = {}


### PR DESCRIPTION
Fixes a customer whose every sync died on arrival — five consecutive ingestions, nothing applied.

**The defect.** A map bound to a query ID with no stored commit was rejected with `unresolved_full_commit`. One ineligible map zeroes planning for the whole sync, so `fetch_workloads` returns at its empty guard and `single_branch_executor.py:83` raises `SyncError`. No fetch ever runs — which is why every Forward API call returned 200 while the run produced nothing.

**This was our policy, not Forward's constraint.** `_nqe_async_execution_payload` already sends `queryId` alone and deliberately omits `commitId` for head. We invented a precondition the API never asked for.

Diff execution is untouched, because there the two commits are path segments in `/nqe-diffs/{before}/{after}` and genuinely required.

**Confirmed against the customer's support bundle** — all 32 maps: `has_query_id=True`, `has_commit_id=False`, `commit_binding=latest_commit`, `query_repository=org`, names matching the bundled queries. Exactly the case this restores.

**Shape protection moved rather than removed.** Declarations are still parsed and matched for built-ins, and `validate_rows` now names the map, its id, and the unpinned-head state on a row-shape failure — one model, precisely, instead of thirty, opaquely.

**Also corrects a health check that was actively misleading.** `query_contract_preflight` listed query-ID maps with no commit as an `info` line reading "This is informational: head is resolved at sync time" — while those syncs were dying. Note that this health computation reads `commit_id` at render and is *not* the code that rejected the contract; the two share a reason-code name. `health.py` carried a recorded counter-example of 32/32 maps reporting it while a sync applied 24,748 changes, so making it blocking would have failed every healthy install. A new fetch-failure check reads `latest_ingestion.model_results` instead: fail when every model failed, warn naming models when some did.

Known limit, documented: custom (non-built-in) ID-bound maps still close on `unverified_full_source`, because source hydration is keyed by commit and there is no read-source-by-ID-at-head capability today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166CtWtsA6qbWz32TZ6zgny