### PR TITLE
fix: attribute an interface NetBox refuses, and say which rule refused it

### DIFF
--- a/docs/03_Plans/active/2026-08-05-interface-validation-tranche.md
+++ b/docs/03_Plans/active/2026-08-05-interface-validation-tranche.md
@@ -1,0 +1,115 @@
+# Stop one interface from failing an entire sync, and say what rejected it
+
+## Goal
+
+Customer ingestion 2719 on 2.7.2 staged 172 changes, failed the whole sync, and
+produced one issue row: phase `sync`, model blank, `Forward ingestion failed
+(ValidationError) on invalid field(s) untagged_vlan.` Three defects behind that
+one row, fixed together because each one hides the next.
+
+## Contract
+
+- A row NetBox refuses is attributed to `dcim.interface`, names the device and
+  the interface, and does not stop the shard.
+- A rejection is recorded with the RULE that fired, not only the field it
+  landed on. `untagged_vlan` carries two unrelated NetBox rules.
+- A rejection on state the row does not write is skipped, not failed: it is not
+  retryable and it is not ours, and a failure fails the row's dependents.
+- No message text is persisted. Rule slugs and field names only, with
+  `redacted_message_shape` for anything uncatalogued.
+
+## Constraints
+
+- `full_clean` validates the whole object and `exclude` does NOT filter errors
+  raised by `Model.clean()` — Django merges them into the error dict verbatim.
+  So field-scoping the validation call cannot avoid this; the disposition has
+  to be decided after the rejection, not before it.
+- `bulk_update` bypasses `save()` and `clean()`. That is how the invalid state
+  gets there in the first place (moving a device's site never revalidates its
+  interfaces) and it is why validating here is voluntary rather than structural.
+- The tail loop counts one statistic per appended outcome slot, so a call site
+  that already appended one must not also increment directly.
+- No customer identifiers.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/diagnostics.py` — rule catalogue and reader
+- `forward_netbox/utilities/sync_reporting.py` — issue detail composition
+- `forward_netbox/utilities/apply_engine_bulk.py` — `_validate_interface` and
+  its four call sites
+- `forward_netbox/tests/test_merge_rule_rejection.py`,
+  `forward_netbox/tests/test_sync.py`
+
+## Approach
+
+**Rule catalogue reads every field, not just `__all__`.** `__all__` is the
+absence of a field name, which is why it was the only case the catalogue
+covered; a field name is equally silent about which rule fired. The catalogue
+gains the two NetBox interface rules, and `describe_failure` and the issue
+recorder report the field and the rule together instead of choosing.
+
+**`_validate_interface` captures instead of propagating.** It returns `"ok"`,
+`"skipped"` or `"failed"`, records the issue itself so four call sites cannot
+describe it differently, and leaves counting to the caller, which is the only
+one that knows whether an outcome slot exists.
+
+**Disposition is decided by what the row writes.** Each call site passes the
+fields it is writing. A catalogued rule on a field outside that set is
+pre-existing state: recorded, skipped, dependents untouched. Anything else —
+including an uncatalogued rule — stays a failure.
+
+## Validation
+
+Two new sync tests build the real shape via `queryset.update()`, since `save()`
+and `full_clean()` both refuse to create it: a cross-site untagged VLAN on an
+existing interface is skipped while an unrelated interface in the same shard is
+still created, and an out-of-range MTU on a field the row does write still
+fails. Plus five diagnostics tests, including that the two `untagged_vlan`
+rules are distinguishable and that values in a field-scoped message are still
+masked.
+
+## Rollback
+
+Revert. The change is confined to failure handling; nothing migrates and no
+persisted shape changes except issue `message`/`raw_data` content.
+
+## Decision Log
+
+- **Skip rather than write around the violation.** We could write only the
+  changed fields with `bulk_update`, which bypasses validation anyway, and
+  leave the pre-existing violation in place. Refused: the object would be
+  written while known-invalid, and the operator would get no signal. Skipping
+  costs that interface's MTU update until the VLAN is fixed, and says so.
+- **Uncatalogued rules stay failures.** Skipping is the disposition for a
+  rejection we understand and did not cause. Treating anything we cannot name
+  as someone else's problem is how a real defect gets quietly downgraded.
+- **The member row is what a LAG parent rejection is recorded against.** A
+  synthesised parent has no row of its own; that is the only attribution there
+  is, and it is better than none.
+
+## Open
+
+- **The adapter path was left alone and now disagrees.** A test written against
+  `_apply_model_rows` turned out to exercise the row-oriented adapter, not the
+  bulk engine — it logged `Failed applying dcim.interface row
+  (ValidationError).` and had to be retargeted. The adapter validates inside the
+  generic `_upsert_values_from_defaults`, so applying this disposition there
+  changes failure handling for every model, not just interfaces; that needs its
+  own blast-radius review. `test_bulk_adapter_parity` compares final DB state
+  and both paths write nothing in the skip case, so it does not catch the
+  divergence — a test covering the interface's dependents would. Tracked as #50.
+  The customer's failure was the bulk path (an issue with no model at all is
+  only produced by the uncaptured bulk path), so the fix is not blocked on it.
+- `_is_destination_rule_rejection` in the merge path is still
+  `isinstance(exc, ValidationError)` — every validation rejection at merge is
+  treated as unsatisfiable. The predicate added here (a catalogued rule on a
+  field the change does not write) is the narrowing that task #39 asks for, and
+  should replace it. Left out of this change because the merge path has no
+  notion of "fields this row writes" and needs its own derivation from the
+  change diff.
+- Which of the two `untagged_vlan` rules the customer actually hit is still
+  unknown. This change is what makes the next occurrence say so.
+- The plugin moves a device between sites without revalidating that device's
+  interfaces, which is the mechanism that produces the cross-site pairing.
+  Detecting it at the point it is created, rather than at the next sync that
+  touches the interface, is not addressed here.

--- a/forward_netbox/tests/test_merge_rule_rejection.py
+++ b/forward_netbox/tests/test_merge_rule_rejection.py
@@ -154,6 +154,84 @@ class DescribeFailurePrecedenceTests(SimpleTestCase):
         )
         self.assertIn("on invalid field(s) address.", message)
 
+    def test_a_named_field_and_its_rule_are_both_reported(self):
+        # They are different facts. The field says where the rejection landed,
+        # the rule says what rejected it, and reporting only the field is what
+        # left a customer's `untagged_vlan` failure ambiguous between two
+        # unrelated NetBox rules.
+        message = describe_failure(
+            "Forward ingestion failed (ValidationError).",
+            {
+                "invalid_fields": ["untagged_vlan"],
+                "validation_rules": ["untagged-vlan-outside-device-site"],
+            },
+        )
+        self.assertIn("on invalid field(s) untagged_vlan", message)
+        self.assertIn("violating untagged-vlan-outside-device-site.", message)
+
+
+class FieldScopedValidationRuleTests(SimpleTestCase):
+    """A rule must be nameable whether or not NetBox scoped it to a field.
+
+    Reading `__all__` alone made a rule legible exactly when NetBox declined to
+    say which field it concerned, and illegible whenever NetBox did say. One
+    field routinely carries several unrelated rules, so the field name alone
+    does not identify the rejection.
+    """
+
+    UNTAGGED_VLAN_SITE = ValidationError(
+        {
+            "untagged_vlan": [
+                "The untagged VLAN (Vlan211 (211)) must belong to the same site "
+                "as the interface's parent device, or it must be global."
+            ]
+        }
+    )
+    UNTAGGED_VLAN_MODE = ValidationError(
+        {"untagged_vlan": ["Interface mode does not support an untagged vlan."]}
+    )
+
+    def test_cross_site_untagged_vlan_is_named(self):
+        diagnosis = structured_failure_diagnosis(self.UNTAGGED_VLAN_SITE)
+        self.assertEqual(["untagged_vlan"], diagnosis["invalid_fields"])
+        self.assertEqual(
+            ["untagged-vlan-outside-device-site"], diagnosis["validation_rules"]
+        )
+
+    def test_untagged_vlan_without_mode_is_named(self):
+        diagnosis = structured_failure_diagnosis(self.UNTAGGED_VLAN_MODE)
+        self.assertEqual(
+            ["untagged-vlan-needs-interface-mode"], diagnosis["validation_rules"]
+        )
+
+    def test_the_two_untagged_vlan_rules_are_distinguishable(self):
+        # The whole point: a customer sync recorded `untagged_vlan` and nothing
+        # else, and these two have different causes and different fixes.
+        self.assertNotEqual(
+            structured_failure_diagnosis(self.UNTAGGED_VLAN_SITE)["validation_rules"],
+            structured_failure_diagnosis(self.UNTAGGED_VLAN_MODE)["validation_rules"],
+        )
+
+    def test_an_uncatalogued_field_rule_keeps_its_wording(self):
+        diagnosis = structured_failure_diagnosis(
+            ValidationError(
+                {"mtu": ["Ensure this value is less than or equal to 65536."]}
+            )
+        )
+        self.assertNotIn("validation_rules", diagnosis)
+        shape = " ".join(diagnosis["unrecognized_validation_rules"])
+        self.assertIn("Ensure this value is less than or equal to", shape)
+
+    def test_values_in_a_field_scoped_message_are_still_masked(self):
+        # Field-scoped messages quote submitted values just as freely as
+        # non-field ones; reading more messages must not start persisting them.
+        diagnosis = structured_failure_diagnosis(
+            ValidationError({"name": ["Device host-9.internal.example is invalid."]})
+        )
+        shape = " ".join(diagnosis["unrecognized_validation_rules"])
+        self.assertNotIn("host-9.internal.example", shape)
+        self.assertIn("invalid", shape)
+
 
 PRIMARY_IP_REJECTION = ValidationError(
     {

--- a/forward_netbox/tests/test_sync.py
+++ b/forward_netbox/tests/test_sync.py
@@ -59,6 +59,9 @@ from forward_netbox.utilities.apply_engine import BULK_ORM_ENABLED_MODELS_WITHOU
 from forward_netbox.utilities.apply_engine import select_apply_engine
 from forward_netbox.utilities.apply_engine import UNCLASSIFIED_SUPPORTED_MODELS
 from forward_netbox.utilities.apply_engine_bulk import (
+    bulk_orm_apply_interface,
+)
+from forward_netbox.utilities.apply_engine_bulk import (
     bulk_orm_apply_tree_models,
 )
 from forward_netbox.utilities.branch_budget import APPLY_DEPENDENCY_MODEL_RANK
@@ -3523,6 +3526,112 @@ select {name: site.name, slug: site.name}
         self.assertTrue(
             any("VLAN was not imported" in message for message in warning_messages)
         )
+
+    def _reject_untagged_vlan_on_existing_interface(self, device, name):
+        """Leave a cross-site untagged VLAN NetBox will refuse.
+
+        Written with `queryset.update()` on purpose: `save()` and `full_clean()`
+        both refuse this pairing, and the point is that a real deployment gets
+        there anyway — a device whose Forward location changed is moved between
+        sites by `bulk_update`, which runs neither, and its interfaces keep the
+        VLAN of the site they were assigned in.
+        """
+        other_site = Site.objects.create(name="site-2", slug="site-2")
+        other_vlan = VLAN.objects.create(
+            site=other_site, vid=30, name="elsewhere", status="active"
+        )
+        interface = Interface.objects.create(
+            device=device, name=name, type="1000base-t", mode="access"
+        )
+        Interface.objects.filter(pk=interface.pk).update(untagged_vlan=other_vlan)
+        return interface
+
+    def test_interface_rejected_on_untouched_field_is_skipped_not_failed(self):
+        device = self._create_device("device-1")
+        self._reject_untagged_vlan_on_existing_interface(device, "eth1-1")
+        logger = Mock()
+        runner = ForwardSyncRunner(
+            sync=self.sync, ingestion=None, client=None, logger_=logger
+        )
+
+        # The bulk engine directly: this is the path that runs at customer
+        # scale, and the one whose uncaptured `ValidationError` ended a sync.
+        #
+        # No `mode`, so the row writes neither mode nor untagged_vlan; the only
+        # change it asks for is the MTU.
+        bulk_orm_apply_interface(
+            runner,
+            [
+                {
+                    "device": "device-1",
+                    "name": "eth1-1",
+                    "type": "1000base-t",
+                    "lag": None,
+                    "enabled": True,
+                    "mtu": 9000,
+                    "description": "",
+                    "speed": 1000000,
+                },
+                {
+                    "device": "device-1",
+                    "name": "eth1-2",
+                    "type": "1000base-t",
+                    "lag": None,
+                    "enabled": True,
+                    "mtu": 1500,
+                    "description": "",
+                    "speed": 1000000,
+                },
+            ],
+        )
+
+        # The rejected row does not stop the shard: the unrelated interface is
+        # still created. This is the failure that ended a customer sync with 172
+        # changes staged and nothing merged.
+        self.assertTrue(Interface.objects.filter(device=device, name="eth1-2").exists())
+        # And the rejected row is not written.
+        self.assertIsNone(
+            Interface.objects.get(device=device, name="eth1-1").mtu,
+        )
+        outcomes = [
+            call.kwargs.get("outcome")
+            for call in logger.increment_statistics.call_args_list
+        ]
+        self.assertIn("skipped", outcomes)
+        self.assertNotIn("failed", outcomes)
+
+    def test_interface_rejected_on_a_field_the_row_writes_still_fails(self):
+        self._create_device("device-1")
+        logger = Mock()
+        runner = ForwardSyncRunner(
+            sync=self.sync, ingestion=None, client=None, logger_=logger
+        )
+
+        # An MTU outside NetBox's accepted range is this row's own doing, and it
+        # names no catalogued rule, so it must stay a failure - "skipped" is the
+        # disposition for a rejection we understand and did not cause.
+        bulk_orm_apply_interface(
+            runner,
+            [
+                {
+                    "device": "device-1",
+                    "name": "eth1-1",
+                    "type": "1000base-t",
+                    "lag": None,
+                    "enabled": True,
+                    "mtu": 99999999,
+                    "description": "",
+                    "speed": 1000000,
+                },
+            ],
+        )
+
+        self.assertFalse(Interface.objects.filter(name="eth1-1").exists())
+        outcomes = [
+            call.kwargs.get("outcome")
+            for call in logger.increment_statistics.call_args_list
+        ]
+        self.assertIn("failed", outcomes)
 
     def test_apply_dcim_interface_creates_lag_placeholder_across_shards(self):
         self._create_device("device-1")

--- a/forward_netbox/utilities/apply_engine_bulk.py
+++ b/forward_netbox/utilities/apply_engine_bulk.py
@@ -1248,10 +1248,12 @@ def bulk_orm_apply_interface(
     from dcim.models import Device
     from dcim.models import Interface
     from django.core.exceptions import ObjectDoesNotExist
+    from django.core.exceptions import ValidationError
     from django.db import transaction
 
     from ..exceptions import ForwardDependencySkipError
     from ..exceptions import ForwardSearchError
+    from .diagnostics import structured_failure_diagnosis
     from .interface_naming import canonical_interface_key
     from .sync_interface import _interface_untagged_vlan
     from .sync_primitives import forget_lookup_object
@@ -1267,18 +1269,77 @@ def bulk_orm_apply_interface(
         "lag",
     ]
 
-    def _validate_interface(interface):
+    def _validate_interface(interface, row, device, written_fields):
+        """Validate one interface. Returns "ok", "skipped" or "failed".
+
+        A `ValidationError` raised here used to leave this function, the apply
+        engine and the sync itself: it surfaced at `_record_forward_sync_failure`,
+        which records phase `sync` with no model and no row. So a single
+        interface NetBox would not accept failed an entire customer run of 172
+        staged changes, and the only evidence produced named neither the device
+        nor the interface — the row-oriented path and the cabled-LAG branch
+        below both capture per row, and this loop was the one that did not.
+
+        The caller counts the outcome, because only the caller knows whether an
+        outcome slot has already been appended for the row; recording the issue
+        happens here so all four call sites cannot describe it differently.
+
+        `written_fields` is what this row actually writes, which decides the
+        disposition. `full_clean` validates the whole object, so a rejection can
+        name a field the row never touched — an untagged VLAN left behind by a
+        device that moved sites is still on the interface when a later sync
+        changes only its MTU. Refusing to write is right either way, but calling
+        it *our* failure is not: it fails the row's dependents and it is not
+        retryable, since nothing about the incoming data can change the answer.
+        A rule the catalogue can name, on a field this row does not write, is
+        therefore recorded and skipped. Anything else stays a failure.
+        """
         # A device created earlier in the same native branch has no row in the
         # main schema. Django's ForeignKey field validation resolves its
         # queryset outside the active branch and rejects that valid branch-only
         # device. The device was already resolved explicitly above and the
         # branch FK enforces it at write time, so validate every other field and
         # the model contract without repeating that cross-schema lookup.
-        interface.full_clean(
-            exclude={"device"},
-            validate_unique=False,
-            validate_constraints=False,
-        )
+        try:
+            interface.full_clean(
+                exclude={"device"},
+                validate_unique=False,
+                validate_constraints=False,
+            )
+        except ValidationError as exc:
+            # The instance was mutated in place before validation, so a cached
+            # lookup would hand the rejected state to a later row in this same
+            # shard and write it under a different row's outcome.
+            forget_lookup_object(runner, interface)
+            diagnosis = structured_failure_diagnosis(exc)
+            rejected = set(diagnosis.get("invalid_fields") or ())
+            # An uncatalogued rule is left a failure deliberately: skipping is
+            # the disposition for a rejection we understand, and an unrecognised
+            # one is exactly the case where we should not be deciding it is
+            # someone else's problem.
+            if diagnosis.get("validation_rules") and not (rejected & written_fields):
+                runner._record_issue(
+                    "dcim.interface",
+                    f"Skipping interface `{row.get('name')}` on `{device.name}`: "
+                    "NetBox rejects existing state on this interface that the "
+                    "sync does not write.",
+                    row,
+                    exception=exc,
+                    context={"device": device.name, "name": row.get("name")},
+                    log_level="warning",
+                )
+                return "skipped"
+            runner._mark_dependency_failed("dcim.interface", row)
+            runner._record_issue(
+                "dcim.interface",
+                f"Interface `{row.get('name')}` on device `{device.name}` was "
+                "rejected by NetBox validation.",
+                row,
+                exception=exc,
+                context={"device": device.name, "name": row.get("name")},
+            )
+            return "failed"
+        return "ok"
 
     device_names = {row.get("device") for row in rows if row.get("device")}
     devices_by_name = {}
@@ -1501,7 +1562,17 @@ def bulk_orm_apply_interface(
                 interface = Interface(**defaults)
                 # Identity proven absent above; skip the per-row validate_unique
                 # DB query (constraint violations still surface via isolate).
-                _validate_interface(interface)
+                # Every field of a new interface is written by this row, so a
+                # rejection here is always ours and never pre-existing state.
+                disposition = _validate_interface(interface, row, device, set(defaults))
+                if disposition != "ok":
+                    # No outcome slot has been appended for this row yet, so the
+                    # tail loop will not count it; count it here as the
+                    # device-not-found paths above do.
+                    runner.logger.increment_statistics(
+                        "dcim.interface", outcome=disposition
+                    )
+                    continue
                 create_objects[key] = interface
                 if canon_key is not None:
                     pending_canonical[canon_key] = interface
@@ -1523,7 +1594,14 @@ def bulk_orm_apply_interface(
             _snapshot_once(existing)
             for field, value in changed_values:
                 setattr(existing, field, value)
-            _validate_interface(existing)
+            disposition = _validate_interface(
+                existing, row, device, {field for field, _ in changed_values}
+            )
+            if disposition != "ok":
+                # The outcome slot is already appended, so the tail loop counts
+                # this row; marking it here would count it twice.
+                outcome[0] = disposition
+                continue
             update_objects[existing.pk] = existing
             outcome[0] = "applied"
         if row.get("lag"):
@@ -1552,7 +1630,19 @@ def bulk_orm_apply_interface(
                 description="",
                 speed=None,
             )
-            _validate_interface(parent)
+            # The member row is what gets recorded: the parent is synthesised
+            # here and has no row of its own, so attributing the rejection to
+            # the member is the only attribution available. Every field of that
+            # synthesised parent is written here.
+            disposition = _validate_interface(
+                parent,
+                row,
+                device,
+                {"device", "name", "type", "enabled", "mtu", "description", "speed"},
+            )
+            if disposition != "ok":
+                outcome[0] = disposition
+                continue
             create_objects[(device.pk, lag_name)] = parent
             canon = canonical_interface_key(lag_name)
             if canon is not None:
@@ -1561,7 +1651,10 @@ def bulk_orm_apply_interface(
         elif parent.type != "lag":
             _snapshot_once(parent)
             parent.type = "lag"
-            _validate_interface(parent)
+            disposition = _validate_interface(parent, row, device, {"type"})
+            if disposition != "ok":
+                outcome[0] = disposition
+                continue
             if getattr(parent, "pk", None) is not None:
                 update_objects[parent.pk] = parent
             outcome[0] = "applied"

--- a/forward_netbox/utilities/diagnostics.py
+++ b/forward_netbox/utilities/diagnostics.py
@@ -461,11 +461,20 @@ def sanitize_job_diagnostics(value):
 # (`_("{ip} is a network ID...").format(ip=...)`), so by the time the exception
 # exists the address is inside the string.
 #
+# A field-scoped error is no better off. A field name identifies *where* the
+# rejection landed, not *which rule* rejected it, and one field routinely
+# carries several unrelated rules: NetBox raises on `untagged_vlan` both for an
+# interface whose mode does not admit one and for a VLAN outside the device's
+# site. Those have different causes and different fixes, and a customer sync
+# recorded only the field name for one of them - leaving the failure as
+# undiagnosable as the `__all__` case this table was built for. So every
+# message is matched here, whatever field it names.
+#
 # Matching against an allowlist keeps the rule identifiable while persisting
 # only slugs this module defines. An unrecognised message records that it was
 # unrecognised and nothing else, which is a prompt to extend this table rather
 # than a reason to start storing message text.
-_NON_FIELD_VALIDATION_RULES = (
+_VALIDATION_RULES = (
     ("network-id-not-assignable", "is a network id, which may not be assigned"),
     ("broadcast-not-assignable", "is a broadcast address, which may not be assigned"),
     (
@@ -479,6 +488,14 @@ _NON_FIELD_VALIDATION_RULES = (
     (
         "primary-mac-reassignment-blocked",
         "cannot reassign mac address while it is designated as the primary mac",
+    ),
+    (
+        "untagged-vlan-needs-interface-mode",
+        "interface mode does not support an untagged vlan",
+    ),
+    (
+        "untagged-vlan-outside-device-site",
+        "must belong to the same site as the interface's parent",
     ),
 )
 
@@ -510,22 +527,30 @@ def redacted_message_shape(message: str) -> str:
     return " ".join(kept)
 
 
-def _non_field_validation_rules(exc) -> tuple[list[str], list[str]]:
+def _validation_rules(exc) -> tuple[list[str], list[str]]:
     """Recognised rule slugs, plus redacted wording for anything unrecognised."""
     # Only a dict-constructed ValidationError has `message_dict`; a bare one
     # raises AttributeError, which `getattr` swallows into None. `full_clean()`
     # produces the dict form, but a ValidationError raised directly still has
     # to be diagnosable - reading only `message_dict` would silently record
     # nothing for it.
+    #
+    # Every field is read, not just `__all__`. Reading `__all__` alone was the
+    # whole gap: it made a rule legible exactly when NetBox declined to say
+    # which field it concerned, and illegible whenever NetBox did say.
     if hasattr(exc, "error_dict"):
-        non_field = list(getattr(exc, "message_dict", {}).get("__all__", ()))
+        messages = [
+            message
+            for field_messages in getattr(exc, "message_dict", {}).values()
+            for message in field_messages
+        ]
     else:
-        non_field = list(getattr(exc, "messages", ()) or ())
+        messages = list(getattr(exc, "messages", ()) or ())
     matched = set()
     unrecognized = []
-    for message in non_field:
+    for message in messages:
         haystack = str(message).casefold()
-        for slug, needle in _NON_FIELD_VALIDATION_RULES:
+        for slug, needle in _VALIDATION_RULES:
             if needle in haystack:
                 matched.add(slug)
                 break
@@ -557,13 +582,21 @@ def describe_failure(message: str, diagnosis: dict) -> str:
         return f"{stem} for {len(failed_models)} model(s): {listed}."
     if constraint:
         return f"{stem} on constraint {constraint}."
+    # `__all__` is the absence of a field name, so it is never worth printing;
+    # a real field name is, and now that rules are read from every field the two
+    # are no longer alternatives. Which field was rejected and which rule
+    # rejected it are different facts, and the field alone was what left a
+    # customer's `untagged_vlan` failure ambiguous between two unrelated causes.
+    named_fields = [field for field in invalid_fields if field != "__all__"]
+    if named_fields:
+        stem = f"{stem} on invalid field(s) {', '.join(named_fields)}"
     if rules:
         return f"{stem} violating {', '.join(rules)}."
     if unrecognized:
         # Wording only - every value-bearing token has already been masked.
         return f"{stem}: {'; '.join(unrecognized)}."
-    if invalid_fields:
-        return f"{stem} on invalid field(s) {', '.join(invalid_fields)}."
+    if named_fields:
+        return f"{stem}."
     return message
 
 
@@ -603,7 +636,7 @@ def structured_failure_diagnosis(exc) -> dict:
     # validation failure exactly as opaque as recording nothing. This runs for
     # a bare ValidationError too, which has no `message_dict` at all and would
     # otherwise be recorded as nothing but its exception class.
-    rules, unrecognized = _non_field_validation_rules(exc)
+    rules, unrecognized = _validation_rules(exc)
     if rules:
         diagnosis["validation_rules"] = rules
     if unrecognized:

--- a/forward_netbox/utilities/sync_reporting.py
+++ b/forward_netbox/utilities/sync_reporting.py
@@ -361,17 +361,26 @@ def record_issue(
     # through `safe_operation_failure`, said `shape-error`. Schema-level detail
     # is appended to the shared name; it does not replace it.
     named = failure_classifier(exception) if exception is not None else exception_name
+    # The field and the rule are different facts, and a rule is now recognised
+    # whatever field it names, so they are no longer alternatives - reporting
+    # only the field is what left a customer's `untagged_vlan` rejection
+    # ambiguous between two unrelated NetBox rules. `__all__` is the absence of
+    # a field name rather than one, so it is still never printed.
+    named_fields = [field for field in invalid_fields if field != "__all__"]
+    field_detail = f"invalid fields {', '.join(named_fields)}" if named_fields else ""
     if is_dependency_skip_summary:
         detail = ""
     elif constraint:
         detail = f"{named}; constraint {constraint}"
     elif rules:
-        detail = f"{named}; {', '.join(rules)}"
+        detail = "; ".join(p for p in (named, field_detail, ", ".join(rules)) if p)
     elif unrecognized:
         # Wording only; value-bearing tokens are masked before they get here.
-        detail = f"{named}; {'; '.join(unrecognized)}"
-    elif invalid_fields:
-        detail = f"{named}; invalid fields {', '.join(invalid_fields)}"
+        detail = "; ".join(
+            p for p in (named, field_detail, "; ".join(unrecognized)) if p
+        )
+    elif field_detail:
+        detail = f"{named}; {field_detail}"
     else:
         detail = named
     message = (


### PR DESCRIPTION
Customer ingestion on 2.7.2: 172 changes staged, sync failed outright, one issue row — phase `sync`, model blank, `Forward ingestion failed (ValidationError) on invalid field(s) untagged_vlan.` Three defects behind it.

**#47 — one rejected interface failed the whole run.** The bulk interface loop had no per-row capture; the row-oriented path and the cabled-LAG branch above it both do. The `ValidationError` left the apply engine and surfaced at `_record_forward_sync_failure`, which records phase `sync` with no model and no row. Now recorded against `dcim.interface` with the device and interface named, and the shard continues.

**#48 — validation rejected state the row never wrote.** `full_clean` validates the whole object while an update writes only what differs. Field-scoping the call cannot help: Django merges `Model.clean()` errors into the dict without consulting `exclude`. Each call site now passes what it writes; a catalogued rule on a field outside that set is skipped, not failed — it is not retryable, and a failure also fails the row's dependents. Uncatalogued rules stay failures.

**#49 — a field-scoped rejection recorded the field but discarded the rule.** The catalogue read only `__all__`. `untagged_vlan` carries two unrelated NetBox rules (`device_components.py:1122` and `:1126`) with different causes and different fixes, and nothing we recorded could distinguish them. Every field is matched now, both rules catalogued, field and rule reported together.

Blake's row would now read `... on invalid field(s) untagged_vlan violating untagged-vlan-outside-device-site.`

### Deliberately not in scope
- The adapter path now disagrees on disposition (#50). It validates inside a generic upsert shared by every model, so the same change there needs its own blast-radius review. Found while writing the tests — a test against `_apply_model_rows` hit the adapter, not the bulk engine, and had to be retargeted. The customer's failure was the bulk path; an issue with no model at all is only produced there.
- Narrowing the merge path's `_is_destination_rule_rejection`, still `isinstance(exc, ValidationError)`, with the predicate added here (#39).

### Tests
Two sync tests build the real shape with `queryset.update()`, since `save()` and `full_clean()` both refuse to create it: a cross-site untagged VLAN is skipped while an unrelated interface in the same shard is still created, and an out-of-range MTU on a field the row does write still fails. Five diagnostics tests, including that the two `untagged_vlan` rules are distinguishable and that values in a field-scoped message are still masked.

Local gates, all green: `pre-commit run --all-files` (to convergence), `scripts/tests` (Ran 328, OK), `check_harness.py`, `check_harness.py --base origin/main`, and the touched Django suites (Ran 329, OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPmp33tVZYDSeuBL4seyw8