### PR TITLE
fix: one validation disposition for both apply paths

### DIFF
--- a/docs/03_Plans/active/2026-08-05-one-validation-disposition.md
+++ b/docs/03_Plans/active/2026-08-05-one-validation-disposition.md
@@ -1,0 +1,84 @@
+# One validation disposition for both apply paths
+
+## Goal
+
+The interface tranche taught the bulk engine to skip a rejection about state the
+row does not write. The row-oriented adapter kept failing the same row, so the
+two apply paths reached opposite conclusions about the same interface while each
+was locally correct. Make it one predicate, used by both.
+
+## Contract
+
+- `is_preexisting_rule_rejection(exc, written_fields)` is the only place the
+  question is answered. Both apply paths call it; neither reimplements it.
+- A skip does not mark the row's dependents failed. The object still exists —
+  the sync only declined to change it — so its IP and MAC rows still resolve.
+- A path that does not say what it wrote keeps failing. Inferring "not ours"
+  from silence is the wrong default.
+
+## Constraints
+
+- The adapter validates inside `coalesce_update_or_create`, which every model
+  goes through. The disposition therefore cannot be decided there without
+  deciding it for everything, so the writer attaches what it wrote and the
+  generic recorder decides.
+- Only a catalogued rule can produce a skip, and the catalogue is seven rules.
+  That is what keeps a change to the generic row loop from being a change to
+  every model's failure handling.
+- `full_clean` on create validates an object whose every field the row wrote, so
+  a create can never be pre-existing state. Said explicitly rather than inferred.
+- No customer identifiers.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/diagnostics.py` — the predicate
+- `forward_netbox/utilities/sync_primitives.py` — attach `forward_written_fields`
+  on both the create and update `full_clean`
+- `forward_netbox/utilities/sync_reporting.py` — the generic row-loop catch
+- `forward_netbox/utilities/apply_engine_bulk.py` — drop the inline copy
+- `forward_netbox/tests/test_sync.py`,
+  `forward_netbox/tests/test_merge_rule_rejection.py`
+
+## Approach
+
+The exception carries the answer to the one question the recorder cannot derive:
+which fields this change wrote. `full_clean` validates the whole object, so the
+rejection alone cannot distinguish "we wrote something invalid" from "something
+invalid was already there". Everything else — is the rule catalogued, does the
+rejected field intersect what was written — is derivable and lives in the
+predicate.
+
+## Validation
+
+The adapter parity test drives the same cross-site untagged VLAN through
+`_apply_model_rows` and asserts both the `skipped` outcome and that the
+dependency is NOT marked failed. Five predicate unit tests cover the written /
+unwritten split, an uncatalogued rule, a non-`ValidationError`, and an empty
+written set. Full plugin suite run, not just the touched files, because the
+change lands in the generic row loop.
+
+## Rollback
+
+Revert. No migration, no persisted shape change; a reverted build returns every
+rejection to `failed`.
+
+## Decision Log
+
+- **The writer attaches the field set; the recorder decides.** The alternative
+  was deciding disposition inside `coalesce_update_or_create`, which would have
+  put model-specific policy in the one function every model shares.
+- **`getattr(exc, "forward_written_fields", None)` defaults to failing.** Any
+  raiser that has not been taught to say what it wrote keeps today's behaviour,
+  so this cannot silently downgrade a path nobody reviewed.
+- **The bulk path lost its inline copy rather than keeping a fast local one.**
+  Two implementations of this question is exactly what produced the divergence.
+
+## Open
+
+- `_is_destination_rule_rejection` at merge is still
+  `isinstance(exc, ValidationError)`. It now has a predicate to narrow to, but
+  the merge path has no notion of "fields this change writes" — it would have to
+  derive one from the change diff. Task #39.
+- The catalogue is seven rules, so most rejections still cannot be skipped even
+  when they are genuinely pre-existing. Growing it is a per-rule decision, made
+  when a rule actually shows up in the field, not speculatively.

--- a/forward_netbox/tests/test_merge_rule_rejection.py
+++ b/forward_netbox/tests/test_merge_rule_rejection.py
@@ -26,6 +26,7 @@ from forward_netbox.models import ForwardIngestion
 from forward_netbox.models import ForwardSource
 from forward_netbox.models import ForwardSync
 from forward_netbox.utilities.diagnostics import describe_failure
+from forward_netbox.utilities.diagnostics import is_preexisting_rule_rejection
 from forward_netbox.utilities.diagnostics import redacted_message_shape
 from forward_netbox.utilities.diagnostics import structured_failure_diagnosis
 from forward_netbox.utilities.drift_report import build_latest_sync_evidence
@@ -168,6 +169,45 @@ class DescribeFailurePrecedenceTests(SimpleTestCase):
         )
         self.assertIn("on invalid field(s) untagged_vlan", message)
         self.assertIn("violating untagged-vlan-outside-device-site.", message)
+
+
+class PreexistingRuleRejectionTests(SimpleTestCase):
+    """One predicate for every apply path, so they cannot disagree again."""
+
+    CROSS_SITE = ValidationError(
+        {
+            "untagged_vlan": [
+                "The untagged VLAN (Vlan211 (211)) must belong to the same site "
+                "as the interface's parent device, or it must be global."
+            ]
+        }
+    )
+
+    def test_catalogued_rule_on_an_unwritten_field_is_preexisting(self):
+        self.assertTrue(is_preexisting_rule_rejection(self.CROSS_SITE, {"mtu"}))
+
+    def test_the_same_rule_on_a_written_field_is_ours(self):
+        self.assertFalse(
+            is_preexisting_rule_rejection(self.CROSS_SITE, {"mtu", "untagged_vlan"})
+        )
+
+    def test_an_uncatalogued_rule_is_never_preexisting(self):
+        # Skipping is the disposition for a rejection we understand. Treating
+        # what we cannot name as someone else's problem downgrades real defects.
+        self.assertFalse(
+            is_preexisting_rule_rejection(
+                ValidationError({"mtu": ["Ensure this value is less than 65536."]}),
+                {"description"},
+            )
+        )
+
+    def test_a_non_validation_error_is_never_preexisting(self):
+        self.assertFalse(is_preexisting_rule_rejection(IntegrityError("dup"), set()))
+
+    def test_no_written_fields_still_requires_a_catalogued_rule(self):
+        self.assertFalse(
+            is_preexisting_rule_rejection(ValidationError("something odd"), set())
+        )
 
 
 class FieldScopedValidationRuleTests(SimpleTestCase):

--- a/forward_netbox/tests/test_sync.py
+++ b/forward_netbox/tests/test_sync.py
@@ -3600,6 +3600,46 @@ select {name: site.name, slug: site.name}
         self.assertIn("skipped", outcomes)
         self.assertNotIn("failed", outcomes)
 
+    def test_adapter_path_reaches_the_same_disposition_as_bulk(self):
+        # `_apply_model_rows` takes the row-oriented adapter, which validates
+        # inside the generic upsert rather than in the interface code. It reached
+        # the opposite conclusion about the same interface while being locally
+        # correct, so the predicate is shared and this pins both paths to it.
+        device = self._create_device("device-1")
+        self._reject_untagged_vlan_on_existing_interface(device, "eth1-1")
+        logger = Mock()
+        runner = ForwardSyncRunner(
+            sync=self.sync, ingestion=None, client=None, logger_=logger
+        )
+
+        runner._apply_model_rows(
+            "dcim.interface",
+            [
+                {
+                    "device": "device-1",
+                    "name": "eth1-1",
+                    "type": "1000base-t",
+                    "lag": None,
+                    "enabled": True,
+                    "mtu": 9000,
+                    "description": "",
+                    "speed": 1000000,
+                },
+            ],
+        )
+
+        outcomes = [
+            call.kwargs.get("outcome")
+            for call in logger.increment_statistics.call_args_list
+        ]
+        self.assertIn("skipped", outcomes)
+        self.assertNotIn("failed", outcomes)
+        # A skip must not fail the row's dependents: the interface still exists,
+        # so its IP and MAC rows can still resolve it.
+        self.assertFalse(
+            runner._dependency_failed("dcim.interface", ("device-1", "eth1-1"))
+        )
+
     def test_interface_rejected_on_a_field_the_row_writes_still_fails(self):
         self._create_device("device-1")
         logger = Mock()

--- a/forward_netbox/utilities/apply_engine_bulk.py
+++ b/forward_netbox/utilities/apply_engine_bulk.py
@@ -1253,7 +1253,7 @@ def bulk_orm_apply_interface(
 
     from ..exceptions import ForwardDependencySkipError
     from ..exceptions import ForwardSearchError
-    from .diagnostics import structured_failure_diagnosis
+    from .diagnostics import is_preexisting_rule_rejection
     from .interface_naming import canonical_interface_key
     from .sync_interface import _interface_untagged_vlan
     from .sync_primitives import forget_lookup_object
@@ -1311,13 +1311,7 @@ def bulk_orm_apply_interface(
             # lookup would hand the rejected state to a later row in this same
             # shard and write it under a different row's outcome.
             forget_lookup_object(runner, interface)
-            diagnosis = structured_failure_diagnosis(exc)
-            rejected = set(diagnosis.get("invalid_fields") or ())
-            # An uncatalogued rule is left a failure deliberately: skipping is
-            # the disposition for a rejection we understand, and an unrecognised
-            # one is exactly the case where we should not be deciding it is
-            # someone else's problem.
-            if diagnosis.get("validation_rules") and not (rejected & written_fields):
+            if is_preexisting_rule_rejection(exc, written_fields):
                 runner._record_issue(
                     "dcim.interface",
                     f"Skipping interface `{row.get('name')}` on `{device.name}`: "

--- a/forward_netbox/utilities/diagnostics.py
+++ b/forward_netbox/utilities/diagnostics.py
@@ -600,6 +600,33 @@ def describe_failure(message: str, diagnosis: dict) -> str:
     return message
 
 
+def is_preexisting_rule_rejection(exc, written_fields) -> bool:
+    """True when a rejection is about state the change did not write.
+
+    `full_clean` validates the whole object, but a sync writes only the fields
+    that differ, so a rejection can name a field the row never touched — an
+    untagged VLAN left behind by a device that moved sites is still on the
+    interface when a later sync changes only its MTU. Refusing to write is right
+    either way; calling it *our* failure is not, because a failure also fails the
+    row's dependents and nothing about the incoming data makes it retryable.
+
+    Both halves matter. The rule must be one the catalogue can name: skipping is
+    the disposition for a rejection we understand, and treating anything we
+    cannot name as someone else's problem is how a real defect gets quietly
+    downgraded. And the rejected field must be outside what this change writes,
+    or it is ours by definition.
+
+    One predicate rather than one per apply path — the bulk engine and the
+    row-oriented adapter reached opposite conclusions about the same interface
+    while each was locally correct.
+    """
+    diagnosis = structured_failure_diagnosis(exc)
+    if not diagnosis.get("validation_rules"):
+        return False
+    rejected = set(diagnosis.get("invalid_fields") or ())
+    return not (rejected & set(written_fields or ()))
+
+
 def structured_failure_diagnosis(exc) -> dict:
     """Schema-level detail about a failure, never the values that caused it.
 

--- a/forward_netbox/utilities/sync_primitives.py
+++ b/forward_netbox/utilities/sync_primitives.py
@@ -137,6 +137,11 @@ def coalesce_update_or_create(
                 return obj, True, True
             return obj, True
         except (IntegrityError, ValidationError) as exc:
+            # Every field of a created row is written by that row, so a
+            # rejection here can never be pre-existing state. Saying so
+            # explicitly keeps the recorder from having to infer it.
+            if isinstance(exc, ValidationError):
+                exc.forward_written_fields = set(create_values)
             # A duplicate surfaces two different ways depending on who notices
             # first. `full_clean` checks uniqueness in Python and raises
             # ValidationError; a genuine race gets past that and the database
@@ -165,7 +170,14 @@ def coalesce_update_or_create(
             setattr(obj, field, value)
             update_fields.append(field)
     if update_fields:
-        obj.full_clean()
+        try:
+            obj.full_clean()
+        except ValidationError as exc:
+            # `full_clean` validates the whole object while this writes only the
+            # fields that differ, so the recorder needs to know which of the two
+            # it is looking at. It cannot work that out from the exception.
+            exc.forward_written_fields = set(update_fields)
+            raise
         obj.save(update_fields=update_fields)
     remember_lookup_object(runner, obj)
     _remember_unique_lookups(runner, model, lookups, obj)

--- a/forward_netbox/utilities/sync_reporting.py
+++ b/forward_netbox/utilities/sync_reporting.py
@@ -16,6 +16,7 @@ from ..exceptions import ForwardSyncDataError
 from .diagnostics import diagnostic_shape
 from .diagnostics import exception_type
 from .diagnostics import failure_classifier
+from .diagnostics import is_preexisting_rule_rejection
 from .diagnostics import structured_failure_diagnosis
 from .json_safe import json_safe_value
 from .sync_primitives import dependency_parent_coverage_summary
@@ -536,20 +537,40 @@ def apply_model_rows(runner, model_string, rows):
             )
         except (ValidationError, IntegrityError) as exc:
             runner.events_clearer.restore(pre_row_events)
+            # A rejection naming a catalogued rule on a field this row does not
+            # write is pre-existing state: recorded and skipped, not failed. The
+            # writer attaches what it wrote, because nothing about the exception
+            # says it. Absent that, the row keeps failing — inferring "not ours"
+            # from silence is exactly the wrong default.
+            written_fields = getattr(exc, "forward_written_fields", None)
+            preexisting = written_fields is not None and is_preexisting_rule_rejection(
+                exc, written_fields
+            )
             logger.error(
                 "Failed applying %s row (%s).",
                 model_string,
                 exception_type(exc),
             )
-            mark_dependency_failed(runner, model_string, row)
-            runner.logger.increment_statistics(model_string, outcome="failed")
-            record_issue(
-                runner,
-                model_string,
-                str(exc),
-                row,
-                exception=exc,
-            )
+            if preexisting:
+                runner.logger.increment_statistics(model_string, outcome="skipped")
+                record_issue(
+                    runner,
+                    model_string,
+                    str(exc),
+                    row,
+                    exception=exc,
+                    log_level="warning",
+                )
+            else:
+                mark_dependency_failed(runner, model_string, row)
+                runner.logger.increment_statistics(model_string, outcome="failed")
+                record_issue(
+                    runner,
+                    model_string,
+                    str(exc),
+                    row,
+                    exception=exc,
+                )
         except JobTimeoutException:
             raise
         except Exception as exc:


### PR DESCRIPTION
Follow-up to #144. That change taught the bulk engine to skip a rejection about state the row does not write; the row-oriented adapter kept failing the same row, so the two apply paths reached opposite conclusions about the same interface while each was locally correct. `test_bulk_adapter_parity` compares final DB state and both paths write nothing in that case, so nothing caught it.

`is_preexisting_rule_rejection` is now the single answer to that question, and the bulk path lost its inline copy — two implementations is what produced the divergence.

### Why the writer attaches the field set
The adapter validates inside `coalesce_update_or_create`, which every model goes through, so the disposition cannot be decided there without deciding it for every model. Instead the writer attaches the one fact the recorder cannot derive — which fields this change wrote. `full_clean` validates the whole object, so the rejection alone cannot distinguish "we wrote something invalid" from "something invalid was already there". Everything else is derivable and lives in the predicate.

### Blast radius
Smaller than the path suggests. A skip requires a **catalogued** rule, and the catalogue holds seven; every other rejection fails exactly as before. A raiser not yet taught to say what it wrote also keeps failing — `getattr(exc, "forward_written_fields", None)` defaults to today's behaviour, so no unreviewed path is silently downgraded.

A skip no longer marks the row's dependents failed: the object still exists and the sync only declined to change it, so its IP and MAC rows still resolve it.

### Tests
The adapter parity test drives the same cross-site untagged VLAN through `_apply_model_rows` and asserts both the `skipped` outcome and that the dependency is NOT marked failed — the key format was checked against `dependency_key` so the assertion isn't vacuous, and an earlier debug run confirmed that row previously produced `['failed', 'applied']`. Five predicate unit tests cover written vs unwritten, an uncatalogued rule, a non-`ValidationError`, and an empty written set.

**Full plugin suite run rather than just the touched files, because the change lands in the generic row loop: 1952 tests, OK (4 skipped).** Plus `pre-commit` to convergence, `scripts/tests` (328, OK), and `check_harness.py` in both modes.

### Still open
`_is_destination_rule_rejection` at merge remains `isinstance(exc, ValidationError)`. It now has a predicate to narrow to, but the merge path has no notion of "fields this change writes" and would have to derive one from the change diff (#39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPmp33tVZYDSeuBL4seyw8