### PR TITLE
fix: name the merge rejections we caused, without wedging a baseline

### DIFF
--- a/docs/03_Plans/active/2026-08-05-merge-rejection-narrowing.md
+++ b/docs/03_Plans/active/2026-08-05-merge-rejection-narrowing.md
@@ -1,0 +1,84 @@
+# Narrow the merge classifier without wedging a baseline
+
+## Goal
+
+`_is_destination_rule_rejection` is `isinstance(exc, ValidationError)`. Every
+validation rejection at merge is therefore unsatisfiable and skipped, including
+rejections the merge itself caused, where a retry is exactly the right response.
+Name those, and only those.
+
+## Contract
+
+- A rejection is a real failure only when a rule the catalogue can name lands on
+  a field this change writes.
+- An uncatalogued rule stays unsatisfiable. So does a caller that never said
+  what it writes.
+- The rejection this classifier was built for — `ipam.ipaddress` on `__all__` —
+  keeps its disposition, because `__all__` cannot intersect a written field.
+
+## Constraints
+
+- Any failed row blocks baseline promotion outright, with no self-service escape
+  short of `forward_accept_merge_failures`. Widening what counts as a failure is
+  therefore the dangerous direction, and it is the direction this change moves.
+  That is why only catalogued rules can move, and the catalogue holds seven.
+- A customer is mid-incident on exactly this surface. The change must not be
+  able to wedge a baseline on a rule nobody has catalogued.
+- No customer identifiers.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/diagnostics.py` — `is_caused_rule_rejection`
+- `forward_netbox/utilities/bulk_merge.py` — `_full_clean_fast` gains
+  `written_fields`; create, update, and batched-relationship sites pass it
+- `forward_netbox/utilities/merge.py` — the classifier
+- `forward_netbox/tests/test_merge_rule_rejection.py`
+
+## Approach
+
+Same mechanism as the sync path: the writer attaches what it wrote, because the
+recorder cannot derive it from an exception raised by whole-object validation.
+The merge already computes the set — `scalar_changes` on update,
+`postchange_data` on create, `changed` in the batched relationship path.
+
+**The predicate is deliberately not the sync path's.** `is_caused_rule_rejection`
+is not the complement of `is_preexisting_rule_rejection`; both are False for an
+uncatalogued rule. The two paths have opposite defaults — sync fails unless it
+can name a reason to skip, merge skips unless it can name a reason to fail — so
+each has to answer for itself. Inverting one to get the other would flip every
+uncatalogued merge rejection to a failure.
+
+## Validation
+
+Five classifier tests pin the asymmetry: a catalogued rule on a written field is
+retryable; the same rule on an unwritten field is not; an uncatalogued rule stays
+unsatisfiable *even on a written field*; a caller that attaches nothing stays
+unsatisfiable; and the customer's `__all__` network-ID rejection still skips.
+Full plugin suite, since the change reaches the merge apply path.
+
+## Rollback
+
+Revert. No migration. A reverted build returns every validation rejection at
+merge to unsatisfiable, which is strictly the safer direction, so this can be
+backed out under incident conditions without further thought.
+
+## Decision Log
+
+- **Inverted rather than symmetric.** The literal reading of the task was to use
+  the sync predicate here. Rejected on consequence: uncatalogued rejections
+  would flip from skipped to failed, and a failed row blocks promotion with no
+  escape — reintroducing the dead-end that the unsatisfiable disposition exists
+  to prevent, for a customer currently living on this code path.
+- **`written_fields=None` means unsatisfiable.** Every merge path not yet taught
+  to attach the set keeps today's behaviour, so the blast radius is the three
+  sites that were changed and nothing else.
+
+## Open
+
+- The catalogue is seven rules, so most merge rejections the plugin genuinely
+  caused still present as unsatisfiable. Growing it is a per-rule decision made
+  when a rule shows up in the field.
+- The batched paths at the status-only and relationship-fallback sites swallow
+  their exceptions into a row-by-row retry, so their disposition is decided on
+  the retry, not at the batch. Left alone; noting it so the next reader does not
+  assume every `full_clean` in this file feeds the classifier.

--- a/forward_netbox/tests/test_merge_rule_rejection.py
+++ b/forward_netbox/tests/test_merge_rule_rejection.py
@@ -50,6 +50,71 @@ class DestinationRuleRejectionTests(SimpleTestCase):
     def test_arbitrary_exceptions_remain_retryable_failures(self):
         self.assertFalse(_is_destination_rule_rejection(RuntimeError("boom")))
 
+    def test_a_rejection_the_merge_caused_is_a_retryable_failure(self):
+        # A catalogued rule landing on a field this change writes is our defect,
+        # not a property of the destination. Retrying is the right response, and
+        # calling it unsatisfiable hides it behind a disposition meant for rows
+        # nothing can fix.
+        exc = ValidationError(
+            {
+                "untagged_vlan": [
+                    "The untagged VLAN (Vlan211 (211)) must belong to the same "
+                    "site as the interface's parent device, or it must be global."
+                ]
+            }
+        )
+        exc.forward_written_fields = {"untagged_vlan", "mtu"}
+        self.assertFalse(_is_destination_rule_rejection(exc))
+
+    def test_the_same_rule_on_an_unwritten_field_stays_unsatisfiable(self):
+        exc = ValidationError(
+            {
+                "untagged_vlan": [
+                    "The untagged VLAN (Vlan211 (211)) must belong to the same "
+                    "site as the interface's parent device, or it must be global."
+                ]
+            }
+        )
+        exc.forward_written_fields = {"mtu"}
+        self.assertTrue(_is_destination_rule_rejection(exc))
+
+    def test_an_uncatalogued_rule_stays_unsatisfiable_even_on_a_written_field(self):
+        # The merge default is to skip, so narrowing it the way the sync path is
+        # narrowed would flip every uncatalogued rejection to a failure and wedge
+        # the baselines this classifier exists to protect.
+        exc = ValidationError({"mtu": ["Ensure this value is less than 65536."]})
+        exc.forward_written_fields = {"mtu"}
+        self.assertTrue(_is_destination_rule_rejection(exc))
+
+    def test_a_caller_that_never_said_what_it_writes_stays_unsatisfiable(self):
+        # Today's behaviour for every path not yet taught to attach the set.
+        self.assertTrue(
+            _is_destination_rule_rejection(
+                ValidationError(
+                    {
+                        "__all__": [
+                            "10.0.0.0/24 is a network ID, which "
+                            "may not be assigned to an interface."
+                        ]
+                    }
+                )
+            )
+        )
+
+    def test_the_customer_network_id_rejection_still_skips(self):
+        # `__all__` cannot intersect a written field, so the rejection that this
+        # classifier was built for keeps its disposition either way.
+        exc = ValidationError(
+            {
+                "__all__": [
+                    "10.0.0.0/24 is a network ID, which may not be assigned "
+                    "to an interface."
+                ]
+            }
+        )
+        exc.forward_written_fields = {"address", "status"}
+        self.assertTrue(_is_destination_rule_rejection(exc))
+
 
 class NonFieldValidationRuleTests(SimpleTestCase):
     """Each catalogued rule resolves to its slug, and values never persist."""

--- a/forward_netbox/utilities/bulk_merge.py
+++ b/forward_netbox/utilities/bulk_merge.py
@@ -31,6 +31,7 @@ from collections import defaultdict
 
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
 from django.db import DEFAULT_DB_ALIAS
 from django.db import models
 from django.db import OperationalError
@@ -572,16 +573,26 @@ def _is_bulk_safe(model_class) -> bool:
     return not issubclass(model_class, MPTTModel)
 
 
-def _full_clean_fast(instance, change_logger):
+def _full_clean_fast(instance, change_logger, written_fields=None):
     """full_clean without the per-row validate_unique/validate_constraints DB
     queries (mirrors the framework's full_clean_with_file_check otherwise).
 
     Database constraints still enforce uniqueness for new rows, while resumed
     rows are locked and converged by primary key. Field-level validation is kept.
     This removes the merge's dominant per-row cost at scale.
+
+    `written_fields` is what this change writes. `full_clean` validates the whole
+    object, so a rejection can name a field the change never touched, and the
+    recorder cannot tell the two apart from the exception alone. A caller that
+    does not say leaves the row unsatisfiable, which is the merge's existing
+    disposition for every validation rejection.
     """
     try:
         instance.full_clean(validate_unique=False, validate_constraints=False)
+    except ValidationError as exc:
+        if written_fields is not None:
+            exc.forward_written_fields = set(written_fields)
+        raise
     except _FILE_NOT_FOUND_EXCEPTIONS as exc:  # pragma: no cover - file backends
         if hasattr(exc, "response"):
             status = exc.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
@@ -595,7 +606,8 @@ def _deserialize(model_class, collapsed, change_logger):
     data = collapsed.postchange_data or {}
     pk = collapsed.key[1]
     deserialized = deserialize_object(model_class, data, pk=pk)
-    _full_clean_fast(deserialized.object, change_logger)
+    # A create writes every field it carries, so any rejection here is its own.
+    _full_clean_fast(deserialized.object, change_logger, written_fields=set(data))
     return deserialized
 
 
@@ -759,7 +771,12 @@ def _converge_existing_create_locked(
     target.snapshot()
     for field, value in scalar_changes:
         setattr(target, field.attname, value)
-    _full_clean_fast(target, change_logger)
+    _full_clean_fast(
+        target,
+        change_logger,
+        written_fields={field.name for field, _ in scalar_changes}
+        | {getattr(manager, "prefetch_cache_name", "") for manager, _ in m2m_changes},
+    )
     if scalar_changes:
         target.save(update_fields=[field.name for field, _ in scalar_changes])
     for manager, values in m2m_changes:
@@ -2613,7 +2630,11 @@ def _bulk_merge_changes_main(
                 for field, value in changed:
                     setattr(target, field.attname, value)
                     update_fields.add(field.name)
-                _full_clean_fast(target, change_logger)
+                _full_clean_fast(
+                    target,
+                    change_logger,
+                    written_fields={field.name for field, _ in changed},
+                )
                 prepared.append((collapsed_change, target))
             except JobTimeoutException:
                 raise

--- a/forward_netbox/utilities/diagnostics.py
+++ b/forward_netbox/utilities/diagnostics.py
@@ -627,6 +627,30 @@ def is_preexisting_rule_rejection(exc, written_fields) -> bool:
     return not (rejected & set(written_fields or ()))
 
 
+def is_caused_rule_rejection(exc, written_fields) -> bool:
+    """True when a rejection is about a field this change itself writes.
+
+    NOT the complement of `is_preexisting_rule_rejection`. Both are False for a
+    rule the catalogue cannot name, and that is the point: the two are used
+    where the *default* differs, so each has to answer for itself rather than
+    invert the other.
+
+    At merge the default is to skip. Every `ValidationError` there was treated
+    as unsatisfiable, which is right for a rule that is a property of the
+    destination — retrying cannot change the answer, and counting it a failure
+    is what turns a handful of refused rows into a baseline that can never
+    promote. But it also swallowed rejections the merge itself caused, where a
+    retry is exactly the right response. Those are the ones this names, and only
+    those change disposition: an uncatalogued rule keeps skipping, so nothing
+    the catalogue has not been taught can newly wedge a baseline.
+    """
+    diagnosis = structured_failure_diagnosis(exc)
+    if not diagnosis.get("validation_rules"):
+        return False
+    rejected = set(diagnosis.get("invalid_fields") or ())
+    return bool(rejected & set(written_fields or ()))
+
+
 def structured_failure_diagnosis(exc) -> dict:
     """Schema-level detail about a failure, never the values that caused it.
 

--- a/forward_netbox/utilities/merge.py
+++ b/forward_netbox/utilities/merge.py
@@ -40,6 +40,7 @@ from .bulk_merge import _ApplyOneFailure
 from .bulk_merge import bulk_merge_changes
 from .diagnostics import describe_failure
 from .diagnostics import exception_type
+from .diagnostics import is_caused_rule_rejection
 from .diagnostics import safe_operation_failure
 from .diagnostics import structured_failure_diagnosis
 from .merge_observability import checkpoint_merge_attempt
@@ -76,10 +77,26 @@ def _is_destination_rule_rejection(exc) -> bool:
     thousands of correct changes from ever being attested. Integrity errors and
     everything else stay failures: those are usually ordering or contention and
     a retry is exactly the right response.
+
+    The one exception is a rejection the merge itself caused: a rule the
+    catalogue can name, landing on a field this change writes. Retrying that is
+    exactly the right response, and calling it unsatisfiable hides a real defect
+    behind a disposition invented for rows nothing can fix.
+
+    Deliberately NOT symmetric with the sync path, which skips only what it can
+    name and fails everything else. The defaults are opposite, so narrowing here
+    the same way would flip every uncatalogued rejection to a failure and wedge
+    the baselines this classifier exists to protect. An uncatalogued rule, and a
+    caller that never said what it writes, both stay unsatisfiable.
     """
     from django.core.exceptions import ValidationError
 
-    return isinstance(exc, ValidationError)
+    if not isinstance(exc, ValidationError):
+        return False
+    written_fields = getattr(exc, "forward_written_fields", None)
+    if written_fields is None:
+        return True
+    return not is_caused_rule_rejection(exc, written_fields)
 
 
 def _replication_side_effect_exists(collapsed_change) -> bool:


### PR DESCRIPTION
Closes #39, the last place a disposition was decided by exception type alone.

`_is_destination_rule_rejection` was `isinstance(exc, ValidationError)`, so every validation rejection at merge counted as unsatisfiable. That is right for a rule which is a property of the destination — retrying cannot change the answer, and counting it a failure is what turns a handful of refused rows into a baseline that can never promote. It also swallowed rejections the merge itself caused, where a retry is exactly the right response.

A rejection is now a real failure only when a **catalogued** rule lands on a field this change **writes**. The merge already computes that set (`scalar_changes` on update, `postchange_data` on create, `changed` in the batched relationship path), so the writer attaches it and the classifier consults it — the same mechanism as #145.

### Why this is not symmetric with the sync path
`is_caused_rule_rejection` is deliberately **not** the complement of `is_preexisting_rule_rejection`; both are False for an uncatalogued rule.

The two paths have opposite defaults — sync fails unless it can name a reason to skip, merge skips unless it can name a reason to fail. Inverting one to get the other would flip every uncatalogued merge rejection into a failure, and a failed row blocks baseline promotion with no self-service escape but `forward_accept_merge_failures`. That would reintroduce the dead end this disposition exists to prevent, on a code path a customer is living on right now.

### Blast radius
- Uncatalogued rule: unchanged (still skips), even on a written field.
- Merge path not yet taught to attach its written set: unchanged (still skips).
- The `ipam.ipaddress` rejection this classifier was built for lands on `__all__`, which cannot intersect a written field: unchanged.

Reverting returns every validation rejection to unsatisfiable — the safer direction — so this can be backed out under incident conditions without analysis.

### Tests
Five classifier tests pin the asymmetry explicitly, including that an uncatalogued rule stays unsatisfiable *even on a written field* and that a caller attaching nothing stays unsatisfiable.

**Full plugin suite: 1957 tests, OK (4 skipped).** `test_bulk_merge` + diagnostics re-run on the post-`black` tree (134, OK) so the verdict covers the exact committed code. Plus `pre-commit` to convergence, `scripts/tests` (328, OK), `check_harness.py` both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPmp33tVZYDSeuBL4seyw8