### PR TITLE
feat: report the interfaces NetBox refuses on their untagged VLAN

### DIFF
--- a/docs/03_Plans/active/2026-08-05-interface-vlan-audit.md
+++ b/docs/03_Plans/active/2026-08-05-interface-vlan-audit.md
@@ -1,0 +1,79 @@
+# Let an operator find the interface a sync refused
+
+## Goal
+
+A customer sync recorded `untagged-vlan-outside-device-site` against
+`dcim.interface` and nothing else. The rule is now nameable; the row is not. Give
+the operator a way to find the interface without asking us.
+
+## Contract
+
+- Read-only. Never writes, never persists.
+- Names the device, interface, both sites and the VID — enough to act on without
+  a second lookup.
+- Counts are exact; the listing is bounded, so it is runnable on a deployment
+  with tens of thousands of interfaces.
+- Reports both `untagged_vlan` rules separately, because they have different
+  fixes.
+
+## Constraints
+
+- Persisted diagnostics carry schema identifiers and never customer data, which
+  is why the issue row cannot name the interface. That policy is not being
+  changed: `record_issue` composes its own message and `diagnostic_shape`
+  reduces context to key names. This writes to the operator's console instead,
+  the same posture as the eleven audits that already exist.
+- The invalid states cannot be built through the model — `save()` nulls an
+  untagged VLAN when mode is unset and `full_clean()` rejects a cross-site one —
+  so tests construct them with `queryset.update()`, which is also how they arise
+  in the field.
+- No customer identifiers in tracked content.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/interface_vlan_audit.py` (new)
+- `forward_netbox/management/commands/forward_interface_vlan_audit.py` (new)
+- `forward_netbox/tests/test_interface_vlan_audit.py` (new)
+
+## Approach
+
+Two querysets over `Interface`, mirroring NetBox's own rules at
+`dcim/models/device_components.py:1122` and `:1126`:
+
+- `cross_site` — `untagged_vlan.site` is non-null and differs from
+  `device.site`. The null case is excluded rather than compared, because a
+  global VLAN is valid on any device.
+- `no_mode` — an untagged VLAN with `mode` empty or null.
+
+## Validation
+
+Seven tests: a clean deployment reports nothing, a global VLAN is not a
+violation, a cross-site VLAN is reported with both sites named, the no-mode rule
+is reported separately from the cross-site one, counts stay exact while the
+listing is capped, a zero limit still counts, and an interface with no untagged
+VLAN is never reported.
+
+## Rollback
+
+Revert. Nothing is written by this code, so removing it cannot leave state
+behind.
+
+## Decision Log
+
+- **A command, not a change to what issues persist.** The alternative was
+  storing device and interface names on the issue row. Refused: that is a
+  deliberate storage policy protecting support bundles and exports, and this
+  need is served by computing the answer on demand instead.
+- **Both rules, not just the one the customer hit.** A sync cannot tell them
+  apart at the point of failure any better than the operator can, and the
+  no-mode pairing is only reachable through a writer that bypasses validation —
+  which makes it worth surfacing when it exists.
+
+## Open
+
+- Not scoped to Forward-owned devices. An interface the plugin never touches can
+  still be reported, which is arguably right — NetBox refuses it either way —
+  but it means the count is not the same as "rows this sync will refuse".
+- Does not report which devices moved sites, which is the mechanism that creates
+  the cross-site pairing (the plugin writes `site` through `bulk_update`, which
+  runs neither `save()` nor `clean()`, so nothing revalidates the interfaces).

--- a/forward_netbox/management/commands/forward_interface_vlan_audit.py
+++ b/forward_netbox/management/commands/forward_interface_vlan_audit.py
@@ -1,0 +1,30 @@
+import json
+
+from django.core.management.base import BaseCommand
+
+from forward_netbox.utilities.interface_vlan_audit import audit_interface_untagged_vlans
+
+
+class Command(BaseCommand):
+    help = (
+        "Read-only audit of interfaces NetBox will refuse on their untagged VLAN. "
+        "Reports each interface whose untagged VLAN belongs to a different site "
+        "than its device (and is not global), and each interface carrying an "
+        "untagged VLAN with no 802.1Q mode. A sync records which rule rejected a "
+        "row but not which row, because persisted diagnostics carry no customer "
+        "data — this names the interfaces on your console instead. Never writes."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=25,
+            help="Rows listed per rule. Counts are always exact; 0 lists none.",
+        )
+
+    def handle(self, *args, **options):
+        payload = audit_interface_untagged_vlans(
+            sample_limit=int(options.get("limit") or 0)
+        )
+        self.stdout.write(json.dumps(payload, indent=2, default=str))

--- a/forward_netbox/tests/test_interface_vlan_audit.py
+++ b/forward_netbox/tests/test_interface_vlan_audit.py
@@ -1,0 +1,148 @@
+# An operator has to be able to find the interface a sync refused.
+#
+# A customer sync recorded `untagged-vlan-outside-device-site` against
+# `dcim.interface` and nothing else: the message is composed by the recorder and
+# the context is reduced to key names, because persisted diagnostics carry schema
+# identifiers and never customer data. Correct policy, and it left one bad
+# interface among tens of thousands with no way to locate it.
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import Interface
+from dcim.models import Manufacturer
+from dcim.models import Site
+from django.test import TestCase
+from ipam.models import VLAN
+
+from forward_netbox.utilities.interface_vlan_audit import audit_interface_untagged_vlans
+
+
+class InterfaceUntaggedVlanAuditTest(TestCase):
+    def setUp(self):
+        self.site = Site.objects.create(name="site-1", slug="site-1")
+        self.other_site = Site.objects.create(name="site-2", slug="site-2")
+        manufacturer = Manufacturer.objects.create(name="vendor-1", slug="vendor-1")
+        self.device_type = DeviceType.objects.create(
+            manufacturer=manufacturer, model="model-1", slug="model-1"
+        )
+        self.role = DeviceRole.objects.create(
+            name="role-1", slug="role-1", color="9e9e9e"
+        )
+
+    def _device(self, name, site=None):
+        return Device.objects.create(
+            name=name,
+            site=site or self.site,
+            role=self.role,
+            device_type=self.device_type,
+            status="active",
+        )
+
+    def _interface(self, device, name, *, vlan=None, mode="access"):
+        """Build the state directly, because the model refuses to build it.
+
+        `save()` nulls an untagged VLAN when mode is unset and `full_clean()`
+        rejects a cross-site one, so a queryset update is the only way to
+        reproduce what a writer bypassing validation leaves behind — which is
+        exactly how these rows arise in the field.
+        """
+        interface = Interface.objects.create(
+            device=device, name=name, type="1000base-t", mode=mode
+        )
+        if vlan is not None:
+            Interface.objects.filter(pk=interface.pk).update(untagged_vlan=vlan)
+        return interface
+
+    def test_a_clean_deployment_reports_nothing(self):
+        device = self._device("device-1")
+        vlan = VLAN.objects.create(
+            site=self.site, vid=10, name="local", status="active"
+        )
+        self._interface(device, "eth1", vlan=vlan)
+
+        payload = audit_interface_untagged_vlans()
+
+        self.assertEqual(0, payload["cross_site_count"])
+        self.assertEqual(0, payload["no_mode_count"])
+        self.assertNotIn("cross_site_remediation", payload)
+
+    def test_a_global_vlan_is_valid_on_any_device(self):
+        # `untagged_vlan.site not in [device.site, None]` — a VLAN with no site
+        # is explicitly allowed, so it must not be reported.
+        device = self._device("device-1")
+        vlan = VLAN.objects.create(site=None, vid=11, name="global", status="active")
+        self._interface(device, "eth1", vlan=vlan)
+
+        self.assertEqual(0, audit_interface_untagged_vlans()["cross_site_count"])
+
+    def test_a_cross_site_vlan_is_reported_with_both_sites_named(self):
+        device = self._device("device-1")
+        vlan = VLAN.objects.create(
+            site=self.other_site, vid=30, name="elsewhere", status="active"
+        )
+        self._interface(device, "eth1", vlan=vlan)
+
+        payload = audit_interface_untagged_vlans()
+
+        self.assertEqual(1, payload["cross_site_count"])
+        (row,) = payload["cross_site"]
+        # Naming the interface is the entire point; naming both sites is what
+        # makes it actionable without a second lookup.
+        self.assertEqual("device-1", row["device"])
+        self.assertEqual("eth1", row["interface"])
+        self.assertEqual("site-1", row["device_site"])
+        self.assertEqual("site-2", row["vlan_site"])
+        self.assertEqual(30, row["vlan_vid"])
+        self.assertIn("cross_site_remediation", payload)
+
+    def test_an_untagged_vlan_without_mode_is_reported_separately(self):
+        device = self._device("device-1")
+        vlan = VLAN.objects.create(
+            site=self.site, vid=12, name="local", status="active"
+        )
+        self._interface(device, "eth1", vlan=vlan, mode="")
+
+        payload = audit_interface_untagged_vlans()
+
+        # Same site, so it is not a cross-site violation - but NetBox still
+        # refuses it, and the two rules have different fixes.
+        self.assertEqual(0, payload["cross_site_count"])
+        self.assertEqual(1, payload["no_mode_count"])
+        self.assertEqual("eth1", payload["no_mode"][0]["interface"])
+        self.assertIn("no_mode_remediation", payload)
+
+    def test_counts_are_exact_while_the_listing_is_bounded(self):
+        # The command has to be runnable on a deployment with tens of thousands
+        # of interfaces, so the sample is capped and the count is not.
+        device = self._device("device-1")
+        vlan = VLAN.objects.create(
+            site=self.other_site, vid=31, name="elsewhere", status="active"
+        )
+        for index in range(5):
+            self._interface(device, f"eth{index}", vlan=vlan)
+
+        payload = audit_interface_untagged_vlans(sample_limit=2)
+
+        self.assertEqual(5, payload["cross_site_count"])
+        self.assertEqual(2, len(payload["cross_site"]))
+
+    def test_a_zero_limit_still_counts(self):
+        device = self._device("device-1")
+        vlan = VLAN.objects.create(
+            site=self.other_site, vid=32, name="elsewhere", status="active"
+        )
+        self._interface(device, "eth1", vlan=vlan)
+
+        payload = audit_interface_untagged_vlans(sample_limit=0)
+
+        self.assertEqual(1, payload["cross_site_count"])
+        self.assertEqual([], payload["cross_site"])
+
+    def test_an_interface_with_no_untagged_vlan_is_never_reported(self):
+        device = self._device("device-1")
+        self._interface(device, "eth1", mode="")
+
+        payload = audit_interface_untagged_vlans()
+
+        self.assertEqual(0, payload["cross_site_count"])
+        self.assertEqual(0, payload["no_mode_count"])

--- a/forward_netbox/utilities/interface_vlan_audit.py
+++ b/forward_netbox/utilities/interface_vlan_audit.py
@@ -1,0 +1,98 @@
+"""Find the interfaces NetBox will refuse on their untagged VLAN.
+
+`Interface.clean()` raises on `untagged_vlan` for two unrelated reasons, and a
+sync that hits either one records the rule but not the row: issue context is
+reduced to key names before it is persisted, because persisted diagnostics carry
+schema identifiers and never customer data. That is the right storage policy and
+it leaves the operator unable to find one bad interface among tens of thousands.
+
+This closes that gap the way the other audits do — computed on demand, written
+to the operator's own console, persisted nowhere.
+
+Both rules are reported because a sync cannot tell them apart at the point of
+failure any better than the operator can:
+
+- `cross_site` — `untagged_vlan.site` is neither the device's site nor null.
+  Usually a device that moved sites: the plugin writes `site` on an existing
+  device through `bulk_update`, which runs neither `save()` nor `clean()`, so
+  nothing revalidates that device's interfaces and the VLAN of the old site
+  stays behind.
+- `no_mode` — an untagged VLAN on an interface with no 802.1Q mode. NetBox's own
+  `save()` nulls the VLAN in that case, so this state is only reachable through
+  a writer that bypasses it.
+"""
+
+CROSS_SITE_REMEDIATION = (
+    "NetBox requires an interface's untagged VLAN to belong to the device's "
+    "site or to be global (no site). Either move the VLAN to the device's "
+    "site, clear the VLAN from the interface, or make the VLAN global. Until "
+    "then the sync refuses to write these interfaces."
+)
+NO_MODE_REMEDIATION = (
+    "NetBox does not accept an untagged VLAN on an interface with no 802.1Q "
+    "mode. Either set the interface mode or clear the untagged VLAN. This "
+    "pairing cannot be created through the NetBox UI or API, so it was written "
+    "by something that bypassed model validation."
+)
+
+
+def _interface_row(interface):
+    vlan = interface.untagged_vlan
+    return {
+        "device": interface.device.name,
+        "interface": interface.name,
+        "device_site": interface.device.site.name if interface.device.site else None,
+        "vlan": vlan.name if vlan else None,
+        "vlan_vid": vlan.vid if vlan else None,
+        "vlan_site": vlan.site.name if vlan and vlan.site else None,
+        "mode": interface.mode or None,
+    }
+
+
+def audit_interface_untagged_vlans(*, sample_limit=25):
+    """Every interface NetBox would refuse on its untagged VLAN.
+
+    Counts are exact; the sampled rows are bounded, because the whole point is
+    to be runnable on a deployment with tens of thousands of interfaces.
+    """
+    from dcim.models import Interface
+    from django.db.models import F
+    from django.db.models import Q
+
+    assigned = Interface.objects.filter(untagged_vlan__isnull=False)
+
+    # `untagged_vlan.site not in [device.site, None]` — a global VLAN is valid
+    # on any device, which is why the null site is excluded rather than compared.
+    cross_site = assigned.filter(untagged_vlan__site__isnull=False).exclude(
+        untagged_vlan__site_id=F("device__site_id")
+    )
+    # `not mode and untagged_vlan`. Empty string and NULL both count as unset.
+    no_mode = assigned.filter(Q(mode="") | Q(mode__isnull=True))
+
+    limit = max(int(sample_limit or 0), 0)
+    payload = {
+        "cross_site_count": cross_site.count(),
+        "no_mode_count": no_mode.count(),
+        "sample_limit": limit,
+        "cross_site": [],
+        "no_mode": [],
+    }
+    if limit:
+        related = ("device", "device__site", "untagged_vlan", "untagged_vlan__site")
+        payload["cross_site"] = [
+            _interface_row(interface)
+            for interface in cross_site.select_related(*related).order_by(
+                "device__name", "name"
+            )[:limit]
+        ]
+        payload["no_mode"] = [
+            _interface_row(interface)
+            for interface in no_mode.select_related(*related).order_by(
+                "device__name", "name"
+            )[:limit]
+        ]
+    if payload["cross_site_count"]:
+        payload["cross_site_remediation"] = CROSS_SITE_REMEDIATION
+    if payload["no_mode_count"]:
+        payload["no_mode_remediation"] = NO_MODE_REMEDIATION
+    return payload


### PR DESCRIPTION
Closes #52. Follow-up to #144, which made the rule nameable — this makes the *row* findable.

Customer ingestion 2720 recorded `untagged-vlan-outside-device-site` against `dcim.interface` and nothing else. That is the storage policy working as intended: `record_issue` composes its own message and `diagnostic_shape` reduces context to key names, because persisted diagnostics carry schema identifiers and never customer data. It also leaves one bad interface among tens of thousands with no way to find it.

**Correcting my own claim in #144:** I wrote there that the issue row would "name the device and interface." It does not — both the message and the context are replaced before persistence. This closes that gap without touching the storage policy.

`forward_interface_vlan_audit` computes the answer on demand and writes it to the operator's console, the same posture as the eleven audits already in the repo. It names the device, the interface, both sites and the VID.

Both `untagged_vlan` rules are reported separately, because they have different fixes:
- `cross_site` — `untagged_vlan.site` is neither the device's site nor null (`dcim/models/device_components.py:1126`)
- `no_mode` — an untagged VLAN with no 802.1Q mode (`:1122`). NetBox's own `save()` nulls this pairing, so its existence means something wrote it while bypassing validation.

Counts are exact; the listing is bounded, so it is runnable at customer scale.

### Tests
Seven, including that a global VLAN (null site) is explicitly legal and must not be reported, that the two rules are counted separately, and that a zero limit still counts. They build both invalid states with `queryset.update()` — `save()` and `full_clean()` each refuse to create one, which is also how they arise in the field.

Local gates: `pre-commit` to convergence, suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPmp33tVZYDSeuBL4seyw8