### PR TITLE
fix: stop calling every spent baseline "the baseline"

### DIFF
--- a/docs/03_Plans/active/2026-08-05-superseded-baseline-refusal.md
+++ b/docs/03_Plans/active/2026-08-05-superseded-baseline-refusal.md
@@ -1,0 +1,80 @@
+# Stop calling every spent baseline "the baseline"
+
+## Goal
+
+A customer reported three ingestions that will not delete. The refusal told him
+each of them "is the baseline for this sync — the durable record of what has
+already converged", which is true of at most one, and directed him to "remove
+those records first", which is an action the product does not offer for a
+superseded baseline. Say what is actually holding each one.
+
+## Contract
+
+- The durable-record wording is reserved for the baseline that actually is one.
+- A refusal never claims an action the product does not support.
+- Wording only. No PROTECT semantics change, no migration, nothing becomes
+  deletable that was not deletable before.
+
+## Constraints
+
+- "Spent" is `status == SUPERSEDED`, NOT `is_current is False`. `is_current`
+  defaults to False and `status` to PENDING, so a baseline that has simply not
+  been promoted yet is also not current — and calling that one spent would tell
+  an operator mid-sync that an intact payload is a dead husk. Only promotion
+  sets SUPERSEDED, and it is promotion that clears the relations and empties the
+  payload (`contributor_baseline.py:848-864`).
+- The refusal path must not raise. It already exists to turn an unhandled
+  `ProtectedError` into something readable, so a lookup added to it fails closed
+  to the conservative wording.
+- `baseline_reference` stays derived from the protecting relations, not from
+  this lookup: what blocks the delete is what the database says, and the status
+  only chooses how to describe it.
+
+## Touched Surfaces
+
+- `forward_netbox/views.py` — `_ingestion_baseline_state` (new),
+  `_ingestion_delete_refusal_detail`
+- `forward_netbox/tests/test_ingestion_delete.py`
+
+## Approach
+
+The refusal decided "this is the baseline" by looking for the substring
+`baseline` in the protecting model's label, which cannot distinguish the live
+baseline from one superseded many syncs ago. Read the row and branch on its
+status instead.
+
+The superseded wording states three things and promises nothing: the record is
+spent, it still protects the ingestion, and no action will release it today.
+
+## Validation
+
+Two tests. A superseded baseline must not get the durable-record wording and
+must not be told to remove records; a pending baseline must still get the
+existing wording, which is the case that would have regressed had this keyed off
+`is_current`. Both refusals stay `expected=True` so they render as warnings
+rather than red errors — the red error was itself reported as a defect twice.
+
+## Rollback
+
+Revert. Wording only.
+
+## Decision Log
+
+- **Wording before behaviour.** Making spent baselines collectable is the actual
+  fix and it changes a PROTECT relation on the baseline-promotion path. Shipping
+  the honest message first costs nothing, is independently correct, and tells us
+  which of the two causes each of the customer's three ingestions has — which
+  the current text cannot.
+- **No "this will be fixed in a later release" in the message.** A refusal that
+  dates itself is wrong the moment it ships. It says the gap exists; it does not
+  make a schedule commitment to an operator.
+
+## Open
+
+- The underlying gap is untouched: every ingestion that ever promoted a baseline
+  is still permanently undeletable, and the backlog grows one row per successful
+  sync. Task #45 carries the CASCADE change and the four claims it has to prove
+  with tests rather than by reading.
+- `ForwardDeviceIdentity` rows for departed source keys are the other cause of an
+  undeletable ingestion and are unaffected by this (#46). An operator whose
+  ingestion is held by both now gets accurate text for the baseline half only.

--- a/forward_netbox/tests/test_ingestion_delete.py
+++ b/forward_netbox/tests/test_ingestion_delete.py
@@ -122,6 +122,45 @@ class IngestionDeleteRefusalTest(TestCase):
             "remove those records first", _ingestion_delete_refusal(self.ingestion)
         )
 
+    def test_a_superseded_baseline_is_not_called_the_current_one(self):
+        # Every ingestion that ever promoted leaves a baseline behind, and
+        # promotion only marks the previous one superseded. A customer with
+        # three undeletable ingestions was told three times that each was "the
+        # baseline for this sync", which is true of at most one of them.
+        from forward_netbox.models import ForwardContributorBaseline
+
+        baseline = self._baseline(ForwardContributorBaseline)
+        baseline.status = ForwardContributorBaseline.Status.SUPERSEDED
+        baseline.is_current = False
+        baseline.save(update_fields=["status", "is_current"])
+
+        refusal, expected = _ingestion_delete_refusal_detail(self.ingestion)
+
+        self.assertTrue(refusal)
+        self.assertNotIn("is the baseline for this sync", refusal)
+        self.assertIn("already been superseded", refusal)
+        # The old text told them to "remove those records first". There is no
+        # supported way to remove this one, so it must not say that.
+        self.assertNotIn("remove those records first", refusal)
+        self.assertIn("ForwardContributorBaseline", refusal)
+        # Still expected rather than a fault, so it stays a warning not an error.
+        self.assertTrue(expected)
+
+    def test_a_pending_baseline_is_not_reported_as_spent(self):
+        # `is_current` defaults to False and `status` to PENDING, so keying the
+        # wording off `is_current` alone would tell an operator mid-sync that an
+        # intact payload is a dead husk. Only promotion sets SUPERSEDED.
+        from forward_netbox.models import ForwardContributorBaseline
+
+        baseline = self._baseline(ForwardContributorBaseline)
+        self.assertEqual(baseline.status, ForwardContributorBaseline.Status.PENDING)
+        self.assertFalse(baseline.is_current)
+
+        refusal = _ingestion_delete_refusal(self.ingestion)
+
+        self.assertNotIn("already been superseded", refusal)
+        self.assertIn("is the baseline for this sync", refusal)
+
     def test_cascading_children_do_not_block_the_delete(self):
         # Issues cascade, so they must not be reported as protecting.
         from forward_netbox.models import ForwardIngestionIssue

--- a/forward_netbox/views.py
+++ b/forward_netbox/views.py
@@ -2164,6 +2164,44 @@ def _ingestion_holds_current_ownership(ingestion) -> bool:
         return True
 
 
+def _ingestion_baseline_state(ingestion) -> str:
+    """``"current"``, ``"spent"``, or ``""`` when no baseline holds this row.
+
+    The refusal used to decide this by looking for "baseline" in the protecting
+    model's label, which cannot distinguish the sync's live baseline from one
+    that was superseded years of syncs ago. Every ingestion that ever promoted
+    leaves a baseline row behind, and promotion only marks the previous one
+    superseded — it clears the relations and empties the payload but keeps the
+    row, which goes on protecting its ingestion forever. So a customer with
+    three undeletable ingestions was told three times that each was "the
+    baseline for this sync", which is true of at most one of them.
+
+    "Spent" is `status == SUPERSEDED` specifically, NOT `is_current is False`.
+    `is_current` defaults to False and `status` to PENDING, so a baseline that
+    has simply not been promoted yet is also not current — and calling that one
+    spent would tell an operator mid-sync that an intact payload is a dead
+    husk. Only promotion sets SUPERSEDED, and it is promotion that clears the
+    relations and empties the payload.
+
+    Fails closed to ``"current"``: the conservative wording promises nothing.
+    """
+    from .models import ForwardContributorBaseline
+
+    if not ingestion.pk:
+        return ""
+    try:
+        baseline = ForwardContributorBaseline.objects.filter(
+            ingestion=ingestion
+        ).first()
+    except Exception:  # noqa: BLE001 - a refusal must not become a 500
+        return "current"
+    if baseline is None:
+        return ""
+    if baseline.status == ForwardContributorBaseline.Status.SUPERSEDED:
+        return "spent"
+    return "current"
+
+
 def _ingestion_delete_refusal_detail(ingestion) -> tuple[str, bool]:
     """The refusal text, and whether it is expected rather than a fault.
 
@@ -2201,6 +2239,21 @@ def _ingestion_delete_refusal_detail(ingestion) -> tuple[str, bool]:
         return "", False
     held_by = ", ".join(f"{label} ({count})" for label, count in references)
     if baseline_reference:
+        if _ingestion_baseline_state(ingestion) == "spent":
+            # Do not repeat the durable-record wording here. This baseline is
+            # spent: promotion already cleared its relations and emptied its
+            # payload, so it protects nothing an operator would want kept, and
+            # telling them to "remove those records first" points at an action
+            # the product does not offer for this row.
+            return (
+                f"{ingestion} is held by a contributor baseline that has "
+                "already been superseded by a later sync. The record is spent - "
+                "its contents were cleared when the newer baseline was promoted "
+                "- but it still protects this ingestion, so the ingestion "
+                f"cannot be deleted. It is held by {held_by}. Nothing is wrong "
+                "with this sync and no action will release it today; collecting "
+                "spent baselines is a known gap."
+            ), True
         return (
             f"{ingestion} is the baseline for this sync - the durable record of "
             "what has already converged - so NetBox protects it from deletion. "


### PR DESCRIPTION
The customer reports three ingestions that will not delete. Each refusal tells him it "is the baseline for this sync — the durable record of what has already converged", which is true of at most one of them, and directs him to "remove those records first" — an action the product does not offer for a superseded baseline.

The refusal decided "this is the baseline" by substring-matching `baseline` in the protecting model's label, which cannot tell the live baseline from one superseded many syncs ago. Every ingestion that ever promoted leaves one behind: promotion marks the previous baseline superseded, clears its relations and empties its payload, but keeps the row (`contributor_baseline.py:848-864`), which goes on protecting its ingestion forever.

### The distinction that matters
"Spent" is `status == SUPERSEDED`, **not** `is_current is False`.

`is_current` defaults to `False` and `status` to `PENDING`, so a baseline that has simply not been promoted yet is also not current. Keying off `is_current` — which is what I wrote first — would tell an operator mid-sync that an intact payload is a dead husk. Only promotion sets `SUPERSEDED`, and promotion is what empties the record. There is a test pinning exactly that.

### Scope
Wording only. No PROTECT semantics change, no migration, nothing becomes deletable that was not deletable before. `baseline_reference` stays derived from the protecting relations — what blocks the delete is what the database says; the status only chooses how to describe it. The lookup fails closed to the conservative wording, because this path exists to turn an unhandled `ProtectedError` into something readable and must not itself raise.

What it buys is diagnosis: an undeletable ingestion now says whether a spent baseline holds it, device identities (#46), or both. The previous text could not distinguish them, which is why the customer's three reads as arbitrary.

The new message carries no repair instruction, because there is none, and names no release, because a refusal that dates itself is wrong the moment it ships.

### Tests
Two new, 18 in the suite. A superseded baseline must not get the durable-record wording and must not be told to remove records; a pending baseline must still get the existing wording. Both stay `expected=True` so they render as warnings — the red error was itself reported as a defect twice.

**Full plugin suite: 1959 tests, OK (4 skipped).** Plus `pre-commit` converged, `scripts/tests` 328 OK, `check_harness.py` both modes.

### Not in scope
The underlying gap (#45): every ingestion that ever promoted is still permanently undeletable, and the backlog grows one row per sync. That change makes the FK CASCADE on the baseline-promotion path and needs tests proving each of its four safety claims rather than my reading of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPmp33tVZYDSeuBL4seyw8