### PR TITLE
fix: collect spent baselines, and say what a skip was waiting for

### DIFF
--- a/docs/03_Plans/active/2026-08-05-ingestion-delete-and-skip-reasons.md
+++ b/docs/03_Plans/active/2026-08-05-ingestion-delete-and-skip-reasons.md
@@ -1,0 +1,103 @@
+# Collect spent baselines, and say what a skip was waiting for
+
+## Goal
+
+Three customer reports in one day, all housekeeping rather than sync failure:
+three ingestions that will not delete, and six issue rows reading exactly
+`netbox_dlm.softwareversion row processing failed (ForwardDependencySkipError).`
+Make the first deletable and the second legible.
+
+## Contract
+
+- A superseded contributor baseline goes with its ingestion. The live one never
+  does, by any path, including `queryset.delete()`.
+- An ingestion with a running job is refused, as a sync already is.
+- A skipped row says "skipped", and names the model it was waiting for when the
+  raiser knows it.
+- No collected value is persisted. Model labels only.
+
+## Constraints
+
+- `PROTECT` cannot express "keep the live generation, collect the spent one",
+  and the collection has to happen before the ingestion row goes, so it cannot
+  be done in the delete view either — NetBox's view owns that transaction. The
+  guarantee therefore moves to a `pre_delete` receiver, which is the pattern
+  `ForwardSync` already uses and the only one that also covers querysets.
+- The view's refusal and the receiver's refusal must test the SAME condition, or
+  the UI refuses deletes the database allows or offers ones it will abort.
+- `log_level` is not a usable signal for skip-versus-fail: the row-oriented
+  handler records a dependency skip at `info` while the bulk engines record
+  theirs at the default. Keying on it would word one condition two ways.
+- No customer identifiers.
+
+## Touched Surfaces
+
+- `forward_netbox/models.py`, `migrations/0050_contributor_baseline_cascade.py`
+- `forward_netbox/signals.py` — `refuse_ingestion_delete_with_live_baseline`
+- `forward_netbox/views.py` — `_ingestion_holds_live_baseline`, the refusal
+- `forward_netbox/exceptions.py` — `dependency` on `ForwardDataError`
+- `forward_netbox/utilities/sync_dlm.py`, `sync_primitives.py` — raisers
+- `forward_netbox/utilities/sync_reporting.py` — message composition
+- tests: `test_ingestion_delete.py`, `test_protecting_relations.py`,
+  `test_dlm_integration.py`, `test_sync.py`
+
+## Approach
+
+**Baselines.** The FK becomes CASCADE so a spent generation is collected, and a
+`pre_delete` receiver keeps the live one. The receiver also refuses while a job
+is running — `ForwardIngestion` carries `JobsMixin` exactly as `ForwardSync`
+does, so its `Job` rows would otherwise cascade through the SQL collector and
+bypass `Job.delete()`'s RQ-cancel override.
+
+**Skips.** `ForwardDependencySkipError` gains a `dependency` attribute holding a
+model label. The raiser's own message names the platform or device, which is why
+it cannot be persisted; the label can be. On the delete path the safe answer is
+inverted — nothing is missing, the object is still referenced — so that raiser
+reports the protecting child models, read from `ProtectedError.protected_objects`.
+
+Raisers not yet taught to name a dependency record exactly what they record
+today. There are about thirty; six are covered here, chosen because they are the
+two groups a customer is currently reading.
+
+## Validation
+
+A spent baseline is collected with its ingestion; a live one survives a
+`queryset.delete()` and raises; the refusal names the live case and says what to
+do. The `protecting_relations` suite asserts the baseline is no longer reported
+as protecting — and that discovery still finds *something*, because the baseline
+was the last visible protecting relation and every remaining one is hidden
+behind `related_name="+"`. Full plugin suite over the lot.
+
+## Rollback
+
+Revert, including migration `0050`. The reverse restores PROTECT and can fail
+only if an ingestion was deleted while this was applied and took its spent
+baseline with it — which is the point of applying it.
+
+## Decision Log
+
+- **CASCADE plus a receiver, not a delete-view helper.** The first attempt kept
+  PROTECT and deleted the husk in the view. Rejected: PROTECT forces the
+  baseline to go first, and making "baseline deleted, ingestion deleted" atomic
+  inside NetBox's delete view needs response-sniffing to know whether the second
+  half happened. A half-applied version destroys the record and keeps the row.
+- **The wording is keyed on the exception, not the log level.** A test asserting
+  `outcome="skipped"` two lines below a message reading "failed" is what made
+  the inconsistency obvious.
+- **Six raisers, not thirty.** Normalising all of them means replacing the
+  context dict at the delete-path site and auditing twenty-odd others; the two
+  groups a customer is reading are worth shipping now, and a raiser that says
+  nothing still behaves exactly as it does today.
+
+## Open
+
+- The remaining ~24 dependency-skip raisers still record only the exception
+  class. The vocabulary already exists in `record_aggregated_skip_warning`
+  (`missing-device`, `missing-interface`, ...) and never reaches the database.
+- `dcim.site`, `ipam.vrf` and `dcim.devicetype` skips come from pruning, not
+  from a missing parent — they mean children still reference the object. They
+  now name those children, but they are still filed under a name that reads
+  like the opposite. `health_summary_blocks` already calls them "protected
+  dependency skips"; the issue list does not.
+- Device identities for departed source keys are the other reason an ingestion
+  will not delete, and are untouched (#46).

--- a/forward_netbox/exceptions.py
+++ b/forward_netbox/exceptions.py
@@ -70,6 +70,7 @@ class ForwardDataError(ForwardSyncError):
         defaults: dict | None = None,
         data: dict | None = None,
         issue_id: int | None = None,
+        dependency: str | None = None,
     ):
         super().__init__(message)
         self.model_string = model_string
@@ -77,6 +78,13 @@ class ForwardDataError(ForwardSyncError):
         self.defaults = defaults or {}
         self.data = data or {}
         self.issue_id = issue_id
+        # The model whose absence (or whose surviving children) caused this.
+        # A schema identifier the plugin defines, so unlike `context` — which
+        # carries the device or platform NAME and is reduced to key names before
+        # anything persists it — this one can be recorded. Without it a skipped
+        # row records only the exception class, and a customer reading six
+        # identical rows has no way to learn which parent was missing.
+        self.dependency = dependency or ""
 
 
 class ForwardSearchError(ForwardDataError):

--- a/forward_netbox/migrations/0050_contributor_baseline_cascade.py
+++ b/forward_netbox/migrations/0050_contributor_baseline_cascade.py
@@ -1,0 +1,49 @@
+import django.db.models.deletion
+from django.db import migrations
+from django.db import models
+
+
+# Contributor baselines are main-schema convergence evidence, like the ownership
+# rows in 0047. Branch schemas must not receive independent constraints for them.
+fake_on_branch = True
+
+
+class Migration(migrations.Migration):
+    """Let an ingestion take its spent contributor baseline with it.
+
+    `ForwardContributorBaseline.ingestion` was PROTECT, and nothing anywhere
+    deletes a baseline. Promotion marks the previous generation SUPERSEDED,
+    deletes its relations and empties its payload — but keeps the row, which
+    goes on protecting its ingestion. So every ingestion that ever promoted
+    became permanently undeletable and the backlog grew by one per successful
+    sync; a customer reported three at once, and the refusal named a record he
+    had no way to remove.
+
+    The live baseline must still be kept, and CASCADE alone would not keep it.
+    That guarantee moves from the database to `refuse_ingestion_delete_with_live
+    _baseline` in `signals.py`, a `pre_delete` receiver, which fires for
+    querysets as well as instances and so covers every path the PROTECT
+    constraint covered. It is a deliberate trade: PROTECT could not express
+    "keep this one, collect that one", and expressing it in Python is what makes
+    the spent rows collectable at all.
+
+    Reversible: the reverse restores PROTECT. It can fail only if an ingestion
+    was deleted while this was applied and its spent baseline went with it —
+    which is the point of applying it — and no reverse resurrects those rows.
+    """
+
+    dependencies = [
+        ("forward_netbox", "0049_drift_policy_row_shrink_floor"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="forwardcontributorbaseline",
+            name="ingestion",
+            field=models.OneToOneField(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="contributor_baseline",
+                to="forward_netbox.forwardingestion",
+            ),
+        ),
+    ]

--- a/forward_netbox/models.py
+++ b/forward_netbox/models.py
@@ -1168,7 +1168,13 @@ class ForwardContributorBaseline(ForwardPluginModelDocsMixin, models.Model):
     )
     ingestion = models.OneToOneField(
         ForwardIngestion,
-        on_delete=models.PROTECT,
+        # CASCADE, not PROTECT: promotion leaves the previous generation
+        # SUPERSEDED with its relations deleted and its payload emptied, and
+        # nothing ever removed that husk, so every ingestion that promoted
+        # became permanently undeletable. PROTECT cannot express "keep the live
+        # one, collect the spent one"; the live one is kept by a `pre_delete`
+        # receiver instead - see `refuse_ingestion_delete_with_live_baseline`.
+        on_delete=models.CASCADE,
         related_name="contributor_baseline",
     )
     parent_baseline = models.ForeignKey(

--- a/forward_netbox/signals.py
+++ b/forward_netbox/signals.py
@@ -143,6 +143,59 @@ def cancel_enqueued_jobs_on_sync_delete(sender, instance, **kwargs):
         job.delete()
 
 
+@receiver(pre_delete, sender=ForwardIngestion)
+def refuse_ingestion_delete_with_live_baseline(sender, instance, **kwargs):
+    """Keep the live contributor baseline, and any ingestion still running.
+
+    Two guarantees that used to belong to the database, moved here when
+    `ForwardContributorBaseline.ingestion` became CASCADE so spent baselines
+    could be collected. PROTECT could not distinguish the live generation from
+    a superseded husk; this can, and unlike a check in the delete view it fires
+    for `queryset.delete()` too, so no path loses a baseline the sync still
+    depends on.
+
+    The running-job half closes the same hole `cancel_enqueued_jobs_on_sync_delete`
+    closes for a sync. `ForwardIngestion` carries `JobsMixin` as well, so its
+    `Job` rows cascade through the SQL collector and bypass `Job.delete()`'s
+    RQ-cancel override - deleting a mid-flight ingestion would drop the job row
+    while its worker kept running against it.
+    """
+    from .models import ForwardContributorBaseline
+
+    baseline = ForwardContributorBaseline.objects.filter(
+        ingestion=instance,
+        is_current=True,
+    ).first()
+    if baseline is not None:
+        raise ProtectedError(
+            "Cannot delete the ingestion holding this sync's current "
+            "contributor baseline; run the sync again so a newer ingestion "
+            "promotes its own, then delete this one.",
+            [baseline],
+        )
+
+    ingestion_type = ContentType.objects.get_for_model(
+        ForwardIngestion, for_concrete_model=False
+    )
+    referenced_job_ids = {
+        job_id
+        for job_id in (instance.job_id, instance.merge_job_id)
+        if job_id is not None
+    }
+    running = list(
+        Job.objects.filter(
+            Q(object_type=ingestion_type, object_id=instance.pk)
+            | Q(pk__in=referenced_job_ids),
+            status=JobStatusChoices.STATUS_RUNNING,
+        ).order_by("pk")
+    )
+    if running:
+        raise ProtectedError(
+            "Cannot delete a Forward ingestion while one of its jobs is " "running.",
+            running,
+        )
+
+
 def acquire_job_schedule_transaction_lock():
     """Serialize deletion through the surrounding transaction's commit."""
     if not connection.in_atomic_block:

--- a/forward_netbox/tests/test_dlm_integration.py
+++ b/forward_netbox/tests/test_dlm_integration.py
@@ -1036,3 +1036,51 @@ class DependencySkipIssueRollupTest(TestCase):
         self.assertEqual(
             ForwardIngestionIssue.objects.filter(ingestion=ingestion).count(), 4
         )
+
+
+class DependencySkipNamesTheMissingParentTest(SimpleTestCase):
+    """A skipped row must say which parent was missing.
+
+    A customer's ingestion showed six rows reading exactly
+    `netbox_dlm.softwareversion row processing failed (ForwardDependencySkipError).`
+    The raiser's own message names the platform, but it embeds the platform NAME
+    so it cannot be persisted, and `context` is reduced to key names before
+    storage. The model label is a schema identifier, so it can be.
+    """
+
+    def test_the_missing_platform_is_named_on_the_exception(self):
+        from forward_netbox.exceptions import ForwardDependencySkipError
+        from forward_netbox.utilities.sync_dlm import _lookup_platform
+
+        runner = Mock()
+        runner._get_unique_or_raise.return_value = None
+        with self.assertRaises(ForwardDependencySkipError) as caught:
+            _lookup_platform(
+                runner,
+                {"platform": "some-platform", "platform_slug": "some-platform"},
+                "netbox_dlm.softwareversion",
+                "DLM software version",
+            )
+        self.assertEqual("dcim.platform", caught.exception.dependency)
+
+    def test_the_missing_device_type_is_named(self):
+        from forward_netbox.exceptions import ForwardDependencySkipError
+        from forward_netbox.utilities.sync_dlm import _lookup_device_type
+
+        runner = Mock()
+        runner._get_unique_or_raise.return_value = None
+        with self.assertRaises(ForwardDependencySkipError) as caught:
+            _lookup_device_type(
+                runner,
+                {"device_type": "some-model", "device_type_slug": "some-model"},
+                "netbox_dlm.hardwarenotice",
+                "DLM hardware notice",
+            )
+        self.assertEqual("dcim.devicetype", caught.exception.dependency)
+
+    def test_a_raiser_that_names_nothing_still_records_what_it_did_before(self):
+        # Most of the plugin's 30-odd raisers are untouched, and they must keep
+        # today's behaviour rather than record an empty slug.
+        from forward_netbox.exceptions import ForwardDependencySkipError
+
+        self.assertEqual("", ForwardDependencySkipError("nope").dependency)

--- a/forward_netbox/tests/test_ingestion_delete.py
+++ b/forward_netbox/tests/test_ingestion_delete.py
@@ -5,15 +5,18 @@ delete action from the table rather than registering the view the action
 pointed at. The crash went away and so did the ability to delete an ingestion —
 reported by a customer against 2.6.5.
 
-Most relations to an ingestion cascade, but `ForwardContributorBaseline` is
-PROTECT: it is durable convergence evidence and deleting the ingestion that
-produced it would strand it. That case must be reported, not surfaced as an
-unhandled `ProtectedError`.
+Most relations to an ingestion cascade. The contributor baseline is the one
+that matters: the LIVE generation is durable convergence evidence and must
+outlive nothing, while every superseded generation is an emptied husk that used
+to protect its ingestion forever. That split is enforced by a `pre_delete`
+receiver rather than by PROTECT, because PROTECT cannot express it, and it must
+be reported rather than surfaced as an unhandled `ProtectedError`.
 """
 
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.db import transaction
 from django.test import TestCase
 from django.urls import reverse
 
@@ -90,8 +93,11 @@ class IngestionDeleteRefusalTest(TestCase):
         self.ingestion.delete()
         self.assertFalse(ForwardIngestion.objects.filter(pk=self.ingestion.pk).exists())
 
-    def test_a_contributor_baseline_blocks_the_delete_and_is_named(self):
-        # The real PROTECT relation against a real row, not a mock.
+    def test_the_live_baseline_blocks_the_delete_and_says_why(self):
+        # The relation is CASCADE now so a spent baseline can be collected; the
+        # live one is kept by the pre_delete receiver instead. Assert the shape
+        # deliberately, so flipping it back is a failing test rather than a
+        # silently lost guarantee.
         from django.db import models as django_models
 
         from forward_netbox.models import ForwardContributorBaseline
@@ -99,34 +105,36 @@ class IngestionDeleteRefusalTest(TestCase):
         field = ForwardContributorBaseline._meta.get_field("ingestion")
         self.assertIs(
             field.remote_field.on_delete,
-            django_models.PROTECT,
-            "ForwardContributorBaseline.ingestion is no longer PROTECT; this "
-            "test no longer covers the case it was written for",
+            django_models.CASCADE,
+            "ForwardContributorBaseline.ingestion is no longer CASCADE; the "
+            "spent-baseline collection this test covers depends on it",
         )
-        self._baseline(ForwardContributorBaseline)
+        baseline = self._baseline(ForwardContributorBaseline)
+        baseline.is_current = True
+        baseline.status = ForwardContributorBaseline.Status.CURRENT
+        baseline.save(update_fields=["is_current", "status"])
 
-        refusal = _ingestion_delete_refusal(self.ingestion)
+        refusal, expected = _ingestion_delete_refusal_detail(self.ingestion)
 
-        self.assertTrue(refusal, "a protected ingestion must be refused")
-        self.assertIn("ForwardContributorBaseline", refusal)
-        # The baseline case now says it is expected rather than reading as a
-        # fault; a customer reported the old red error as a defect twice.
-        self.assertIn("is the baseline for this sync", refusal)
+        self.assertTrue(refusal, "the live baseline must be refused")
+        self.assertIn("current contributor baseline", refusal)
+        # Expected rather than a fault; a customer reported the old red error
+        # as a defect twice.
         self.assertIn("expected, not a failure", refusal)
+        self.assertTrue(expected)
 
     def test_the_refusal_names_what_to_do(self):
         from forward_netbox.models import ForwardContributorBaseline
 
-        self._baseline(ForwardContributorBaseline)
-        self.assertIn(
-            "remove those records first", _ingestion_delete_refusal(self.ingestion)
-        )
+        baseline = self._baseline(ForwardContributorBaseline)
+        baseline.is_current = True
+        baseline.save(update_fields=["is_current"])
+        self.assertIn("Run the sync again", _ingestion_delete_refusal(self.ingestion))
 
-    def test_a_superseded_baseline_is_not_called_the_current_one(self):
-        # Every ingestion that ever promoted leaves a baseline behind, and
-        # promotion only marks the previous one superseded. A customer with
-        # three undeletable ingestions was told three times that each was "the
-        # baseline for this sync", which is true of at most one of them.
+    def test_a_spent_baseline_is_collected_with_its_ingestion(self):
+        # The customer case: every ingestion that ever promoted left a baseline
+        # behind, and nothing removed it, so the backlog grew by one per
+        # successful sync until three were undeletable at once.
         from forward_netbox.models import ForwardContributorBaseline
 
         baseline = self._baseline(ForwardContributorBaseline)
@@ -134,32 +142,39 @@ class IngestionDeleteRefusalTest(TestCase):
         baseline.is_current = False
         baseline.save(update_fields=["status", "is_current"])
 
-        refusal, expected = _ingestion_delete_refusal_detail(self.ingestion)
+        self.assertEqual(_ingestion_delete_refusal(self.ingestion), "")
 
-        self.assertTrue(refusal)
-        self.assertNotIn("is the baseline for this sync", refusal)
-        self.assertIn("already been superseded", refusal)
-        # The old text told them to "remove those records first". There is no
-        # supported way to remove this one, so it must not say that.
-        self.assertNotIn("remove those records first", refusal)
-        self.assertIn("ForwardContributorBaseline", refusal)
-        # Still expected rather than a fault, so it stays a warning not an error.
-        self.assertTrue(expected)
+        self.ingestion.delete()
 
-    def test_a_pending_baseline_is_not_reported_as_spent(self):
-        # `is_current` defaults to False and `status` to PENDING, so keying the
-        # wording off `is_current` alone would tell an operator mid-sync that an
-        # intact payload is a dead husk. Only promotion sets SUPERSEDED.
+        self.assertFalse(ForwardIngestion.objects.filter(pk=self.ingestion.pk).exists())
+        self.assertFalse(
+            ForwardContributorBaseline.objects.filter(pk=baseline.pk).exists(),
+            "the spent baseline must go with its ingestion, not outlive it",
+        )
+
+    def test_a_live_baseline_is_never_collected_even_by_a_queryset_delete(self):
+        # The guarantee moved from PROTECT to a pre_delete receiver, and the
+        # whole point of that receiver over a check in the view is that it fires
+        # for querysets too.
+        from django.db.models.deletion import ProtectedError
+
         from forward_netbox.models import ForwardContributorBaseline
 
         baseline = self._baseline(ForwardContributorBaseline)
-        self.assertEqual(baseline.status, ForwardContributorBaseline.Status.PENDING)
-        self.assertFalse(baseline.is_current)
+        baseline.is_current = True
+        baseline.status = ForwardContributorBaseline.Status.CURRENT
+        baseline.save(update_fields=["is_current", "status"])
 
-        refusal = _ingestion_delete_refusal(self.ingestion)
+        # A refused delete aborts the transaction it ran in, so the assertions
+        # after it need a surviving one.
+        with transaction.atomic():
+            with self.assertRaises(ProtectedError):
+                ForwardIngestion.objects.filter(pk=self.ingestion.pk).delete()
 
-        self.assertNotIn("already been superseded", refusal)
-        self.assertIn("is the baseline for this sync", refusal)
+        self.assertTrue(ForwardIngestion.objects.filter(pk=self.ingestion.pk).exists())
+        self.assertTrue(
+            ForwardContributorBaseline.objects.filter(pk=baseline.pk).exists()
+        )
 
     def test_cascading_children_do_not_block_the_delete(self):
         # Issues cascade, so they must not be reported as protecting.
@@ -480,11 +495,17 @@ class ReconciliationNoLongerPinsAnIngestionTest(TestCase):
             scope_config_fingerprint="cf",
             scope_membership_fingerprint="sf",
             scope_payload_checksum="pc",
+            is_current=True,
+            status=ForwardContributorBaseline.Status.CURRENT,
         )
 
         refusal, expected = _ingestion_delete_refusal_detail(self.newer)
 
-        self.assertIn("is the baseline for this sync", refusal)
+        self.assertIn("current contributor baseline", refusal)
         self.assertTrue(expected)
-        with self.assertRaises(ProtectedError):
-            self.newer.delete()
+        # The refusal is now raised by the pre_delete receiver rather than by a
+        # PROTECT constraint, and it aborts the surrounding transaction either
+        # way - so keep it in its own atomic block.
+        with transaction.atomic():
+            with self.assertRaises(ProtectedError):
+                self.newer.delete()

--- a/forward_netbox/tests/test_protecting_relations.py
+++ b/forward_netbox/tests/test_protecting_relations.py
@@ -27,6 +27,11 @@ class ProtectingRelationsSeesHiddenRelationsTest(TestCase):
     # naming rows no supported action could remove. It is still hidden, so it
     # still belongs in HIDDEN_MODELS below — discovery must keep seeing it, it
     # just must not be reported as protecting.
+    #
+    # `ForwardContributorBaseline` went the same way for the same reason: every
+    # ingestion that ever promoted left a superseded husk behind that protected
+    # it forever. The LIVE generation is still kept, by a `pre_delete` receiver
+    # rather than by the constraint, because PROTECT cannot tell the two apart.
     OWNERSHIP_MODELS = {
         "forward_netbox.ForwardDeviceIdentity",
         "forward_netbox.ForwardDeviceTagClaim",
@@ -50,14 +55,27 @@ class ProtectingRelationsSeesHiddenRelationsTest(TestCase):
             f"{sorted(self.OWNERSHIP_MODELS - found)}",
         )
 
-    def test_the_visible_baseline_protection_is_still_discovered(self):
-        # Widening discovery must not lose the one relation that was already
-        # being found; the baseline refusal is the expected, benign case.
+    def test_the_baseline_is_not_reported_as_protecting(self):
+        # The baseline was the last VISIBLE protecting relation, and it now
+        # cascades so a superseded generation can be collected with its
+        # ingestion. Reporting it would refuse a delete the database allows.
+        #
+        # Which means every remaining protection is hidden behind
+        # related_name="+", so `test_hidden_protect_relations_are_discovered` is
+        # now the only thing standing between discovery and finding nothing at
+        # all. Losing the widening would no longer under-report — it would
+        # report an ingestion as freely deletable while the database refused it,
+        # which is the failure that made every ingestion undeletable in 2.7.0.
         found = {
             relation.related_model._meta.label
             for relation in protecting_relations(ForwardIngestion)
         }
-        self.assertIn("forward_netbox.ForwardContributorBaseline", found)
+        self.assertNotIn("forward_netbox.ForwardContributorBaseline", found)
+        self.assertTrue(
+            found,
+            "no protecting relation is discovered at all; the hidden-relation "
+            "traversal has been lost",
+        )
 
     def test_cascading_relations_are_not_reported_as_protecting(self):
         # Over-reporting would refuse deletes that the database would allow.

--- a/forward_netbox/tests/test_sync.py
+++ b/forward_netbox/tests/test_sync.py
@@ -9049,7 +9049,7 @@ class ForwardApplyEngineParityTest(TestCase):
         self.assertEqual(issue.exception, "ForwardDependencySkipError")
         self.assertEqual(
             issue.message,
-            "dcim.virtualchassis row processing failed (ForwardDependencySkipError).",
+            "dcim.virtualchassis row processing skipped (ForwardDependencySkipError).",
         )
         runner.logger.increment_statistics.assert_any_call(
             "dcim.virtualchassis",

--- a/forward_netbox/utilities/sync_dlm.py
+++ b/forward_netbox/utilities/sync_dlm.py
@@ -58,6 +58,7 @@ def _lookup_platform(runner, row, model_string, object_label):
             f"Skipping {object_label} because platform `{name or slug}` is not "
             "in NetBox yet.",
             model_string=model_string,
+            dependency="dcim.platform",
             context={"platform": name or slug},
             data=row,
         )
@@ -81,6 +82,7 @@ def _lookup_device_type(runner, row, model_string, object_label):
             "alias-aware device query, use the 'Forward DLM Hardware Notices "
             "with NetBox Aliases' map so notices look up the same name.",
             model_string=model_string,
+            dependency="dcim.devicetype",
             context={"device_type": model or slug},
             data=row,
         )
@@ -97,6 +99,7 @@ def _lookup_device(runner, row, model_string, object_label):
                 f"Skipping {object_label} because dependency `dcim.device` "
                 f"failed for {key}.",
                 model_string=model_string,
+                dependency="dcim.device",
                 context={"device": row["name"]},
                 data=row,
             ) from exc
@@ -104,6 +107,7 @@ def _lookup_device(runner, row, model_string, object_label):
             f"Skipping {object_label} because device `{row['name']}` is not "
             "in the current NetBox branch.",
             model_string=model_string,
+            dependency="dcim.device",
             context={"device": row["name"]},
             data=row,
         ) from exc
@@ -236,6 +240,7 @@ def _lookup_inventory_item(runner, row):
             "Skipping DLM inventory item software because its device is not "
             "in the current NetBox branch.",
             model_string="netbox_dlm.inventoryitemsoftware",
+            dependency="dcim.inventoryitem",
             context={"dependency": "dcim.inventoryitem"},
             data=row,
         ) from exc
@@ -248,6 +253,7 @@ def _lookup_inventory_item(runner, row):
             "item is not in the current NetBox branch. Enable Forward CIMC "
             "Endpoint Inventory alongside this map.",
             model_string="netbox_dlm.inventoryitemsoftware",
+            dependency="dcim.inventoryitem",
             context={"dependency": "dcim.inventoryitem"},
             data=row,
         )
@@ -262,6 +268,7 @@ def ensure_dlm_inventory_item_role_platform(runner, inventory_item, row):
             "Skipping DLM inventory item software because the target inventory "
             "item has no role.",
             model_string="netbox_dlm.inventoryitemsoftware",
+            dependency="dcim.inventoryitemrole",
             context={"dependency": "dcim.inventoryitemrole"},
             data=row,
         )

--- a/forward_netbox/utilities/sync_primitives.py
+++ b/forward_netbox/utilities/sync_primitives.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 from django.db.models import Q
 from django.db.models.deletion import ProtectedError
+from rq.timeouts import JobTimeoutException
 
 from ..exceptions import ForwardDependencySkipError
 from ..exceptions import ForwardQueryError
@@ -452,6 +453,28 @@ def upsert_values_from_defaults(
     )
 
 
+def _protecting_model_labels(exc) -> str:
+    """The distinct models still referencing the row, as a comma-joined slug.
+
+    `ProtectedError.protected_objects` holds the actual surviving rows, whose
+    `str()` is a device or site name. Only their model labels are taken, and
+    only the first few, so a prune blocked by ten thousand devices does not
+    write ten thousand of anything.
+    """
+    labels = set()
+    try:
+        for obj in getattr(exc, "protected_objects", ()) or ():
+            labels.add(obj._meta.label_lower)
+            if len(labels) >= 4:
+                break
+    except JobTimeoutException:
+        # A worker boundary must never be swallowed by a diagnostic.
+        raise
+    except Exception:  # noqa: BLE001 - a diagnostic must not mask the skip
+        return ""
+    return ", ".join(sorted(labels))
+
+
 def delete_by_coalesce(runner, model, lookups):
     lookups = _dedupe_lookups([lookup for lookup in lookups or [] if lookup])
     if not lookups:
@@ -462,9 +485,15 @@ def delete_by_coalesce(runner, model, lookups):
             try:
                 obj.delete()
             except ProtectedError as exc:
+                # This skip is the inverse of every other one: nothing is
+                # missing, the object is still referenced and the database
+                # refuses to prune it. Naming the models still pointing at it is
+                # the whole answer, and they are schema identifiers — unlike
+                # `lookup`, which is the object's own name or slug.
                 raise ForwardDependencySkipError(
                     f"Skipping delete for `{model._meta.label_lower}` due to protected dependencies: {exc}",
                     model_string=model._meta.label_lower,
+                    dependency=_protecting_model_labels(exc),
                     context=lookup,
                 ) from exc
             forget_lookup_object(runner, obj)

--- a/forward_netbox/utilities/sync_reporting.py
+++ b/forward_netbox/utilities/sync_reporting.py
@@ -369,8 +369,16 @@ def record_issue(
     # a field name rather than one, so it is still never printed.
     named_fields = [field for field in invalid_fields if field != "__all__"]
     field_detail = f"invalid fields {', '.join(named_fields)}" if named_fields else ""
+    # The model whose absence — or whose surviving children, on the delete path
+    # — caused the skip. A schema identifier, so unlike everything in `context`
+    # it can be recorded. Six identical `(ForwardDependencySkipError)` rows told
+    # a customer nothing about which parent was missing; a raiser that has not
+    # been taught to name one still records exactly what it did before.
+    dependency = str(getattr(exception, "dependency", "") or "")
     if is_dependency_skip_summary:
         detail = ""
+    elif dependency:
+        detail = f"{named}; {dependency}"
     elif constraint:
         detail = f"{named}; constraint {constraint}"
     elif rules:
@@ -384,10 +392,26 @@ def record_issue(
         detail = f"{named}; {field_detail}"
     else:
         detail = named
+    # "failed" was written for every row regardless of what the caller decided,
+    # so a row deliberately skipped read exactly like one that blocks a
+    # baseline. The merge recorder says "Recorded and skipped" for its own
+    # skips; the sync recorder could not say anything of the kind.
+    #
+    # NOT keyed on `log_level` alone. The row-oriented handler records a
+    # dependency skip at "info" while the bulk engines record theirs at the
+    # default, so the same condition would be worded two ways depending on which
+    # engine ran — a test asserting `outcome="skipped"` two lines below a
+    # message reading "failed" is what surfaced it. A dependency skip is a skip
+    # by definition of the exception, whatever level it was logged at.
+    outcome_word = (
+        "skipped"
+        if exception_name == "ForwardDependencySkipError" or log_level != "failure"
+        else "failed"
+    )
     message = (
         message
         if is_dependency_skip_summary
-        else f"{model_string} row processing failed ({detail})."
+        else f"{model_string} row processing {outcome_word} ({detail})."
     )
     context_data = (
         json_safe_value(context or {})

--- a/forward_netbox/views.py
+++ b/forward_netbox/views.py
@@ -2164,42 +2164,33 @@ def _ingestion_holds_current_ownership(ingestion) -> bool:
         return True
 
 
-def _ingestion_baseline_state(ingestion) -> str:
-    """``"current"``, ``"spent"``, or ``""`` when no baseline holds this row.
+def _ingestion_holds_live_baseline(ingestion) -> bool:
+    """Whether the sync's live contributor baseline belongs to this ingestion.
 
-    The refusal used to decide this by looking for "baseline" in the protecting
-    model's label, which cannot distinguish the sync's live baseline from one
-    that was superseded years of syncs ago. Every ingestion that ever promoted
-    leaves a baseline row behind, and promotion only marks the previous one
-    superseded — it clears the relations and empties the payload but keeps the
-    row, which goes on protecting its ingestion forever. So a customer with
-    three undeletable ingestions was told three times that each was "the
-    baseline for this sync", which is true of at most one of them.
+    Exactly the condition `refuse_ingestion_delete_with_live_baseline` enforces,
+    and it has to stay exactly that condition: the receiver is what actually
+    refuses, so a view that answered a different question would either refuse a
+    delete the database allows or offer one it will reject.
 
-    "Spent" is `status == SUPERSEDED` specifically, NOT `is_current is False`.
-    `is_current` defaults to False and `status` to PENDING, so a baseline that
-    has simply not been promoted yet is also not current — and calling that one
-    spent would tell an operator mid-sync that an intact payload is a dead
-    husk. Only promotion sets SUPERSEDED, and it is promotion that clears the
-    relations and empties the payload.
+    `is_current`, not `status`. Every ingestion that ever promoted leaves a
+    baseline behind and promotion only marks the previous one SUPERSEDED, so
+    reading anything wider than "is this the live one" is what made three of a
+    customer's ingestions each claim to be the baseline for the sync.
 
-    Fails closed to ``"current"``: the conservative wording promises nothing.
+    Fails closed: an unprovable answer refuses rather than offering a delete the
+    receiver would abort.
     """
     from .models import ForwardContributorBaseline
 
     if not ingestion.pk:
-        return ""
+        return False
     try:
-        baseline = ForwardContributorBaseline.objects.filter(
-            ingestion=ingestion
-        ).first()
+        return ForwardContributorBaseline.objects.filter(
+            ingestion=ingestion,
+            is_current=True,
+        ).exists()
     except Exception:  # noqa: BLE001 - a refusal must not become a 500
-        return "current"
-    if baseline is None:
-        return ""
-    if baseline.status == ForwardContributorBaseline.Status.SUPERSEDED:
-        return "spent"
-    return "current"
+        return True
 
 
 def _ingestion_delete_refusal_detail(ingestion) -> tuple[str, bool]:
@@ -2220,10 +2211,23 @@ def _ingestion_delete_refusal_detail(ingestion) -> tuple[str, bool]:
     action behind it.
     """
     references = describe_protecting_references(type(ingestion), ingestion.pk)
-    baseline_reference = any(
-        "baseline" in str(label).casefold() for label, _count in references
-    )
-    if not baseline_reference and _ingestion_holds_current_ownership(ingestion):
+    # A spent baseline cascades with its ingestion now, so it no longer appears
+    # here at all and no longer has to be described. A live one does not cascade
+    # and is not a PROTECT relation either, so it has to be asked about directly
+    # rather than read off the protecting references the way it used to be.
+    if _ingestion_holds_live_baseline(ingestion):
+        held_by = ", ".join(f"{label} ({count})" for label, count in references)
+        also_held = f" It is also held by {held_by}." if held_by else ""
+        return (
+            f"{ingestion} holds the current contributor baseline for this sync - "
+            "the durable record of what has already converged - so it is kept "
+            "until a later sync promotes a new one. This is expected, not a "
+            "failure, and it is why one ingestion in a sequence will not delete "
+            f"when the others do.{also_held} Run the sync again; once a newer "
+            "ingestion has promoted its own baseline, this one deletes normally "
+            "and takes the spent record with it."
+        ), True
+    if _ingestion_holds_current_ownership(ingestion):
         return (
             f"{ingestion} is the ingestion whose ownership reconciliation is "
             "currently complete for this sync, so it is the record that proves "
@@ -2238,31 +2242,6 @@ def _ingestion_delete_refusal_detail(ingestion) -> tuple[str, bool]:
     if not references:
         return "", False
     held_by = ", ".join(f"{label} ({count})" for label, count in references)
-    if baseline_reference:
-        if _ingestion_baseline_state(ingestion) == "spent":
-            # Do not repeat the durable-record wording here. This baseline is
-            # spent: promotion already cleared its relations and emptied its
-            # payload, so it protects nothing an operator would want kept, and
-            # telling them to "remove those records first" points at an action
-            # the product does not offer for this row.
-            return (
-                f"{ingestion} is held by a contributor baseline that has "
-                "already been superseded by a later sync. The record is spent - "
-                "its contents were cleared when the newer baseline was promoted "
-                "- but it still protects this ingestion, so the ingestion "
-                f"cannot be deleted. It is held by {held_by}. Nothing is wrong "
-                "with this sync and no action will release it today; collecting "
-                "spent baselines is a known gap."
-            ), True
-        return (
-            f"{ingestion} is the baseline for this sync - the durable record of "
-            "what has already converged - so NetBox protects it from deletion. "
-            "This is expected, not a failure, and it is why one ingestion in a "
-            "sequence will not delete when the others do. It is held by "
-            f"{held_by}. Deleting it would strand that evidence and force the "
-            "next sync to re-establish a baseline from scratch; if that is "
-            "genuinely what you want, remove those records first."
-        ), True
     return (
         f"{ingestion} cannot be deleted while it is still referenced by "
         f"{held_by}. Those records are convergence evidence for this ingestion; "


### PR DESCRIPTION
Closes #45, #44, #51, #53. Three customer reports in one day, all housekeeping rather than sync failure: three ingestions that would not delete, and six issue rows reading exactly `netbox_dlm.softwareversion row processing failed (ForwardDependencySkipError).`

### Spent baselines are collected
Every ingestion that promotes leaves a baseline behind. Promotion marks the previous one SUPERSEDED, clears its relations and empties its payload — but keeps the row, which goes on protecting its ingestion. Nothing anywhere deleted one, so every ingestion that ever promoted was permanently undeletable and the backlog grew by one per successful sync.

The FK becomes CASCADE; the live generation is kept by a `pre_delete` receiver.

**Why not keep PROTECT and delete the husk in the view** (my first attempt): PROTECT forces the baseline to go first, and making "baseline deleted, ingestion deleted" atomic inside NetBox's delete view requires sniffing the response to know whether the second half happened. A half-applied version destroys the record *and* keeps the row it was blocking. The receiver also fires for `queryset.delete()`, so no path can lose a live baseline — strictly more than the constraint guaranteed. There is a test for exactly that.

The same receiver refuses an ingestion whose job is running (#44). `ForwardIngestion` carries `JobsMixin` exactly as `ForwardSync` does, so its `Job` rows cascade through the SQL collector and bypass `Job.delete()`'s RQ-cancel override.

### A skip says what it was waiting for (#53)
`ForwardDependencySkipError` gains a `dependency` model label. The raiser's message names the platform or device — customer data, hence unpersistable; the label is a schema identifier. On the delete path the answer is **inverted**: `dcim.site` / `ipam.vrf` / `dcim.devicetype` skips are not missing parents at all, they are prunes refused because children still reference the object, so that raiser reports the protecting child models from `ProtectedError.protected_objects`.

Six of ~30 raisers covered — the two groups a customer is reading. The rest record exactly what they did before.

### A skipped row says "skipped" (#51)
Keyed on the exception class, **not** `log_level`: the row-oriented handler logs a dependency skip at `info` while the bulk engines use the default, so the level would word one condition two ways. A test asserting `outcome="skipped"` two lines below a message reading `"failed"` is what surfaced it.

### Caught by the gates, worth naming
`scripts/tests` flagged a broad `except` that would have swallowed an RQ timeout — and the `JobTimeoutException` I added was **not imported**, so it would have been a `NameError` firing only when a job timed out mid-prune.

### Tests
`test_protecting_relations` now asserts the baseline is *not* reported as protecting — and that discovery still finds something, because the baseline was the last **visible** protecting relation and every remaining one is hidden behind `related_name="+"`. Losing that traversal would no longer under-report; it would call a protected ingestion freely deletable.

**Full plugin suite: 1962 tests, OK (4 skipped).** Plus `pre-commit` converged, `scripts/tests` 328 OK, `check_harness.py` both modes.

### Not in scope
The other ~24 skip raisers (the vocabulary already exists in `record_aggregated_skip_warning` and never reaches the database), #46 device-identity pruning, #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPmp33tVZYDSeuBL4seyw8