### PR TITLE
fix: correct the 2.7.4 release evidence and retry the PyPI lookup

### DIFF
--- a/docs/03_Plans/active/2026-08-06-release-2.7.4.md
+++ b/docs/03_Plans/active/2026-08-06-release-2.7.4.md
@@ -103,8 +103,20 @@ at tag time.
 ## Release Authorization
 
 Both gates ran against the final tree, whose parent is
-`bdda04cbd79d8edad013d9e64333e815a2d7a83b`, on a clean working tree.
+`7fe1d00aa72c7e097f0dc3530fdd2def5bc2e9fa`, on a clean working tree.
 
-- Evidence base commit: `bdda04cbd79d8edad013d9e64333e815a2d7a83b`
-- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke ci` passed with status 0 across the whole fan-out: 328 harness tests, 70 scenario tests, 1969 plugin tests and the 1 UI harness test all reported OK, the strict sync release gate passed, and the 5 artifact-upgrade paths each seeded under a previous release, migrated onto the built wheel, and kept the rows seeded under that previous release.
+- Evidence base commit: `7fe1d00aa72c7e097f0dc3530fdd2def5bc2e9fa`
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke ci` passed with status 0 across the whole fan-out: 299 harness tests, 70 scenario tests, 1969 plugin tests and the 1 UI harness test all reported OK, the strict sync release gate passed, and the artifact-upgrade gate seeded 2.7.2 on NetBox 4.6.5, migrated it onto the built 2.7.4 wheel on NetBox 4.6.6, and kept the rows seeded under 2.7.2.
 - [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke artifact-test` passed with status 0: the built `forward_netbox-2.7.4-py3-none-any.whl` installed into the exact runtime image on NetBox 4.6.6 with Branching 1.1.2 under Python 3.14, migrated through `forward_netbox.0050_contributor_baseline_cascade`, reported no unmade migrations, served all 7 installed menu routes with status 200, and the recorded runtime SBOM carries 156 components reporting forward_netbox 2.7.4, netbox 4.6.6, branching 1.1.2.
+
+The gates ran against the tree merged as `7fe1d00` plus this correction and
+the PyPI retry beside it; neither changes what `invoke ci` executes, and the
+evidence base commit is that merged release commit.
+
+The upgrade evidence names ONE path, deliberately. An earlier draft of this
+section claimed five, copied from the 2.7.2 plan; those five lines in the gate
+log come from `scripts/tests` exercising the upgrade harness against fixture
+versions (2.6.6 -> 2.6.7) and say nothing about this release. The real gate ran
+only after `artifact-upgrade-test` was added to the local `ci` flow, and it
+resolves what to upgrade from by asking PyPI what was actually published -
+which is 2.7.2, because 2.7.3 was tagged and never published.

--- a/tasks.py
+++ b/tasks.py
@@ -1076,23 +1076,38 @@ def _previous_released_version(context, version):
     the index can answer that.
     """
     import json
+    import time
     import urllib.error
     import urllib.request
 
     url = "https://pypi.org/pypi/forward-netbox/json"
-    try:
-        with urllib.request.urlopen(url, timeout=60) as response:
-            payload = json.load(response)
-    # OSError, not just TimeoutError: the read can also fail with
-    # ConnectionResetError, which is not a URLError and was escaping raw -
-    # failing the release gate with a bare socket error instead of the message
-    # that says how to run it offline.
-    except (urllib.error.URLError, OSError, ValueError) as exc:
+    # Retry before failing. A single attempt failed this gate twice in a row on
+    # a read timeout while PyPI was reachable from the same host seconds later:
+    # the gate runs right after the whole docker fan-out, which is exactly when
+    # a 60s read is most likely to lose. One transient blip must not cost a
+    # release cycle.
+    payload = None
+    last_error: Exception | None = None
+    for attempt in range(3):
+        if attempt:
+            time.sleep(5 * attempt)
+        try:
+            with urllib.request.urlopen(url, timeout=60) as response:
+                payload = json.load(response)
+            break
+        # OSError, not just TimeoutError: the read can also fail with
+        # ConnectionResetError, which is not a URLError and was escaping raw -
+        # failing the release gate with a bare socket error instead of the
+        # message that says how to run it offline.
+        except (urllib.error.URLError, OSError, ValueError) as exc:
+            last_error = exc
+    if payload is None:
         raise Exit(
-            f"Could not read released versions from PyPI ({exc}). Pass "
-            "--from-version explicitly to run this gate offline.",
+            f"Could not read released versions from PyPI ({last_error}) after "
+            "3 attempts. Pass --from-version explicitly to run this gate "
+            "offline.",
             code=2,
-        ) from exc
+        ) from last_error
 
     # `version` is whatever the tree carries, and between releases that is a
     # `.dev0` marker - `main` is deliberately moved onto one so an install from


### PR DESCRIPTION
Auto-merge on #152 was still armed from earlier. The moment the required status checks came off the ruleset, the last thing blocking it disappeared and GitHub merged the branch **as last pushed** rather than as it stood locally, so two corrections missed the release commit.

## The evidence was wrong

`main`'s authorization section claims `invoke ci` covered *"328 harness tests"* and *"5 artifact-upgrade paths"*. Neither is true of this release:

- the suite is **299** tests, since the workflow-dependent harness tests went with the workflows
- those five upgrade lines come from `scripts/tests` exercising the upgrade *harness* against fixture versions (2.6.6 → 2.6.7) and say nothing about 2.7.4

The sentence was copied from the 2.7.2 plan. The real gate ran only once `artifact-upgrade-test` joined the local `ci` flow, and it records **one genuine path**: 2.7.2 seeded on NetBox 4.6.5, migrated onto the built 2.7.4 wheel on 4.6.6, rows intact. It resolves the from-version by asking PyPI what was actually *published*, which is why it picks 2.7.2 and not the tagged-but-never-published 2.7.3.

## The upgrade gate had no retry

One 60s PyPI read, single attempt. It failed the entire release twice while PyPI answered fine from the same host seconds later — it runs immediately after the docker fan-out, exactly when a read is most likely to lose. Now three attempts with backoff.

## Binding

`Evidence base commit` is re-pointed at `7fe1d00`, the merged release commit, so authorization still binds to the parent of the commit that gets tagged. Neither change alters what `invoke ci` executes.

## Verification

- `invoke ci` **rc=0** — 299 harness, 70 scenario, 1969 plugin (4 skipped), 1 UI, strict release gate, real 2.7.2→2.7.4 upgrade
- `invoke artifact-test` **rc=0** — wheel into the exact runtime, migrated through `forward_netbox.0050_contributor_baseline_cascade`, 7 menu routes 200, SBOM 156 components
- `check_harness.py`, `check_release_authorization.py`, `scripts/tests` (299), pre-commit all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5Ax5f23uwWLmjGMtQq39p