### PR TITLE
fix: unpin ownership provenance and adopt pre-existing reserved status tags

### DIFF
--- a/docs/03_Plans/active/2026-08-07-adopt-reserved-status-tags.md
+++ b/docs/03_Plans/active/2026-08-07-adopt-reserved-status-tags.md
@@ -1,0 +1,66 @@
+# Adopt a pre-existing reserved status tag instead of refusing forever
+
+## Goal
+
+Stop an existing `forward-backfilled` tag from breaking ownership
+reconciliation permanently.
+
+## Contract
+
+- The operator keeps everything they tagged. Adoption records their existing
+  assignments as preserved, and preserved assignments are never removed.
+- A genuine conflict still refuses: one tag cannot be two claim types.
+
+## Constraints
+
+- `forward-backfilled` exists in any deployment that has ever had a collection
+  failure, so this is not an edge case.
+- The refusal is unrecoverable by the operator: the ownership domain never
+  completes, convergence stays blocked, and every drift figure reads "Not
+  measured" on every subsequent run. Nothing short of deleting the tag clears
+  it.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/ownership.py`
+- `forward_netbox/tests/test_reserved_status_tag_adoption.py`,
+  `forward_netbox/tests/test_ownership.py`
+
+## Approach
+
+Delete the reserved-slug refusal and the `allow_reserved_adoption` parameter,
+and let the adoption path that follows it do its job.
+
+## Validation
+
+- `invoke test-isolated` - full plugin suite, 1998 tests, OK (4 skipped)
+- The new tests were confirmed to FAIL without the fix (4 of 5 error) before
+  being accepted
+- Adoption verified empirically to leave both the reserved tag and the
+  operator's own tag on the device
+
+## Rollback
+
+Revert. The refusal returns, and with it the permanent failure for any
+deployment whose reserved tag lacks a managed row.
+
+## Decision Log
+
+- **The override could never fire.** The sole caller passed
+  `allow_reserved_adoption=tag_created`, true only when the plugin had just
+  created the tag - exactly when there is nothing to adopt. So the refusal was
+  unconditional in every case that mattered. Same shape as `#43`.
+- **The refusal was redundant, not protective.** An existing test asserted it
+  kept an operator's tag on their device. It does not:
+  `_materialize_managed_tag_assignments` folds preserved assignments back into
+  `desired_ids`, so they are never removed. That test was rewritten to assert
+  the outcome it actually cared about, and it passes under adoption.
+- **Checked before overriding the test.** The full suite caught it, and the
+  first move was to find what it protected rather than to update it to match
+  the change.
+
+## Open
+
+- Whether this is THE cause of the customer's `Ownership: Incomplete` is still
+  inference from screenshots, not confirmation. `#58` means a surviving
+  conflict now names itself.

--- a/docs/03_Plans/active/2026-08-07-unpin-ownership-provenance.md
+++ b/docs/03_Plans/active/2026-08-07-unpin-ownership-provenance.md
@@ -1,0 +1,77 @@
+# Stop a provenance stamp pinning its ingestion
+
+## Goal
+
+Make an ingestion deletable once nothing but an old provenance stamp holds it,
+without releasing ownership of any live device.
+
+## Contract
+
+- Ownership must survive. The sync, device, source key and `snapshot_id` on
+  each evidence row are untouched; only the pointer to a deleted run goes.
+- No device changes hands. Nothing is pruned, released, or re-adopted.
+- `ForwardOwnershipReconciliation` keeps CASCADE. It is a child record of the
+  ingestion, not evidence held against it.
+
+## Constraints
+
+- The evidence rows that pin an ingestion are NOT stale - the devices still
+  exist and are still owned. Only the stamp is old. Any fix that prunes them
+  releases ownership of live devices that are merely out of scope, and devices
+  leave scope for benign reasons: a Forward-side tag edit is enough.
+- `exclude(ingestion__sync_id=F("sync_id"))` compiles to a LEFT OUTER JOIN
+  guarded by `ingestion.sync_id IS NOT NULL`. A null stamp satisfies the
+  negation, so the cross-sync mismatch counters must require a stamp before
+  comparing it. `exclude(ingestion_id=generation)` behaves the OPPOSITE way and
+  correctly counts a null stamp as stale - verify the compiled SQL, do not
+  reason from the Python.
+- `related_name="+"` makes these relations invisible to
+  `_meta.related_objects`; `protecting_relations` reads them explicitly.
+
+## Touched Surfaces
+
+- `forward_netbox/models.py`, `forward_netbox/migrations/0051_...py`
+- `forward_netbox/utilities/ownership.py`, `forward_netbox/utilities/bulk_merge.py`
+- `forward_netbox/tests/test_ingestion_delete.py`,
+  `test_protecting_relations.py`, `test_ownership.py`
+
+## Approach
+
+Change the shared `ForwardIngestionProvenanceMixin.ingestion` from PROTECT to
+SET_NULL (nullable, blank), and guard the two cross-sync mismatch counters so a
+null stamp is not mistaken for a stamp pointing at another sync.
+
+## Validation
+
+- `invoke test-isolated` - full plugin suite, 1993 tests, OK (4 skipped)
+- `invoke makemigrations` reports no model drift
+- The new counter test was confirmed to FAIL without the guard (`1 != 0`) before
+  being accepted as a regression test
+
+## Rollback
+
+Revert both. The reverse migration restores PROTECT and non-null, and fails if
+any row already has a null stamp - which is the expected state once an
+ingestion has been deleted, so reversing means deciding what those rows should
+point at.
+
+## Decision Log
+
+- **The stamp is provenance, not a dependency.** Reframing it that way is what
+  made this tractable after three wrong models. The question is not "is this
+  evidence still valid" (it is) but "should a record of ownership block the
+  deletion of the run that recorded it".
+- **Rejected: re-point every row on each merge.** It would assert the current
+  run saw devices it never saw, and would permanently zero the `stale_claims`
+  signal.
+- **Rejected: prune evidence for departed devices (#46).** The dangerous
+  option, for the reason in Constraints.
+- **A subagent sweep found the counter defect.** It contradicted the premise I
+  gave it and was right; the compiled SQL settled it. Worth repeating for any
+  nullable-FK change.
+
+## Open
+
+- #46 is now optional rather than blocking. Pruning genuinely dead identities
+  may still be worth doing, but it is no longer what stands between an operator
+  and deleting an old ingestion.

--- a/forward_netbox/migrations/0051_ownership_provenance_stamp_nullable.py
+++ b/forward_netbox/migrations/0051_ownership_provenance_stamp_nullable.py
@@ -1,0 +1,70 @@
+import django.db.models.deletion
+from django.db import migrations
+from django.db import models
+
+
+# Ownership evidence is main-schema convergence state, like the rows in 0047 and
+# the baseline in 0050. Branch schemas must not receive independent constraints
+# for them.
+fake_on_branch = True
+
+
+class Migration(migrations.Migration):
+    """Stop a provenance stamp behaving like a dependency.
+
+    `ForwardDeviceIdentity`, `ForwardDeviceTagClaim` and
+    `ForwardVirtualParentClaim` each carry an `ingestion` FK recording which run
+    last asserted the evidence. It was PROTECT, so that stamp pinned the run.
+
+    Evidence is only re-pointed for what the current run sees: identities for
+    the current candidate set, tag claims for the tags the sync still manages.
+    A device that leaves Forward's scope - or a tag that is removed from the
+    include list - is never visited again, so its evidence freezes on the last
+    ingestion that saw it and pins that ingestion permanently. A customer
+    accumulated one undeletable ingestion per scope change.
+
+    The rows doing the pinning are NOT stale. The devices still exist and are
+    still owned; only the stamp is old. That is why every model of this problem
+    that proposed pruning the evidence was wrong - it would have released
+    ownership of live devices that were merely out of scope, and devices leave
+    scope for entirely benign reasons, such as someone editing a tag in Forward.
+
+    SET_NULL keeps the ownership and drops only the pointer to a run that no
+    longer exists. Everything the evidence is FOR - the sync, the device, the
+    source key, the `snapshot_id` it was last seen in - lives on the row and is
+    untouched. The generation comparisons already treat a non-matching stamp as
+    stale, and NULL reads the same way.
+
+    `ForwardOwnershipReconciliation` is deliberately not included: it overrides
+    the field to CASCADE because it is a child record of the ingestion rather
+    than evidence held against it.
+
+    Reversible: the reverse restores PROTECT and non-null. It fails if any row
+    has a null stamp by then, which is the expected state once an ingestion has
+    been deleted - so reversing requires deciding what those rows should point
+    at, and no reverse can invent it.
+    """
+
+    dependencies = [
+        ("forward_netbox", "0050_contributor_baseline_cascade"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name=model_name,
+            name="ingestion",
+            field=models.ForeignKey(
+                blank=True,
+                db_column="generation",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to="forward_netbox.forwardingestion",
+            ),
+        )
+        for model_name in (
+            "forwarddeviceidentity",
+            "forwarddevicetagclaim",
+            "forwardvirtualparentclaim",
+        )
+    ]

--- a/forward_netbox/models.py
+++ b/forward_netbox/models.py
@@ -1405,17 +1405,37 @@ class ForwardPreservedDeviceTagAssignment(ForwardPluginModelDocsMixin, models.Mo
 
 
 class ForwardIngestionProvenanceMixin(models.Model):
-    """Protected ownership evidence tied to one exact merged ingestion.
+    """Ownership evidence stamped with the ingestion that last asserted it.
 
     `ForwardOwnershipReconciliation` overrides ``ingestion`` to cascade; it is a
     child record of the ingestion rather than evidence held against it. See that
     model for why.
+
+    ``ingestion`` is a PROVENANCE STAMP, not a dependency, and that distinction
+    is why it is nullable. The substance of the evidence - which sync owns which
+    device, under which source key, and the ``snapshot_id`` it was last seen in
+    - is carried on the row itself and stays true whatever happens to the run
+    that recorded it.
+
+    It was PROTECT, which made a stamp behave like a dependency: a device that
+    left Forward's scope stopped being re-pointed, froze on the last ingestion
+    that saw it, and pinned that ingestion permanently. A customer accumulated
+    one undeletable ingestion for every scope change. The rows doing the pinning
+    were not stale - the devices still existed and were still owned - so every
+    attempt to fix this by pruning the evidence risked releasing a live device,
+    which is why three successive models of the problem were wrong.
+
+    SET_NULL keeps the ownership and drops only the pointer to a run that no
+    longer exists. A null stamp reads as "asserted before the oldest retained
+    ingestion", which the generation comparisons already treat as stale.
     """
 
     ingestion = models.ForeignKey(
         ForwardIngestion,
         db_column="generation",
-        on_delete=models.PROTECT,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
         related_name="+",
     )
 

--- a/forward_netbox/tests/test_ingestion_delete.py
+++ b/forward_netbox/tests/test_ingestion_delete.py
@@ -320,10 +320,13 @@ class ReconciliationNoLongerPinsAnIngestionTest(TestCase):
         )[0]
 
     def test_the_reconciliation_fk_cascades_and_its_siblings_still_protect(self):
-        # The whole fix rests on exactly one of the four provenance models
-        # cascading. Pin that split so a future edit to the shared mixin cannot
-        # quietly take the other three with it — those describe live NetBox
-        # rows and must keep protecting their provenance.
+        # The four provenance models resolve three different ways, and each is
+        # deliberate. Reconciliation CASCADEs: it is a child record of the
+        # ingestion. The other three SET_NULL: they describe live NetBox rows,
+        # so their evidence must survive the run being deleted, but the stamp
+        # naming that run is provenance rather than a dependency and must not
+        # pin it. Pin the split so an edit to the shared mixin cannot quietly
+        # collapse them onto one behaviour.
         from django.db import models as django_models
 
         from forward_netbox.models import ForwardDeviceIdentity
@@ -343,9 +346,14 @@ class ReconciliationNoLongerPinsAnIngestionTest(TestCase):
             ForwardVirtualParentClaim,
         ):
             with self.subTest(model=model._meta.label):
+                field = model._meta.get_field("ingestion")
                 self.assertIs(
-                    model._meta.get_field("ingestion").remote_field.on_delete,
-                    django_models.PROTECT,
+                    field.remote_field.on_delete,
+                    django_models.SET_NULL,
+                )
+                self.assertTrue(
+                    field.null,
+                    "SET_NULL requires the column to be nullable",
                 )
 
     def test_an_ingestion_held_only_by_reconciliation_rows_is_deletable(self):
@@ -431,15 +439,16 @@ class ReconciliationNoLongerPinsAnIngestionTest(TestCase):
             "the surviving rows belong to the newer ingestion and must remain",
         )
 
-    def test_virtual_parent_claims_still_pin_their_ingestion(self):
-        # Unchanged on purpose: a claim describes a live NetBox device, so its
-        # provenance must survive.
+    def test_a_virtual_parent_claim_survives_its_ingestion_without_pinning_it(self):
+        # A claim describes a live NetBox device, so the claim must survive the
+        # run being deleted. It used to achieve that by refusing the delete,
+        # which pinned the ingestion forever once the claim stopped being
+        # re-pointed. SET_NULL keeps the claim and drops only the stamp.
         from dcim.models import Device
         from dcim.models import DeviceRole
         from dcim.models import DeviceType
         from dcim.models import Manufacturer
         from dcim.models import Site
-        from django.db.models.deletion import ProtectedError
 
         from forward_netbox.models import ForwardVirtualParentClaim
 
@@ -467,10 +476,13 @@ class ReconciliationNoLongerPinsAnIngestionTest(TestCase):
 
         refusal, expected = _ingestion_delete_refusal_detail(self.newer)
 
-        self.assertIn("ForwardVirtualParentClaim", refusal)
-        self.assertFalse(expected)
-        with self.assertRaises(ProtectedError):
-            self.newer.delete()
+        self.assertNotIn("ForwardVirtualParentClaim", refusal)
+
+        self.newer.delete()
+
+        claim = ForwardVirtualParentClaim.objects.get(device=child)
+        self.assertIsNone(claim.ingestion_id)
+        self.assertEqual(claim.parent_device_id, parent.pk)
 
     def test_the_baseline_ingestion_is_still_refused_and_still_protected(self):
         # The baseline protection must not be weakened by any of this, and its
@@ -509,3 +521,130 @@ class ReconciliationNoLongerPinsAnIngestionTest(TestCase):
         with transaction.atomic():
             with self.assertRaises(ProtectedError):
                 self.newer.delete()
+
+
+class StaleProvenanceStampDoesNotPinTest(TestCase):
+    """The customer's 2700/2709: pinned by ownership evidence, not by a child.
+
+    A device that leaves Forward's scope stops being re-pointed. Its identity
+    and tag claims freeze on the last ingestion that saw them, and while that
+    stamp was PROTECT it pinned that ingestion permanently - one more
+    undeletable ingestion for every scope change.
+
+    The evidence is NOT stale. The device still exists in NetBox and is still
+    owned, which is why deleting the evidence was never the right answer: a
+    device leaves scope for entirely benign reasons, such as someone editing a
+    tag in Forward. Only the stamp is old.
+    """
+
+    def setUp(self):
+        from dcim.models import Device
+        from dcim.models import DeviceRole
+        from dcim.models import DeviceType
+        from dcim.models import Manufacturer
+        from dcim.models import Site
+
+        self.user = get_user_model().objects.create_user(username="stale-stamp")
+        source = ForwardSource.objects.create(
+            name="stale-stamp-source",
+            type="saas",
+            url="https://fwd.app",
+            parameters={
+                "username": "user@example.com",
+                "password": "secret",
+                "verify": True,
+                "network_id": "net-1",
+            },
+        )
+        self.sync = ForwardSync.objects.create(
+            name="stale-stamp-sync",
+            source=source,
+            user=self.user,
+            parameters={"snapshot_id": LATEST_PROCESSED_SNAPSHOT},
+        )
+        self.departed = ForwardIngestion.objects.create(
+            sync=self.sync,
+            snapshot_selector=LATEST_PROCESSED_SNAPSHOT,
+            snapshot_id="snapshot-old",
+        )
+        site = Site.objects.create(name="stale-site", slug="stale-site")
+        manufacturer = Manufacturer.objects.create(name="stale-mfr", slug="stale-mfr")
+        device_type = DeviceType.objects.create(
+            manufacturer=manufacturer, model="stale-model", slug="stale-model"
+        )
+        role = DeviceRole.objects.create(name="stale-role", slug="stale-role")
+        self.device = Device.objects.create(
+            name="stale-device", site=site, device_type=device_type, role=role
+        )
+
+    def test_evidence_frozen_on_an_old_ingestion_no_longer_pins_it(self):
+        from forward_netbox.models import ForwardDeviceIdentity
+
+        identity = ForwardDeviceIdentity.objects.create(
+            sync=self.sync,
+            ingestion=self.departed,
+            source_device_key="stale-device",
+            device=self.device,
+            snapshot_id="snapshot-old",
+        )
+        self.assertEqual(_ingestion_delete_refusal(self.departed), "")
+
+        self.departed.delete()
+
+        self.assertFalse(ForwardIngestion.objects.filter(pk=self.departed.pk).exists())
+        identity.refresh_from_db()
+        # The ownership survives intact; only the pointer to the deleted run is
+        # gone. Releasing it would hand a live device to whatever claims it next.
+        self.assertIsNone(identity.ingestion_id)
+        self.assertEqual(identity.sync_id, self.sync.pk)
+        self.assertEqual(identity.device_id, self.device.pk)
+        self.assertEqual(identity.source_device_key, "stale-device")
+        self.assertEqual(identity.snapshot_id, "snapshot-old")
+
+    def test_a_frozen_tag_claim_does_not_pin_its_ingestion_either(self):
+        from extras.models import Tag
+
+        from forward_netbox.models import ForwardDeviceTagClaim
+
+        tag = Tag.objects.create(name="Departed.Owner", slug="departedowner")
+        claim = ForwardDeviceTagClaim.objects.create(
+            sync=self.sync,
+            ingestion=self.departed,
+            device=self.device,
+            tag=tag,
+            claim_type="scope",
+            snapshot_id="snapshot-old",
+        )
+        self.assertEqual(_ingestion_delete_refusal(self.departed), "")
+
+        self.departed.delete()
+
+        claim.refresh_from_db()
+        self.assertIsNone(claim.ingestion_id)
+        self.assertEqual(claim.device_id, self.device.pk)
+        self.assertEqual(claim.claim_type, "scope")
+
+    def test_a_null_stamp_is_not_counted_as_a_cross_sync_mismatch(self):
+        # `exclude(ingestion__sync_id=F("sync_id"))` compiles to a LEFT OUTER
+        # JOIN guarded by `ingestion.sync_id IS NOT NULL`, so a null stamp
+        # satisfies the negation and would be counted as a stamp pointing at
+        # ANOTHER sync's ingestion. It is not that; it is an absent stamp.
+        #
+        # This would never have self-corrected: an identity for a device that
+        # left Forward's scope is never re-stamped, so the count would stay
+        # non-zero forever - failing `forward_ownership_audit
+        # --fail-on-inconsistent`, warning the ownership health check, and
+        # stopping stuck-recovery short-circuiting on a converged sync.
+        from forward_netbox.models import ForwardDeviceIdentity
+        from forward_netbox.utilities.ownership import ownership_integrity_summary
+
+        ForwardDeviceIdentity.objects.create(
+            sync=self.sync,
+            ingestion=self.departed,
+            source_device_key="stale-device",
+            device=self.device,
+            snapshot_id="snapshot-old",
+        )
+        self.departed.delete()
+
+        self.assertEqual(ownership_integrity_summary()["provenance_sync_mismatches"], 0)

--- a/forward_netbox/tests/test_ownership.py
+++ b/forward_netbox/tests/test_ownership.py
@@ -263,7 +263,13 @@ class OwnershipControlPlaneTest(TestCase):
             ).exists()
         )
 
-    def test_scope_reconciliation_rejects_split_name_and_slug_identity(self):
+    def test_an_unmanaged_slug_collision_resolves_to_the_configured_name(self):
+        # This asserted a refusal until the scope-tag resolution was fixed. An
+        # operator configures a scope tag by NAME; the slug is derived from it.
+        # Refusing whenever some other row merely held the derived slug turned a
+        # benign collision into a hard failure that left the whole ownership
+        # domain Incomplete - blocking convergence and reporting every drift
+        # figure as "Not measured".
         name_tag = Tag.objects.create(
             name="Claim Tag",
             slug="operator-legacy-claim-tag",
@@ -273,11 +279,34 @@ class OwnershipControlPlaneTest(TestCase):
             slug="claim-tag",
         )
 
-        with self.assertRaisesMessage(
-            OwnershipConflictError,
-            "Scope tag name `Claim Tag` and normalized slug `claim-tag` identify "
-            "different NetBox tags.",
-        ):
+        reconcile_sync_scope_tag_claims(
+            self.sync,
+            {self.device.name: ["Claim Tag"]},
+            generation=self.ingestion.pk,
+            snapshot_id=self.ingestion.snapshot_id,
+        )
+
+        # The named tag wins, and the unrelated row holding the derived slug is
+        # left entirely alone.
+        self.assertTrue(ForwardDeviceTagClaim.objects.filter(tag=name_tag).exists())
+        self.assertFalse(ForwardDeviceTagClaim.objects.filter(tag=slug_tag).exists())
+        self.assertFalse(ForwardManagedDeviceTag.objects.filter(tag=slug_tag).exists())
+        self.assertTrue(Tag.objects.filter(pk=slug_tag.pk).exists())
+
+    def test_scope_reconciliation_rejects_a_managed_slug_collision(self):
+        # A row this plugin already manages is the one case that stays a
+        # refusal: switching away from it would strand its claims.
+        name_tag = Tag.objects.create(
+            name="Claim Tag",
+            slug="operator-legacy-claim-tag",
+        )
+        slug_tag = Tag.objects.create(
+            name="Different Tag",
+            slug="claim-tag",
+        )
+        ForwardManagedDeviceTag.objects.create(tag=slug_tag, claim_type="scope")
+
+        with self.assertRaises(OwnershipConflictError) as caught:
             reconcile_sync_scope_tag_claims(
                 self.sync,
                 {self.device.name: ["Claim Tag"]},
@@ -285,10 +314,13 @@ class OwnershipControlPlaneTest(TestCase):
                 snapshot_id=self.ingestion.snapshot_id,
             )
 
+        message = str(caught.exception)
+        # Tag names are customer data - for one customer they are people - so
+        # the refusal reports ids.
+        self.assertIn(str(name_tag.pk), message)
+        self.assertIn(str(slug_tag.pk), message)
+        self.assertNotIn("Claim Tag", message)
         self.assertFalse(ForwardDeviceTagClaim.objects.exists())
-        self.assertFalse(ForwardManagedDeviceTag.objects.exists())
-        self.assertTrue(Tag.objects.filter(pk=name_tag.pk).exists())
-        self.assertTrue(Tag.objects.filter(pk=slug_tag.pk).exists())
 
     def test_blank_newer_baseline_does_not_supersede_current_generation(self):
         self._complete_status_reconciliation(self.sync, self.ingestion)
@@ -385,18 +417,27 @@ class OwnershipControlPlaneTest(TestCase):
             ["backfilled"],
         )
 
-    def test_ingestion_with_provenance_cannot_be_deleted(self):
+    def test_provenance_survives_its_ingestion_without_pinning_it(self):
+        # This asserted a ProtectedError until the stamp became SET_NULL. The
+        # claim describes a live NetBox device, so it must survive the run being
+        # deleted - but it used to achieve that by refusing the delete, which
+        # pinned the ingestion forever once the claim stopped being re-pointed.
+        # A customer accumulated one undeletable ingestion per scope change.
         reconcile_sync_scope_tag_claims(
             self.sync,
             {self.device.name: ["Claim Tag"]},
             generation=self.ingestion.pk,
             snapshot_id=self.ingestion.snapshot_id,
         )
+        claim = ForwardDeviceTagClaim.objects.get(device=self.device)
 
-        with self.assertRaises(ProtectedError):
-            self.ingestion.delete()
+        self.ingestion.delete()
 
-        self.assertTrue(ForwardIngestion.objects.filter(pk=self.ingestion.pk).exists())
+        self.assertFalse(ForwardIngestion.objects.filter(pk=self.ingestion.pk).exists())
+        claim.refresh_from_db()
+        self.assertIsNone(claim.ingestion_id)
+        self.assertEqual(claim.device_id, self.device.pk)
+        self.assertEqual(claim.sync_id, self.sync.pk)
 
     def test_integrity_summary_detects_cross_sync_provenance(self):
         other_source = ForwardSource.objects.create(

--- a/forward_netbox/tests/test_ownership.py
+++ b/forward_netbox/tests/test_ownership.py
@@ -662,7 +662,19 @@ class OwnershipControlPlaneTest(TestCase):
 
         self.assertTrue(self.device.tags.filter(slug="forward-out-of-scope").exists())
 
-    def test_status_reconciliation_rejects_unowned_reserved_tag(self):
+    def test_status_reconciliation_adopts_an_unowned_reserved_tag_safely(self):
+        # This asserted a refusal. The refusal was redundant with the thing that
+        # actually protects the operator here: `_materialize_managed_tag_
+        # assignments` folds preserved assignments back into `desired_ids`, so
+        # they are never removed. Adoption keeps both tags on the device.
+        #
+        # Refusing was not free. `forward-backfilled` exists in any deployment
+        # that has ever had a collection failure, so an unowned reserved tag
+        # made status reconciliation raise on EVERY run - the ownership domain
+        # never completed, convergence stayed blocked, and every drift figure
+        # read "Not measured" with nothing the operator could do about it.
+        from forward_netbox.models import ForwardPreservedDeviceTagAssignment
+
         stale_status = Tag.objects.create(
             name="Forward Out Of Scope",
             slug="forward-out-of-scope",
@@ -675,21 +687,28 @@ class OwnershipControlPlaneTest(TestCase):
         )
         self.device.tags.add(stale_status, customer_tag)
 
-        with self.assertRaises(OwnershipConflictError):
-            reconcile_source_device_tag_claims(
-                self.sync,
-                set(),
-                slug=stale_status.slug,
-                name=stale_status.name,
-                color=stale_status.color,
-                description="",
-                claim_type="out_of_scope",
-                generation=self.ingestion.pk,
-                snapshot_id=self.ingestion.snapshot_id,
-            )
+        reconcile_source_device_tag_claims(
+            self.sync,
+            set(),
+            slug=stale_status.slug,
+            name=stale_status.name,
+            color=stale_status.color,
+            description="",
+            claim_type="out_of_scope",
+            generation=self.ingestion.pk,
+            snapshot_id=self.ingestion.snapshot_id,
+        )
 
+        # The operator keeps everything they had.
         self.assertTrue(self.device.tags.filter(pk=stale_status.pk).exists())
         self.assertTrue(self.device.tags.filter(pk=customer_tag.pk).exists())
+        # And the assignment is recorded as theirs, so releasing ownership
+        # restores it rather than stranding it.
+        self.assertTrue(
+            ForwardPreservedDeviceTagAssignment.objects.filter(
+                device=self.device, tag=stale_status
+            ).exists()
+        )
 
     def test_customer_removal_clears_preserved_assignment_without_resurrection(self):
         tag = Tag.objects.create(

--- a/forward_netbox/tests/test_protecting_relations.py
+++ b/forward_netbox/tests/test_protecting_relations.py
@@ -41,18 +41,52 @@ class ProtectingRelationsSeesHiddenRelationsTest(TestCase):
         "forward_netbox.ForwardOwnershipReconciliation",
     }
 
-    def test_hidden_protect_relations_are_discovered(self):
-        # Each of these declares related_name="+", so none of them appear in
-        # _meta.related_objects. All of them still refuse the delete in the
-        # database, which is the only thing that actually matters.
+    def _hidden_relations(self):
+        return {
+            relation.related_model._meta.label: relation
+            for relation in ForwardIngestion._meta._get_fields(
+                forward=False, reverse=True, include_hidden=True
+            )
+            if getattr(relation, "related_model", None) is not None
+        }
+
+    def test_the_hidden_traversal_still_reaches_the_ownership_models(self):
+        # The three ownership models are SET_NULL now (migration 0051), so they
+        # are correctly absent from `protecting_relations`. That makes this the
+        # test standing between the hidden-relation traversal and silently
+        # returning nothing: if `include_hidden` is ever dropped, protection on
+        # a `related_name="+"` FK becomes invisible again, which is the failure
+        # that made every ingestion undeletable in 2.7.0.
+        reachable = self._hidden_relations()
+        missing = self.HIDDEN_MODELS - set(reachable)
+        self.assertFalse(
+            missing,
+            f"hidden relations no longer reachable by traversal: {sorted(missing)}",
+        )
+
+    def test_a_provenance_stamp_does_not_protect_its_ingestion(self):
+        # The stamp records which run last asserted the evidence. It was
+        # PROTECT, so a device that left Forward's scope froze its evidence on
+        # the last ingestion that saw it and pinned that ingestion forever - one
+        # undeletable ingestion per scope change, for a customer.
+        #
+        # The rows are not stale: the devices still exist and are still owned.
+        # Only the stamp is old, which is why pruning the evidence was never the
+        # right fix.
+        reachable = self._hidden_relations()
+        for label in self.OWNERSHIP_MODELS:
+            with self.subTest(model=label):
+                self.assertIs(
+                    reachable[label].field.remote_field.on_delete,
+                    models.SET_NULL,
+                )
         found = {
             relation.related_model._meta.label
             for relation in protecting_relations(ForwardIngestion)
         }
-        self.assertTrue(
-            self.OWNERSHIP_MODELS.issubset(found),
-            f"hidden PROTECT relations missing from discovery: "
-            f"{sorted(self.OWNERSHIP_MODELS - found)}",
+        self.assertFalse(
+            self.OWNERSHIP_MODELS & found,
+            "ownership evidence is reported as protecting its ingestion again",
         )
 
     def test_the_baseline_is_not_reported_as_protecting(self):
@@ -60,22 +94,16 @@ class ProtectingRelationsSeesHiddenRelationsTest(TestCase):
         # cascades so a superseded generation can be collected with its
         # ingestion. Reporting it would refuse a delete the database allows.
         #
-        # Which means every remaining protection is hidden behind
-        # related_name="+", so `test_hidden_protect_relations_are_discovered` is
-        # now the only thing standing between discovery and finding nothing at
-        # all. Losing the widening would no longer under-report — it would
-        # report an ingestion as freely deletable while the database refused it,
-        # which is the failure that made every ingestion undeletable in 2.7.0.
+        # With the ownership stamps now SET_NULL, an ingestion may legitimately
+        # have no protecting relation at all - what refuses a delete is the
+        # `pre_delete` receiver guarding the live baseline and a running job.
+        # `test_the_hidden_traversal_still_reaches_the_ownership_models` is what
+        # now stands between discovery and silently seeing nothing.
         found = {
             relation.related_model._meta.label
             for relation in protecting_relations(ForwardIngestion)
         }
         self.assertNotIn("forward_netbox.ForwardContributorBaseline", found)
-        self.assertTrue(
-            found,
-            "no protecting relation is discovered at all; the hidden-relation "
-            "traversal has been lost",
-        )
 
     def test_cascading_relations_are_not_reported_as_protecting(self):
         # Over-reporting would refuse deletes that the database would allow.

--- a/forward_netbox/tests/test_reserved_status_tag_adoption.py
+++ b/forward_netbox/tests/test_reserved_status_tag_adoption.py
@@ -1,0 +1,105 @@
+# `forward-backfilled` exists in any deployment that has ever had a collection
+# failure. If its `ForwardManagedDeviceTag` row is absent - an operator made the
+# tag by hand, it predates the managed-tag registry, or the row was cleaned up
+# while the tag survived - status-tag reconciliation used to raise
+# OwnershipConflictError on EVERY run.
+#
+# Nothing cleared that. The ownership domain never completed, so convergence
+# stayed blocked and every drift figure read "Not measured", run after run. A
+# customer sat in exactly that state.
+#
+# The override that was supposed to permit adoption was passed `tag_created`,
+# true only when the plugin had just created the tag - precisely when there is
+# nothing to adopt. So it could never fire when it was needed.
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import Manufacturer
+from dcim.models import Site
+from django.test import TestCase
+from extras.models import Tag
+
+from forward_netbox.models import ForwardManagedDeviceTag
+from forward_netbox.models import ForwardPreservedDeviceTagAssignment
+from forward_netbox.utilities.ownership import _ensure_managed_tag
+
+
+class ReservedStatusTagAdoptionTest(TestCase):
+    def setUp(self):
+        site = Site.objects.create(name="adopt-site", slug="adopt-site")
+        manufacturer = Manufacturer.objects.create(name="adopt-mfr", slug="adopt-mfr")
+        device_type = DeviceType.objects.create(
+            manufacturer=manufacturer, model="adopt-model", slug="adopt-model"
+        )
+        role = DeviceRole.objects.create(name="adopt-role", slug="adopt-role")
+        self.plugin_device = Device.objects.create(
+            name="adopt-plugin", site=site, device_type=device_type, role=role
+        )
+        self.operator_device = Device.objects.create(
+            name="adopt-operator", site=site, device_type=device_type, role=role
+        )
+
+    def test_a_preexisting_reserved_tag_is_adopted_not_refused(self):
+        tag = Tag.objects.create(name="Forward Backfilled", slug="forward-backfilled")
+
+        managed = _ensure_managed_tag(
+            tag,
+            "backfilled",
+            plugin_assignment_ids={self.plugin_device.pk},
+        )
+
+        self.assertEqual(managed.tag_id, tag.pk)
+        self.assertEqual(managed.claim_type, "backfilled")
+
+    def test_adoption_preserves_what_the_operator_had_tagged(self):
+        # Refusing was never protecting these; the preservation path is what
+        # protects them, and the refusal ran before it could.
+        tag = Tag.objects.create(name="Forward Backfilled", slug="forward-backfilled")
+        self.operator_device.tags.add(tag)
+
+        _ensure_managed_tag(
+            tag,
+            "backfilled",
+            plugin_assignment_ids={self.plugin_device.pk},
+        )
+
+        self.assertTrue(
+            ForwardPreservedDeviceTagAssignment.objects.filter(
+                device=self.operator_device, tag=tag
+            ).exists()
+        )
+
+    def test_the_plugins_own_assignments_are_not_recorded_as_preserved(self):
+        tag = Tag.objects.create(name="Forward Backfilled", slug="forward-backfilled")
+        self.plugin_device.tags.add(tag)
+
+        _ensure_managed_tag(
+            tag,
+            "backfilled",
+            plugin_assignment_ids={self.plugin_device.pk},
+        )
+
+        self.assertFalse(
+            ForwardPreservedDeviceTagAssignment.objects.filter(
+                device=self.plugin_device
+            ).exists()
+        )
+
+    def test_adoption_is_idempotent_across_runs(self):
+        # The failure repeated every run, so the fix has to hold every run.
+        tag = Tag.objects.create(name="Forward Backfilled", slug="forward-backfilled")
+        for _ in range(3):
+            _ensure_managed_tag(
+                tag, "backfilled", plugin_assignment_ids={self.plugin_device.pk}
+            )
+        self.assertEqual(ForwardManagedDeviceTag.objects.filter(tag=tag).count(), 1)
+
+    def test_a_tag_claimed_by_another_claim_type_still_refuses(self):
+        # The genuine conflict is unchanged: one tag cannot be two claim types.
+        tag = Tag.objects.create(name="Forward Backfilled", slug="forward-backfilled")
+        ForwardManagedDeviceTag.objects.create(tag=tag, claim_type="scope")
+
+        from forward_netbox.utilities.ownership import OwnershipConflictError
+
+        with self.assertRaises(OwnershipConflictError):
+            _ensure_managed_tag(tag, "backfilled")

--- a/forward_netbox/utilities/bulk_merge.py
+++ b/forward_netbox/utilities/bulk_merge.py
@@ -1415,14 +1415,14 @@ def protecting_relations(model_class):
 
     `_meta.related_objects` omits relations declared with ``related_name="+"``,
     and Django calls those hidden. Reading protection from it therefore misses
-    exactly the relations this plugin uses for ownership evidence:
-    `ForwardIngestionProvenanceMixin` declares its ingestion FK as PROTECT with
+    exactly the relations this plugin uses for ownership evidence.
+    `ForwardIngestionProvenanceMixin` declares its ingestion FK with
     ``related_name="+"``, so `ForwardDeviceIdentity`, `ForwardDeviceTagClaim`
-    and `ForwardVirtualParentClaim` were all invisible to protection checks
-    while still refusing the delete in the database. (The fourth,
-    `ForwardOwnershipReconciliation`, later became CASCADE - it is a child
-    record of the ingestion, not evidence held against it - so discovery still
-    sees it and correctly declines to report it.)
+    and `ForwardVirtualParentClaim` were invisible to protection checks while -
+    at the time - still refusing the delete in the database. (The fourth,
+    `ForwardOwnershipReconciliation`, cascades: it is a child record of the
+    ingestion, not evidence held against it, so discovery sees it and correctly
+    declines to report it.)
 
     That gap had two customer-visible faces. An ingestion held only by device
     identities reported no refusal at all, so the delete view rendered its wall
@@ -1430,6 +1430,13 @@ def protecting_relations(model_class):
     ingestion, since each owns one identity per synced device. And a merge
     delete blocked by one of these was never predicted, so it was scheduled and
     failed at apply time, and a failed row blocks baseline promotion.
+
+    Those three FKs are SET_NULL now (migration 0051), because the stamp they
+    carry is provenance rather than a dependency, so they no longer appear here
+    at all. The hidden-relation handling stays regardless: it is a property of
+    how this function reads the schema, not of which fields happen to be
+    PROTECT today, and any future ``related_name="+"`` protection would hit the
+    same blind spot.
 
     Ask for hidden relations explicitly so protection is read from the database
     truth rather than from what happens to have a reverse accessor.

--- a/forward_netbox/utilities/ownership.py
+++ b/forward_netbox/utilities/ownership.py
@@ -12,7 +12,6 @@ from django.db.models.deletion import ProtectedError
 from django.utils import timezone
 
 from .tag_contracts import candidate_managed_tag_slugs
-from .tag_contracts import RESERVED_STATUS_TAG_SLUGS
 from .tag_contracts import validate_scope_tag_names
 
 
@@ -503,7 +502,6 @@ def _ensure_managed_tag(
     tag,
     claim_type,
     *,
-    allow_reserved_adoption=False,
     plugin_assignment_ids=(),
 ):
     from ..models import ForwardManagedDeviceTag
@@ -521,15 +519,28 @@ def _ensure_managed_tag(
             f"Tag slug `{tag.slug}` is already controlled as "
             f"`{conflicting.claim_type}` and cannot also be `{claim_type}`."
         )
-    if (
-        claim_type in {"backfilled", "out_of_scope"}
-        and tag.slug in RESERVED_STATUS_TAG_SLUGS
-        and not allow_reserved_adoption
-    ):
-        raise OwnershipConflictError(
-            f"Tag slug `{tag.slug}` is reserved for Forward status ownership but "
-            "already exists without plugin provenance."
-        )
+    # A reserved status slug that already exists is ADOPTED, not refused.
+    #
+    # This used to raise unless `allow_reserved_adoption` was set, and the only
+    # caller sets it from `tag_created` - true only when the plugin had just
+    # created the tag, which is precisely when there is nothing to adopt. So
+    # whenever adoption was actually needed the override could not fire, and the
+    # refusal was unconditional.
+    #
+    # The cost was total and permanent. `forward-backfilled` exists in any
+    # deployment that has ever had a collection failure, and if its
+    # `ForwardManagedDeviceTag` row is absent - an operator created the tag by
+    # hand, it predates the managed-tag registry, or the row was cleaned up
+    # while the tag survived - then STATUS_TAGS reconciliation raised on every
+    # run, for ever. The ownership domain never completed, so convergence stayed
+    # blocked and every drift figure read "Not measured". Nothing the operator
+    # could do cleared it short of deleting the tag.
+    #
+    # Refusing was never protecting anything either: the two statements below
+    # already record every pre-existing assignment in
+    # `ForwardPreservedDeviceTagAssignment`, which is exactly the machinery for
+    # taking over a tag without destroying what an operator put on it, and it is
+    # restored when ownership is released.
     preserved_ids = _tag_assignment_device_ids(tag) - set(plugin_assignment_ids)
     managed = ForwardManagedDeviceTag.objects.create(
         tag=tag,
@@ -804,7 +815,6 @@ def reconcile_source_device_tag_claims(
     desired_ids = set(identities.values())
     with ownership_write_lock():
         tag = Tag.objects.filter(slug=slug).first()
-        tag_created = False
         if tag is None and desired_ids:
             tag = Tag.objects.create(
                 slug=slug,
@@ -812,7 +822,6 @@ def reconcile_source_device_tag_claims(
                 color=color,
                 description=description,
             )
-            tag_created = True
         if tag is None:
             finalized = {
                 "assignments_added": 0,
@@ -838,7 +847,6 @@ def reconcile_source_device_tag_claims(
         _ensure_managed_tag(
             tag,
             claim_type,
-            allow_reserved_adoption=tag_created,
             plugin_assignment_ids=desired_ids,
         )
         current_ids = set(

--- a/forward_netbox/utilities/ownership.py
+++ b/forward_netbox/utilities/ownership.py
@@ -1538,8 +1538,20 @@ def ownership_finalization_summary(sync, *, generation=None):
         .exclude(ingestion_id=generation)
         .count()
     )
+    # `ingestion__isnull=False` first, deliberately. This counts a stamp that
+    # points at ANOTHER sync's ingestion; an absent stamp is not that. Django
+    # compiles the negated join as a LEFT OUTER JOIN guarded by
+    # `ingestion.sync_id IS NOT NULL`, so a null stamp satisfies the negation
+    # and would be counted as a cross-sync violation. Since a nulled stamp is
+    # never re-stamped for a device that left Forward's scope, that count would
+    # be permanently non-zero - failing `forward_ownership_audit
+    # --fail-on-inconsistent`, warning the ownership health check, and stopping
+    # stuck-recovery short-circuiting on a converged sync, forever.
     provenance_sync_mismatches = sum(
-        model.objects.filter(sync=sync).exclude(ingestion__sync_id=F("sync_id")).count()
+        model.objects.filter(sync=sync)
+        .filter(ingestion__isnull=False)
+        .exclude(ingestion__sync_id=F("sync_id"))
+        .count()
         for model in (
             ForwardDeviceIdentity,
             ForwardDeviceTagClaim,
@@ -1669,8 +1681,19 @@ def ownership_integrity_summary():
     from ..models import ForwardSync
     from ..models import ForwardVirtualParentClaim
 
+    # `ingestion__isnull=False` first, deliberately. This counts a stamp that
+    # points at ANOTHER sync's ingestion; an absent stamp is not that. Django
+    # compiles the negated join as a LEFT OUTER JOIN guarded by
+    # `ingestion.sync_id IS NOT NULL`, so a null stamp satisfies the negation
+    # and would be counted as a cross-sync violation. Since a nulled stamp is
+    # never re-stamped for a device that left Forward's scope, that count would
+    # be permanently non-zero - failing `forward_ownership_audit
+    # --fail-on-inconsistent`, warning the ownership health check, and stopping
+    # stuck-recovery short-circuiting on a converged sync, forever.
     provenance_sync_mismatches = sum(
-        model.objects.exclude(ingestion__sync_id=F("sync_id")).count()
+        model.objects.filter(ingestion__isnull=False)
+        .exclude(ingestion__sync_id=F("sync_id"))
+        .count()
         for model in (
             ForwardDeviceIdentity,
             ForwardDeviceTagClaim,


### PR DESCRIPTION
Two customer-blocking defects in the ownership control plane, both permanent and neither self-healing.

## The ownership domain never completed

`_ensure_managed_tag` refused to adopt a tag whose slug is reserved for Forward status ownership (`forward-backfilled`, `forward-out-of-scope`) unless `allow_reserved_adoption` was set. The sole caller passed it **`tag_created`** — true only when the plugin had just created the tag, i.e. exactly when there is nothing to adopt. The override could never fire when it was needed, so the refusal was unconditional. Same defect shape as #43.

`forward-backfilled` exists in any deployment that has ever had a collection failure. If its `ForwardManagedDeviceTag` row is absent — an operator made the tag by hand, it predates the managed-tag registry, or the row was cleaned up while the tag survived — status-tag reconciliation raised on **every run, forever**: ownership never completed, convergence stayed blocked, every drift figure read "Not measured", and nothing the operator could do cleared it short of deleting the tag.

Refusing was never what protected them. `_materialize_managed_tag_assignments` folds preserved assignments back into `desired_ids` (ownership.py:622), so an assignment the plugin did not make is never removed — and adoption records every pre-existing assignment as preserved before that runs. Verified empirically: after adoption both the reserved tag **and** the operator's own unrelated tag remain on the device, and releasing ownership restores the assignment.

An existing test asserted the refusal kept the operator's tag. I checked what it protected rather than overwriting it — the tag survives adoption, so it now asserts that outcome instead of a mechanism that was not providing it.

## Old ingestions could never be deleted

`ForwardDeviceIdentity`, `ForwardDeviceTagClaim` and `ForwardVirtualParentClaim` each carry an `ingestion` FK recording which run last asserted the evidence. It was PROTECT, so the stamp pinned the run.

Evidence is only re-pointed for what the current run sees. A device that leaves Forward's scope, or a tag removed from the include list, is never visited again — so its evidence freezes on the last ingestion that saw it and pins that ingestion permanently. One undeletable ingestion per scope change; a customer reported three at once.

Those rows are **not stale** — the devices still exist and are still owned. Only the stamp is old. That is why pruning them was never right: it would release ownership of live devices that are merely out of scope, and devices leave scope for benign reasons. SET_NULL keeps the ownership and drops only the pointer to a deleted run; sync, device, source key and `snapshot_id` are untouched.

One consequence needed guarding, found by checking the compiled SQL rather than reasoning from the Python: `exclude(ingestion__sync_id=F("sync_id"))` becomes a LEFT OUTER JOIN guarded by `ingestion.sync_id IS NOT NULL`, so a null stamp satisfies the negation and would be counted as a stamp pointing at *another sync's* ingestion. Since a nulled stamp is never re-stamped, that count would have been permanently non-zero — failing `forward_ownership_audit --fail-on-inconsistent`, warning the ownership health check, and stopping stuck-recovery short-circuiting on a converged sync. Both counters now require a stamp before comparing it.

## Also fixed

`test_ownership.test_scope_reconciliation_rejects_split_name_and_slug_identity` had been **red on main** since #153 — it still asserted the refusal that the scope-tag resolution fix deliberately removed. I had only re-run the suites I judged adjacent after rebasing that PR.

## Verification

- `invoke test-isolated` — full plugin suite, **1998 tests, OK** (4 skipped)
- `invoke makemigrations` — no model drift
- Every new regression test confirmed to **fail without its fix** before being accepted
- `check_harness.py` and pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5Ax5f23uwWLmjGMtQq39p