### PR TITLE
fix: say which way a skipped row's dependency points

### DIFF
--- a/docs/03_Plans/active/2026-08-08-skip-dependency-direction.md
+++ b/docs/03_Plans/active/2026-08-08-skip-dependency-direction.md
@@ -1,0 +1,58 @@
+# Say which way a skipped row's dependency points
+
+## Goal
+
+Stop two opposite conditions reading identically in the ingestion issue list.
+
+## Contract
+
+- Only schema identifiers are persisted. The direction is a property of the
+  raiser, not of any customer value.
+- A raiser that names no dependency records exactly what it did before.
+
+## Constraints
+
+- The delete path is the inverse of every other skip, and the raiser already
+  says so in a comment - the wording just never reached the persisted row.
+- `diagnostic_shape` keeps dict KEYS and drops VALUES, which is why the
+  dependency travels as an exception attribute rather than in `context`.
+
+## Touched Surfaces
+
+- `forward_netbox/exceptions.py`, `forward_netbox/utilities/sync_primitives.py`,
+  `forward_netbox/utilities/sync_reporting.py`
+- `forward_netbox/tests/test_skip_dependency_direction.py`
+
+## Approach
+
+Carry `dependency_is_protecting` on the exception, set it at the one delete-path
+raiser, and phrase the detail as "waiting on X" or "still referenced by X".
+Extract `dependency_phrase` so the choice is unit-testable rather than buried in
+a long `elif` chain.
+
+## Validation
+
+- `invoke test-isolated` - full plugin suite, 2002 tests, OK (4 skipped)
+- `invoke test-isolated --test-label=...test_skip_dependency_direction` - 4 OK
+
+## Rollback
+
+Revert. Both directions return to naming the model with no relationship.
+
+## Decision Log
+
+- **Found from a customer's real rows, not from reading code.** Their ingestion
+  recorded `netbox_dlm.softwareversion row processing skipped (...;
+  netbox_dlm.inventoryitemsoftware)`. As a missing parent that is backwards -
+  `inventoryitemsoftware` depends on `softwareversion` - which is what made the
+  inversion visible. The rows were a prune correctly refused, but nothing in
+  the message said so.
+- **Extracted a helper rather than testing through `record_issue`.** The
+  composition sits in a long `elif` chain needing database state to reach; the
+  phrasing choice is the whole behaviour and deserves a direct test.
+
+## Open
+
+- Roughly two dozen raisers still name no dependency at all and record only the
+  exception class. The vocabulary exists in `record_aggregated_skip_warning`
+  and never reaches the database. Unchanged here.

--- a/forward_netbox/exceptions.py
+++ b/forward_netbox/exceptions.py
@@ -71,6 +71,7 @@ class ForwardDataError(ForwardSyncError):
         data: dict | None = None,
         issue_id: int | None = None,
         dependency: str | None = None,
+        dependency_is_protecting: bool = False,
     ):
         super().__init__(message)
         self.model_string = model_string
@@ -85,6 +86,15 @@ class ForwardDataError(ForwardSyncError):
         # row records only the exception class, and a customer reading six
         # identical rows has no way to learn which parent was missing.
         self.dependency = dependency or ""
+        # Which DIRECTION the dependency points. Almost every skip is waiting on
+        # something absent, but the delete path is the inverse: the row is still
+        # REFERENCED and the database refuses to prune it. Both used to persist
+        # the same "row processing skipped (...; app.model)" shape, so the two
+        # opposite conditions read identically - a customer's DLM skips named
+        # `netbox_dlm.inventoryitemsoftware` as the dependency of
+        # `netbox_dlm.softwareversion`, which is backwards for a missing parent
+        # and exactly right for a surviving child.
+        self.dependency_is_protecting = bool(dependency_is_protecting)
 
 
 class ForwardSearchError(ForwardDataError):

--- a/forward_netbox/tests/test_skip_dependency_direction.py
+++ b/forward_netbox/tests/test_skip_dependency_direction.py
@@ -1,0 +1,64 @@
+# Almost every dependency skip is waiting on something ABSENT. The delete path
+# is the inverse: the row is still REFERENCED and the database refuses to prune
+# it. Both used to persist the same shape, so the two opposite conditions read
+# identically.
+#
+# A customer's ingestion showed `netbox_dlm.softwareversion row processing
+# skipped (ForwardDependencySkipError; netbox_dlm.inventoryitemsoftware)`. Read
+# as a missing parent that is backwards - `inventoryitemsoftware` depends on
+# `softwareversion`, not the reverse. It was a surviving child refusing the
+# prune, which is the opposite situation and needs the opposite response.
+from django.test import TestCase
+
+from forward_netbox.exceptions import ForwardDependencySkipError
+from forward_netbox.utilities.sync_reporting import dependency_phrase
+
+
+class SkipDependencyDirectionTest(TestCase):
+    def test_a_missing_parent_reads_as_waiting(self):
+        detail = dependency_phrase(
+            ForwardDependencySkipError(
+                "Skipping DLM inventory item software.",
+                model_string="netbox_dlm.inventoryitemsoftware",
+                dependency="dcim.inventoryitem",
+            )
+        )
+        self.assertIn("waiting on dcim.inventoryitem", detail)
+        self.assertNotIn("still referenced by", detail)
+
+    def test_a_surviving_child_reads_as_still_referenced(self):
+        # The customer's exact shape.
+        detail = dependency_phrase(
+            ForwardDependencySkipError(
+                "Skipping delete for `netbox_dlm.softwareversion`.",
+                model_string="netbox_dlm.softwareversion",
+                dependency="netbox_dlm.inventoryitemsoftware",
+                dependency_is_protecting=True,
+            )
+        )
+        self.assertIn(
+            "still referenced by netbox_dlm.inventoryitemsoftware", detail
+        )
+        self.assertNotIn("waiting on", detail)
+
+    def test_the_two_directions_never_produce_the_same_text(self):
+        # The whole defect was that they did.
+        shared = {
+            "model_string": "netbox_dlm.softwareversion",
+            "dependency": "netbox_dlm.devicesoftware",
+        }
+        waiting = dependency_phrase(
+            ForwardDependencySkipError("m", **shared)
+        )
+        referenced = dependency_phrase(
+            ForwardDependencySkipError("m", **shared, dependency_is_protecting=True)
+        )
+        self.assertNotEqual(waiting, referenced)
+
+    def test_a_raiser_that_names_no_dependency_is_unchanged(self):
+        # Most raisers have not been taught to name one; they must not regress.
+        detail = dependency_phrase(
+            ForwardDependencySkipError("m", model_string="dcim.device")
+        )
+        self.assertNotIn("waiting on", detail)
+        self.assertNotIn("still referenced by", detail)

--- a/forward_netbox/utilities/sync_primitives.py
+++ b/forward_netbox/utilities/sync_primitives.py
@@ -494,6 +494,7 @@ def delete_by_coalesce(runner, model, lookups):
                     f"Skipping delete for `{model._meta.label_lower}` due to protected dependencies: {exc}",
                     model_string=model._meta.label_lower,
                     dependency=_protecting_model_labels(exc),
+                    dependency_is_protecting=True,
                     context=lookup,
                 ) from exc
             forget_lookup_object(runner, obj)

--- a/forward_netbox/utilities/sync_reporting.py
+++ b/forward_netbox/utilities/sync_reporting.py
@@ -285,6 +285,25 @@ def _emit_progress_heartbeat(
     return last_emit_at
 
 
+def dependency_phrase(exception) -> str:
+    """How a skip's dependency reads, in the direction it actually points.
+
+    Naming the model alone made two opposite conditions identical. A customer's
+    rows recorded `netbox_dlm.softwareversion row processing skipped (...;
+    netbox_dlm.inventoryitemsoftware)`, which reads as a missing parent but
+    means a surviving child refusing the prune - `inventoryitemsoftware`
+    depends on `softwareversion`, not the reverse. "Nothing to build on" and
+    "something still needs this" call for opposite responses, so they must not
+    share a sentence.
+    """
+    dependency = str(getattr(exception, "dependency", "") or "")
+    if not dependency:
+        return ""
+    if getattr(exception, "dependency_is_protecting", False):
+        return f"still referenced by {dependency}"
+    return f"waiting on {dependency}"
+
+
 def record_issue(
     runner,
     model_string,
@@ -375,10 +394,18 @@ def record_issue(
     # a customer nothing about which parent was missing; a raiser that has not
     # been taught to name one still records exactly what it did before.
     dependency = str(getattr(exception, "dependency", "") or "")
+    # Say which way the dependency points. Naming the model alone made two
+    # opposite conditions read identically: a customer's DLM rows recorded
+    # `netbox_dlm.softwareversion row processing skipped (...;
+    # netbox_dlm.inventoryitemsoftware)`, which reads as a missing parent but
+    # means a surviving child refusing the prune - `inventoryitemsoftware`
+    # depends on `softwareversion`, not the reverse. The reader has no way to
+    # tell "nothing to build on" from "something still needs this".
+    dependency_detail = dependency_phrase(exception)
     if is_dependency_skip_summary:
         detail = ""
     elif dependency:
-        detail = f"{named}; {dependency}"
+        detail = f"{named}; {dependency_detail}"
     elif constraint:
         detail = f"{named}; constraint {constraint}"
     elif rules:


### PR DESCRIPTION
Two opposite conditions read identically in the ingestion issue list.

Almost every dependency skip is waiting on something **absent**. The delete path is the inverse: the row is still **referenced** and the database refuses to prune it. Both persisted the same `row processing skipped (...; app.model)` shape.

Found from a customer's real rows, not from reading code. Their ingestion showed:

```
netbox_dlm.softwareversion row processing skipped
  (ForwardDependencySkipError; netbox_dlm.inventoryitemsoftware)
```

As a missing parent that is backwards — `inventoryitemsoftware` depends on `softwareversion`, not the reverse. Those rows were a prune **correctly refused** by surviving children. Nothing in the message said so, and the two situations call for opposite responses.

The raiser already knew: its comment reads *"this skip is the inverse of every other one"*. That fact just never reached the row an operator reads.

Now:
- `waiting on dcim.inventoryitem` — nothing to build on
- `still referenced by netbox_dlm.inventoryitemsoftware` — something still needs this

`dependency_phrase` is extracted so the choice is unit-tested directly rather than buried in a long `elif` chain that needs database state to reach. A raiser that names no dependency records exactly what it did before.

**Verification:** full plugin suite **2002 tests OK** (4 skipped), 4 new direction tests, pre-commit and harness clean.

Still open: roughly two dozen raisers name no dependency at all — the vocabulary exists in `record_aggregated_skip_warning` and never reaches the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5Ax5f23uwWLmjGMtQq39p