### PR TITLE
fix: make the force-allow override reachable on the sync path

### DIFF
--- a/docs/03_Plans/active/2026-08-08-force-allow-override.md
+++ b/docs/03_Plans/active/2026-08-08-force-allow-override.md
@@ -1,0 +1,60 @@
+# Make the force-allow override reachable on the sync path
+
+## Goal
+
+An operator who force-allows a blocked run should not be blocked by the same
+reason on the next run.
+
+## Contract
+
+- The override is still scoped: same policy, same snapshot selector, same
+  snapshot. Widening it is not the fix.
+- A run that was not force-allowed carries nothing forward.
+
+## Constraints
+
+- `record_plan_validation` CREATES the new `ForwardValidationRun` before
+  blocking reasons are evaluated, so anything reading
+  `sync.latest_validation_run` at that point sees the run being recorded, whose
+  `override_applied` is always False.
+- The old coverage called `_blocking_reasons` directly with no current run.
+  That path still worked, so the suite passed straight over the dead branch -
+  which is why the test here must go through `record_plan_validation`.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/validation.py`
+- `forward_netbox/tests/test_force_allow_override.py`
+
+## Approach
+
+Resolve the override against the most recent force-allowed run EXCLUDING the one
+being recorded, via `_previous_override_run`. This is the same exclusion
+`_row_shrink_already_accepted` already had to write for itself, applied where it
+belonged.
+
+## Validation
+
+- `invoke test-isolated` - full plugin suite, 2007 tests, OK (4 skipped)
+- The carry-forward test was confirmed to FAIL against the previous behaviour
+  before being accepted; the four negative cases pass either way, as they should
+
+## Rollback
+
+Revert. The override returns to being unreachable on the sync path.
+
+## Decision Log
+
+- **Fixed the helper rather than adding a second workaround.** The row-count
+  floor already worked around this with its own previous-run lookup and said so
+  in a docstring. A second copy would have been the third place this logic
+  lived.
+- **Tested through `record_plan_validation`.** The defect only exists because a
+  run is created first; a test that does not create one cannot see it. That is
+  precisely how it hid.
+
+## Open
+
+- `_row_shrink_already_accepted` still keeps its own lookup. It is scoped to the
+  baseline rather than the snapshot, deliberately, so it is not simply the same
+  query - collapsing them needs its own change.

--- a/forward_netbox/tests/test_force_allow_override.py
+++ b/forward_netbox/tests/test_force_allow_override.py
@@ -1,0 +1,135 @@
+"""An operator's force-allow must carry forward to the next run.
+
+`_forced_validation_override_applies` read `sync.latest_validation_run`, and on
+the sync path `record_plan_validation` CREATES the new run before blocking
+reasons are evaluated. So the lookup returned the run being recorded, whose
+`override_applied` is always False, and the override could never fire on the
+only path that matters: an operator force-allowed a blocked run, and the same
+reason blocked the next one with nothing to say why.
+
+The old coverage called `_blocking_reasons` directly with no current run, which
+exercises the branch that still worked and passes straight over the dead one.
+These tests go through `record_plan_validation`, so the run exists before the
+decision is made - which is the whole condition of the defect.
+"""
+
+from unittest.mock import Mock
+
+from django.test import TestCase
+
+from forward_netbox.choices import ForwardValidationStatusChoices
+from forward_netbox.models import ForwardDriftPolicy
+from forward_netbox.models import ForwardSource
+from forward_netbox.models import ForwardSync
+from forward_netbox.models import ForwardValidationRun
+from forward_netbox.utilities.forward_api import LATEST_PROCESSED_SNAPSHOT
+from forward_netbox.utilities.validation import ForwardValidationRunner
+
+SNAPSHOT = "snapshot-blocked"
+
+
+class ForceAllowOverrideCarriesForwardTest(TestCase):
+    def setUp(self):
+        self.source = ForwardSource.objects.create(
+            name="override-source",
+            type="saas",
+            url="https://fwd.app",
+            parameters={
+                "username": "user@example.com",
+                "password": "secret",
+                "verify": True,
+                "network_id": "test-network",
+            },
+        )
+        self.policy = ForwardDriftPolicy.objects.create(
+            name="override-policy",
+            enabled=True,
+            require_processed_snapshot=True,
+        )
+        self.sync = ForwardSync.objects.create(
+            name="override-sync",
+            source=self.source,
+            drift_policy=self.policy,
+            parameters={"snapshot_id": LATEST_PROCESSED_SNAPSHOT},
+        )
+
+    def context(self):
+        # An unprocessed snapshot: a blocking reason that is stable across runs,
+        # so the only thing that can change the verdict is the override.
+        return {
+            "snapshot_selector": LATEST_PROCESSED_SNAPSHOT,
+            "snapshot_id": SNAPSHOT,
+            "snapshot_info": {"state": "UNPROCESSED"},
+            "snapshot_metrics": {},
+        }
+
+    def runner(self):
+        return ForwardValidationRunner(sync=self.sync, client=None, logger_=Mock())
+
+    def force_allowed_previous_run(self, **overrides):
+        values = {
+            "sync": self.sync,
+            "policy": self.policy,
+            "snapshot_selector": LATEST_PROCESSED_SNAPSHOT,
+            "snapshot_id": SNAPSHOT,
+            "override_applied": True,
+            "override_blocking_reasons": ["Target snapshot is not processed."],
+            "status": ForwardValidationStatusChoices.PASSED,
+        }
+        values.update(overrides)
+        return ForwardValidationRun.objects.create(**values)
+
+    def record(self):
+        return self.runner().record_plan_validation(
+            self.context(),
+            plan=[],
+            model_results=[],
+            raise_on_block=False,
+        )
+
+    def test_without_an_override_the_run_is_blocked(self):
+        # Establishes that the reason really does block, so the next test is
+        # measuring the override rather than an absent reason.
+        self.record()
+        run = self.sync.validation_runs.order_by("-pk").first()
+        self.assertTrue(run.blocking_reasons)
+
+    def test_a_previous_force_allow_carries_forward_through_the_sync_path(self):
+        self.force_allowed_previous_run()
+
+        self.record()
+
+        run = self.sync.validation_runs.order_by("-pk").first()
+        self.assertEqual(
+            run.blocking_reasons or [],
+            [],
+            "the operator's force-allow did not carry forward; the override "
+            "resolved against the run being recorded again",
+        )
+
+    def test_an_override_for_a_different_snapshot_does_not_carry_forward(self):
+        self.force_allowed_previous_run(snapshot_id="some-other-snapshot")
+
+        self.record()
+
+        run = self.sync.validation_runs.order_by("-pk").first()
+        self.assertTrue(run.blocking_reasons)
+
+    def test_an_override_for_a_different_policy_does_not_carry_forward(self):
+        other = ForwardDriftPolicy.objects.create(name="other-policy", enabled=True)
+        self.force_allowed_previous_run(policy=other)
+
+        self.record()
+
+        run = self.sync.validation_runs.order_by("-pk").first()
+        self.assertTrue(run.blocking_reasons)
+
+    def test_a_previous_run_that_was_not_force_allowed_does_not_carry_forward(self):
+        self.force_allowed_previous_run(
+            override_applied=False, override_blocking_reasons=[]
+        )
+
+        self.record()
+
+        run = self.sync.validation_runs.order_by("-pk").first()
+        self.assertTrue(run.blocking_reasons)

--- a/forward_netbox/tests/test_skip_dependency_direction.py
+++ b/forward_netbox/tests/test_skip_dependency_direction.py
@@ -36,9 +36,7 @@ class SkipDependencyDirectionTest(TestCase):
                 dependency_is_protecting=True,
             )
         )
-        self.assertIn(
-            "still referenced by netbox_dlm.inventoryitemsoftware", detail
-        )
+        self.assertIn("still referenced by netbox_dlm.inventoryitemsoftware", detail)
         self.assertNotIn("waiting on", detail)
 
     def test_the_two_directions_never_produce_the_same_text(self):
@@ -47,9 +45,7 @@ class SkipDependencyDirectionTest(TestCase):
             "model_string": "netbox_dlm.softwareversion",
             "dependency": "netbox_dlm.devicesoftware",
         }
-        waiting = dependency_phrase(
-            ForwardDependencySkipError("m", **shared)
-        )
+        waiting = dependency_phrase(ForwardDependencySkipError("m", **shared))
         referenced = dependency_phrase(
             ForwardDependencySkipError("m", **shared, dependency_is_protecting=True)
         )

--- a/forward_netbox/utilities/validation.py
+++ b/forward_netbox/utilities/validation.py
@@ -279,7 +279,9 @@ class ForwardValidationRunner:
         *,
         validation_run=None,
     ):
-        if self._forced_validation_override_applies(context, policy):
+        if self._forced_validation_override_applies(
+            context, policy, validation_run=validation_run
+        ):
             return []
 
         reasons = []
@@ -490,19 +492,43 @@ class ForwardValidationRunner:
         configured = str(parameters.get("diff_fallback_mode") or "").strip()
         return configured == ForwardDiffFallbackModeChoices.REQUIRE_DIFF
 
-    def _forced_validation_override_applies(self, context, policy):
-        latest_validation_run = getattr(self.sync, "latest_validation_run", None)
-        if latest_validation_run is None or not getattr(
-            latest_validation_run, "override_applied", False
-        ):
+    def _forced_validation_override_applies(
+        self, context, policy, *, validation_run=None
+    ):
+        """Whether an operator's force-allow carries forward to this run.
+
+        Must resolve against the PREVIOUS run, excluding the one being recorded.
+        It read `sync.latest_validation_run`, and on the sync path
+        `record_plan_validation` creates the new run BEFORE blocking reasons are
+        evaluated - so the lookup returned the run being recorded, whose
+        `override_applied` is always False. The override could therefore never
+        fire on the only path that matters: an operator force-allowed a blocked
+        run and the same reason blocked the next one, with nothing to say why.
+
+        `_row_shrink_already_accepted` had to work around this with its own
+        previous-run lookup, and its docstring says so. This is the same
+        exclusion, applied where it belonged.
+
+        The old coverage called `_blocking_reasons` directly with no current
+        run, so it exercised the branch that still worked and passed straight
+        over the dead one.
+        """
+        previous = self._previous_override_run(validation_run)
+        if previous is None:
             return False
-        if policy is None or latest_validation_run.policy_id != getattr(
-            policy, "pk", None
-        ):
+        if policy is None or previous.policy_id != getattr(policy, "pk", None):
             return False
-        return latest_validation_run.snapshot_selector == context.get(
+        return previous.snapshot_selector == context.get(
             "snapshot_selector"
-        ) and latest_validation_run.snapshot_id == context.get("snapshot_id")
+        ) and previous.snapshot_id == context.get("snapshot_id")
+
+    def _previous_override_run(self, validation_run=None):
+        """The most recent force-allowed run that is not the one being recorded."""
+        runs = self.sync.validation_runs.filter(override_applied=True)
+        pk = getattr(validation_run, "pk", None)
+        if pk is not None:
+            runs = runs.exclude(pk=pk)
+        return runs.order_by("-pk").first()
 
     def _snapshot_is_processed(self, context):
         info = context.get("snapshot_info") or {}


### PR DESCRIPTION
An operator force-allows a blocked run; the same reason blocks the next run anyway, with nothing to say why.

`_forced_validation_override_applies` read `sync.latest_validation_run`, and on the sync path `record_plan_validation` **creates the new run before blocking reasons are evaluated**. So the lookup returned the run being recorded, whose `override_applied` is always False. The override could never fire on the only path that matters — for every blocking reason, not one feature.

It now resolves against the most recent force-allowed run **excluding the one being recorded**. That is the same exclusion `_row_shrink_already_accepted` already had to write for itself — its docstring says it cannot reuse this helper for exactly this reason — applied where it belonged rather than copied a third time.

Scope is unchanged: same policy, same snapshot selector, same snapshot.

## Why it hid

The previous coverage called `_blocking_reasons` **directly, with no current run**. That path still worked, so the suite passed straight over the dead branch. The new tests go through `record_plan_validation`, so a run exists before the decision is made — the condition the defect depends on.

The carry-forward test was confirmed to **fail against the old behaviour** before being accepted. The four negative cases (different snapshot, different policy, not force-allowed, no override at all) pass either way, as they should.

**Verification:** full plugin suite **2007 tests OK** (4 skipped), harness and pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5Ax5f23uwWLmjGMtQq39p