### PR TITLE
style: apply black formatting to the skip-raiser structural test

### DIFF
--- a/forward_netbox/tests/test_skip_raisers_name_dependency.py
+++ b/forward_netbox/tests/test_skip_raisers_name_dependency.py
@@ -69,8 +69,7 @@ class SkipRaisersNameTheirDependencyTest(SimpleTestCase):
                 guard = test.args[0].value
                 for child in ast.walk(node):
                     if not (
-                        isinstance(child, ast.Raise)
-                        and isinstance(child.exc, ast.Call)
+                        isinstance(child, ast.Raise) and isinstance(child.exc, ast.Call)
                     ):
                         continue
                     name = getattr(child.exc.func, "id", None) or getattr(
@@ -92,7 +91,9 @@ class SkipRaisersNameTheirDependencyTest(SimpleTestCase):
                             f"{path.relative_to(PLUGIN_ROOT)}:{child.lineno} "
                             f"guard={guard!r} dependency={declared!r}"
                         )
-        self.assertEqual(mismatches, [], f"dependency disagrees with guard: {mismatches}")
+        self.assertEqual(
+            mismatches, [], f"dependency disagrees with guard: {mismatches}"
+        )
 
     def test_there_are_still_raisers_to_check(self):
         # Guards the two tests above against silently passing on an empty set,


### PR DESCRIPTION
`invoke lint` is failing on `main`. The file was committed before black had run on it — a `git stash`/`stash pop` during an unrelated investigation reverted the formatting after the lint pass and before the commit.

Formatting only, no behaviour change.

Second time today. The lesson: lint must be verified **immediately before the commit**, not earlier in the session — a pass that was clean ten minutes ago says nothing about the tree actually being committed.

**Verification:** `invoke lint` rc=0, re-run after committing with a clean working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5Ax5f23uwWLmjGMtQq39p