### PR TITLE
test: prove the ownership domain completes with a pre-existing status tag

### DIFF
--- a/docs/03_Plans/active/2026-08-10-ownership-completion-assurance.md
+++ b/docs/03_Plans/active/2026-08-10-ownership-completion-assurance.md
@@ -1,0 +1,61 @@
+# Prove the ownership domain completes, not just that a helper returns
+
+## Goal
+
+Be sure 2.7.5 actually fixed the customer's failure, rather than sure that a
+helper behaves.
+
+## Contract
+
+- The assertion is on the recorded DOMAIN status, because that is what the
+  Drift Report reads and what "Ownership: Incomplete" reflects.
+- The tests must fail against pre-2.7.5 behaviour, or they prove nothing.
+
+## Constraints
+
+- `_apply_maintained_device_tag` takes keyword-only arguments after
+  `device_names`.
+- Tag ASSIGNMENT removal is gated on `_domain_is_current` (ownership.py:637),
+  which compares against a promoted baseline. A fixture that never promotes one
+  will not see removal, and that is correct - the gate stops one sync stripping
+  a tag another sync still claims.
+
+## Touched Surfaces
+
+- `forward_netbox/tests/test_ownership_completes_with_preexisting_status_tag.py`
+
+## Approach
+
+Drive the reconciliation the scope-tag job calls, with `forward-backfilled`
+already present and unowned - the customer's exact state - and assert the
+STATUS_TAGS domain reaches COMPLETED, repeatedly, while an operator's own
+assignment survives.
+
+## Validation
+
+- 4 tests, OK; full plugin suite 2014 tests, OK (4 skipped)
+- All four confirmed to FAIL with the pre-2.7.5 refusal restored
+
+## Rollback
+
+Revert. Coverage returns to the isolated helper test.
+
+## Decision Log
+
+- **The existing coverage was not evidence.** `_ensure_managed_tag` passing in
+  isolation says nothing about whether the domain completes, and the domain is
+  the thing the customer sees. Asserting the helper was assurance theatre.
+- **Verified the tests fail against the old behaviour.** Restored the refusal
+  and confirmed all four error, then restored the fix. A regression test never
+  observed failing is a guess.
+- **Corrected one expectation rather than the code.** The fourth test first
+  asserted the tag assignment was removed; it is not, because the fixture never
+  promotes a baseline and removal is gated on domain currency. The gate is
+  right, so the test now asserts the claim release and documents why the
+  assignment is out of scope here.
+
+## Open
+
+- Whether the customer's specific conflict was this one is still unconfirmed -
+  their tag table was never inspected. What is now proven is that this failure
+  mode is fixed end to end, and that a surviving conflict names itself.

--- a/forward_netbox/tests/test_ownership_completes_with_preexisting_status_tag.py
+++ b/forward_netbox/tests/test_ownership_completes_with_preexisting_status_tag.py
@@ -1,0 +1,159 @@
+# The customer's live failure, end to end.
+#
+# `forward-backfilled` existed in their NetBox with no ForwardManagedDeviceTag
+# row. Status-tag reconciliation refused to adopt it on EVERY run, so the
+# ownership domain never completed, convergence stayed blocked, and every drift
+# figure read "Not measured" with no remedy available to them.
+#
+# The unit test for the fix covers `_ensure_managed_tag` in isolation. That is
+# not the thing that was broken for them: the job is what failed, and a helper
+# passing says nothing about whether the DOMAIN now reaches COMPLETED. These
+# tests drive the reconciliation the job calls and assert on the recorded
+# domain state, which is what the Drift Report reads.
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import Manufacturer
+from dcim.models import Site
+from django.test import TestCase
+from extras.models import Tag
+
+from forward_netbox.models import ForwardDeviceTagClaim
+from forward_netbox.models import ForwardIngestion
+from forward_netbox.models import ForwardManagedDeviceTag
+from forward_netbox.models import ForwardOwnershipReconciliation
+from forward_netbox.models import ForwardPreservedDeviceTagAssignment
+from forward_netbox.models import ForwardSource
+from forward_netbox.models import ForwardSync
+from forward_netbox.utilities.scope_reconciliation import (
+    _apply_maintained_device_tag,
+)
+
+BACKFILLED_SLUG = "forward-backfilled"
+
+
+class OwnershipCompletesWithPreexistingStatusTagTest(TestCase):
+    def setUp(self):
+        source = ForwardSource.objects.create(
+            name="e2e-src",
+            type="saas",
+            url="https://fwd.app",
+            parameters={"network_id": "net-1"},
+        )
+        self.sync = ForwardSync.objects.create(name="e2e-sync", source=source)
+        self.ingestion = ForwardIngestion.objects.create(
+            sync=self.sync, snapshot_id="snap-e2e"
+        )
+        site = Site.objects.create(name="e2e-site", slug="e2e-site")
+        manufacturer = Manufacturer.objects.create(name="e2e-mfr", slug="e2e-mfr")
+        device_type = DeviceType.objects.create(
+            manufacturer=manufacturer, model="e2e", slug="e2e"
+        )
+        role = DeviceRole.objects.create(name="e2e-role", slug="e2e-role")
+        self.device = Device.objects.create(
+            name="e2e-backfilled-device",
+            site=site,
+            device_type=device_type,
+            role=role,
+        )
+        self.operator_device = Device.objects.create(
+            name="e2e-operator-device",
+            site=site,
+            device_type=device_type,
+            role=role,
+        )
+
+    def _reconcile(self, device_names):
+        return _apply_maintained_device_tag(
+            self.sync,
+            device_names,
+            slug=BACKFILLED_SLUG,
+            name="Forward Backfilled",
+            color="f44336",
+            description="",
+            claim_type="backfilled",
+            generation=self.ingestion.pk,
+            snapshot_id=self.ingestion.snapshot_id,
+        )
+
+    def _status_domain(self):
+        return ForwardOwnershipReconciliation.objects.filter(
+            sync=self.sync,
+            domain=ForwardOwnershipReconciliation.Domain.STATUS_TAGS,
+        ).first()
+
+    def test_the_domain_completes_when_the_tag_already_exists_unowned(self):
+        # Exactly the customer's state: the tag is present, nothing owns it.
+        Tag.objects.create(name="Forward Backfilled", slug=BACKFILLED_SLUG)
+
+        self._reconcile({self.device.name})
+
+        domain = self._status_domain()
+        self.assertIsNotNone(domain, "status-tag domain was never recorded")
+        self.assertEqual(
+            domain.status,
+            ForwardOwnershipReconciliation.Status.COMPLETED,
+            "the ownership domain did not complete, so convergence stays "
+            "blocked and drift reads 'Not measured'",
+        )
+        self.assertTrue(
+            self.device.tags.filter(slug=BACKFILLED_SLUG).exists(),
+            "the backfilled device was never tagged",
+        )
+
+    def test_it_completes_again_on_the_next_run(self):
+        # The failure repeated every run, so once is not evidence.
+        Tag.objects.create(name="Forward Backfilled", slug=BACKFILLED_SLUG)
+        for _ in range(3):
+            self._reconcile({self.device.name})
+        self.assertEqual(
+            self._status_domain().status,
+            ForwardOwnershipReconciliation.Status.COMPLETED,
+        )
+        self.assertEqual(
+            ForwardManagedDeviceTag.objects.filter(tag__slug=BACKFILLED_SLUG).count(),
+            1,
+        )
+
+    def test_an_operators_own_assignment_survives_adoption(self):
+        # Adoption takes over a tag the operator already used. What they put on
+        # their own devices must not be swept away by that.
+        tag = Tag.objects.create(name="Forward Backfilled", slug=BACKFILLED_SLUG)
+        self.operator_device.tags.add(tag)
+
+        self._reconcile({self.device.name})
+
+        self.assertTrue(
+            self.operator_device.tags.filter(slug=BACKFILLED_SLUG).exists(),
+            "adoption removed a tag assignment the operator made themselves",
+        )
+        self.assertTrue(
+            ForwardPreservedDeviceTagAssignment.objects.filter(
+                device=self.operator_device, tag=tag
+            ).exists(),
+            "the operator's assignment was not recorded as preserved, so "
+            "releasing ownership would not restore it",
+        )
+
+    def test_a_device_leaving_backfilled_state_releases_the_plugins_claim(self):
+        Tag.objects.create(name="Forward Backfilled", slug=BACKFILLED_SLUG)
+        self._reconcile({self.device.name})
+        self.assertTrue(self.device.tags.filter(slug=BACKFILLED_SLUG).exists())
+
+        # Collection succeeds next run, so the device is no longer backfilled.
+        self._reconcile(set())
+
+        # The CLAIM is what this sync owns, and it is released.
+        self.assertFalse(
+            ForwardDeviceTagClaim.objects.filter(device=self.device).exists()
+        )
+        self.assertEqual(
+            self._status_domain().status,
+            ForwardOwnershipReconciliation.Status.COMPLETED,
+        )
+        # The tag ASSIGNMENT is deliberately not asserted here. Removing it is
+        # gated on `_domain_is_current` (ownership.py:637), which compares
+        # against the sync's promoted baseline - this fixture never promotes
+        # one, so the removal correctly does not run. That gate is what stops
+        # one sync stripping a tag another sync still claims, and it deserves
+        # its own test rather than being incidentally exercised here.


### PR DESCRIPTION
The fix for the customer's ownership failure shipped in 2.7.5 with a unit test on `_ensure_managed_tag` **in isolation**. That was not evidence of anything they would see: the *job* is what failed for them, and a helper returning a managed tag says nothing about whether the `STATUS_TAGS` domain reaches `COMPLETED` — which is what the Drift Report reads and what `Ownership: Incomplete` reflects.

These drive the reconciliation the scope-tag job actually calls, with `forward-backfilled` already present and unowned — their exact state — and assert on the recorded domain status:

- the domain **completes**
- it completes **again on repeat runs** (the failure recurred every run, so once is not evidence)
- an operator's own assignment **survives adoption** and is recorded as preserved
- a device leaving backfilled state **releases the plugin's claim**

**All four were confirmed to fail** with the pre-2.7.5 refusal restored, then pass with it removed. A regression test never observed failing is a guess.

## One expectation corrected, not the code

The fourth test first asserted the tag *assignment* was removed. It is not — removal is gated on `_domain_is_current` (ownership.py:637) and the fixture never promotes a baseline. That gate is what stops one sync stripping a tag another sync still claims, so the test now asserts the claim release and records why the assignment is out of scope here.

## Also verified the shipped tag

2.7.4 shipped without its own scope tranche, so I no longer assume `main` and the tag agree. Checked `v2.7.5` directly: the reserved-slug refusal is **absent**, migration `0051` is **present**, and the provenance stamp is **SET_NULL**.

**Verification:** full plugin suite **2014 tests OK** (4 skipped), `invoke lint` rc=0 immediately before *and* after the commit, harness clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5Ax5f23uwWLmjGMtQq39p