### PR TITLE
fix: a device Forward reports but NetBox lacks no longer refuses the domain

### DIFF
--- a/docs/03_Plans/active/2026-08-10-absent-device-does-not-block-tag-domain.md
+++ b/docs/03_Plans/active/2026-08-10-absent-device-does-not-block-tag-domain.md
@@ -1,0 +1,67 @@
+# A device Forward reports but NetBox lacks must not refuse the whole domain
+
+## Goal
+
+Let ownership reconciliation complete when Forward reports devices that this
+NetBox does not have.
+
+## Contract
+
+- A name with no device in NetBox is SKIPPED and counted. Nothing to tag,
+  nothing to release, so no NetBox row changes.
+- A name shared by several devices still REFUSES. `desired_ids` drives both the
+  add and the remove, so dropping the key could release a claim from a device
+  that holds one, and resolving it could tag the wrong device.
+- The refusal reports counts. Device names are customer data.
+- Both return paths carry the same keys.
+
+## Constraints
+
+- NetBox scopes device-name uniqueness to the SITE, so a test for genuine
+  ambiguity needs the same name in two sites - which is also how it arises in a
+  real estate.
+- `reconcile_virtual_parent_claims` already resolves identities this way and
+  skips per key. It is the one ownership domain that kept completing for the
+  customer while these two failed.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/ownership.py`
+- `forward_netbox/tests/test_absent_device_does_not_block_tag_domain.py`
+
+## Approach
+
+Split the two failure kinds that were lumped into one refusal: skip `missing`,
+keep refusing `ambiguous`, and report `skipped_absent_devices` so the skip is
+visible.
+
+## Validation
+
+- 6 tests, OK; full plugin suite 2020 tests, OK (4 skipped)
+- The three missing-device tests confirmed to ERROR with the previous
+  `if missing or ambiguous` restored; the ambiguity tests pass either way,
+  which is the split the fix is built on
+
+## Rollback
+
+Revert. One absent device again refuses the whole tag domain.
+
+## Decision Log
+
+- **Found by the diagnostic, not by guessing.** The conflict catalogue shipped
+  in 2.7.6 named `tag-mutation-identity-unresolved` on the customer's job. The
+  earlier suspicion - reserved status-tag adoption - was wrong, and would have
+  stayed wrong without the catalogue.
+- **`missing` and `ambiguous` are not equally dangerous.** Treating them alike
+  is what made an absent device fatal. Only the one that can mis-tag or wrongly
+  release still refuses.
+- **Two defects surfaced from the tests, not the premise.** The "nothing
+  resolved" exit returned a different dict shape, so callers could not rely on
+  the new key; and the first ambiguity fixture could not be built at all,
+  because NetBox scopes name uniqueness to the site.
+
+## Open
+
+- The customer's eleven absent devices remain absent. This stops them blocking
+  convergence; whether Forward should be tagging devices that NetBox has never
+  had is a question for their side, and the count now makes it visible.

--- a/forward_netbox/tests/test_absent_device_does_not_block_tag_domain.py
+++ b/forward_netbox/tests/test_absent_device_does_not_block_tag_domain.py
@@ -1,0 +1,147 @@
+# The customer's live blocker on 2.7.6, named by the conflict catalogue as
+# `tag-mutation-identity-unresolved`.
+#
+# Forward reported eleven devices carrying the include tags that did not exist
+# in their NetBox, out of roughly 3400. `reconcile_source_device_tag_claims`
+# refused the ENTIRE mutation if any name failed to resolve, so both the
+# scope-tag and status-tag domains failed on every run: ownership never
+# completed, convergence stayed blocked, and every drift figure read "Not
+# measured" with no remedy available to them.
+#
+# The two resolution failures are deliberately treated differently, and these
+# tests pin both halves:
+#
+#   missing   - no device of that name exists, so there is nothing to tag and
+#               nothing to release. Skipping changes no NetBox row.
+#   ambiguous - several devices share the name. `desired_ids` drives both the
+#               add and the remove, so dropping the key could release a claim
+#               from a device that holds one, or tag the wrong device.
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import Manufacturer
+from dcim.models import Site
+from django.test import TestCase
+
+from forward_netbox.models import ForwardDeviceTagClaim
+from forward_netbox.models import ForwardIngestion
+from forward_netbox.models import ForwardOwnershipReconciliation
+from forward_netbox.models import ForwardSource
+from forward_netbox.models import ForwardSync
+from forward_netbox.utilities.ownership import OwnershipConflictError
+from forward_netbox.utilities.ownership import reconcile_source_device_tag_claims
+
+SLUG = "b-chalasani"
+
+
+class AbsentDeviceDoesNotBlockTagDomainTest(TestCase):
+    def setUp(self):
+        source = ForwardSource.objects.create(
+            name="absent-src",
+            type="saas",
+            url="https://fwd.app",
+            parameters={"network_id": "net-1"},
+        )
+        self.sync = ForwardSync.objects.create(name="absent-sync", source=source)
+        self.ingestion = ForwardIngestion.objects.create(
+            sync=self.sync, snapshot_id="snap-absent"
+        )
+        self.site = Site.objects.create(name="absent-site", slug="absent-site")
+        manufacturer = Manufacturer.objects.create(name="absent-mfr", slug="absent-mfr")
+        self.device_type = DeviceType.objects.create(
+            manufacturer=manufacturer, model="am", slug="am"
+        )
+        self.role = DeviceRole.objects.create(name="absent-role", slug="absent-role")
+        self.present = self._device("present-device")
+
+    def _device(self, name, site=None):
+        return Device.objects.create(
+            name=name,
+            site=site or self.site,
+            device_type=self.device_type,
+            role=self.role,
+        )
+
+    def _twin_named(self, name):
+        """Two devices sharing a name. NetBox scopes name uniqueness to the
+        site, so genuine ambiguity means the same name in two sites - which is
+        precisely how it arises in a real estate."""
+        second_site = Site.objects.create(
+            name=f"{name}-other-site", slug=f"{name}-other-site"
+        )
+        return self._device(name), self._device(name, site=second_site)
+
+    def _reconcile(self, names):
+        return reconcile_source_device_tag_claims(
+            self.sync,
+            names,
+            slug=SLUG,
+            name="B.Chalasani",
+            color="9e9e9e",
+            description="",
+            claim_type="scope",
+            generation=self.ingestion.pk,
+            snapshot_id=self.ingestion.snapshot_id,
+        )
+
+    def test_a_device_absent_from_netbox_is_skipped_not_fatal(self):
+        # The customer's shape: most names resolve, a few do not exist at all.
+        result = self._reconcile({"present-device", "never-existed"})
+
+        self.assertEqual(result["skipped_absent_devices"], 1)
+        self.assertTrue(
+            ForwardDeviceTagClaim.objects.filter(device=self.present).exists(),
+            "the devices that DO exist were not claimed",
+        )
+
+    def test_the_domain_completes_despite_an_absent_device(self):
+        self._reconcile({"present-device", "never-existed"})
+
+        domain = ForwardOwnershipReconciliation.objects.filter(
+            sync=self.sync,
+            domain=ForwardOwnershipReconciliation.Domain.SCOPE_TAGS,
+        ).first()
+        self.assertIsNotNone(domain)
+        self.assertEqual(
+            domain.status,
+            ForwardOwnershipReconciliation.Status.COMPLETED,
+            "ownership still did not complete, so convergence stays blocked",
+        )
+
+    def test_only_absent_names_still_completes(self):
+        # Nothing resolves. There is still nothing unsafe about proceeding.
+        result = self._reconcile({"never-existed", "also-never-existed"})
+        self.assertEqual(result["skipped_absent_devices"], 2)
+        self.assertEqual(result["total"], 0)
+
+    def test_an_ambiguous_name_still_refuses(self):
+        # Two devices share a name. Resolving it could tag the wrong one, and
+        # dropping it could release a claim from one that holds it.
+        self._twin_named("twin")
+
+        with self.assertRaises(OwnershipConflictError) as caught:
+            self._reconcile({"present-device", "twin"})
+
+        message = str(caught.exception)
+        self.assertIn("ambiguous", message)
+        # Device names are customer data; the counts are what gets reported.
+        self.assertNotIn("twin", message)
+
+    def test_the_refusal_reports_both_counts(self):
+        self._twin_named("twin")
+
+        with self.assertRaises(OwnershipConflictError) as caught:
+            self._reconcile({"twin", "never-existed", "also-never-existed"})
+
+        message = str(caught.exception)
+        self.assertIn("1", message)  # one ambiguous
+        self.assertIn("2", message)  # two absent
+
+    def test_a_fully_resolvable_run_is_unchanged(self):
+        other = self._device("second-device")
+
+        result = self._reconcile({"present-device", "second-device"})
+
+        self.assertEqual(result["skipped_absent_devices"], 0)
+        self.assertEqual(result["total"], 2)
+        self.assertTrue(ForwardDeviceTagClaim.objects.filter(device=other).exists())

--- a/forward_netbox/utilities/ownership.py
+++ b/forward_netbox/utilities/ownership.py
@@ -807,10 +807,36 @@ def reconcile_source_device_tag_claims(
         generation=generation,
         snapshot_id=snapshot_id,
     )
-    if missing or ambiguous:
+    # A name Forward reports that NetBox does not have is SKIPPED, not fatal.
+    #
+    # This refused the whole mutation when any name failed to resolve, and a
+    # customer sat behind it: eleven devices carried the include tags in Forward
+    # but did not exist in their NetBox, out of roughly 3400, and both the
+    # scope-tag and status-tag domains refused on every run. Ownership never
+    # completed, so convergence stayed blocked and every drift figure read "Not
+    # measured", with no remedy short of creating the absent devices or editing
+    # Forward's tags.
+    #
+    # The two failures are not equally dangerous, which is why only one is fatal:
+    #
+    # `missing` - no device of that name exists. There is nothing to tag and
+    # nothing to release, so skipping the key changes no NetBox row. Safe.
+    #
+    # `ambiguous` - several devices share the name. `desired_ids` drives BOTH
+    # the add and the remove below, so dropping the key silently could release a
+    # claim from a device that currently holds one, and resolving it could tag
+    # the wrong device. Neither is acceptable, so this stays a refusal.
+    #
+    # `reconcile_virtual_parent_claims` already resolves identities this way -
+    # it skips unresolved names per key and counts them - and that is the one
+    # ownership domain that kept completing for the customer while these two
+    # failed.
+    if ambiguous:
         raise OwnershipConflictError(
-            "Refusing name-only tag mutation because device identity is unresolved "
-            "or ambiguous: " + ", ".join((ambiguous + missing)[:10])
+            "Refusing name-only tag mutation because device identity is "
+            f"ambiguous for {len(ambiguous)} name(s); {len(missing)} further "
+            "name(s) are absent from NetBox. Names are customer data, so the "
+            "counts are reported instead."
         )
     desired_ids = set(identities.values())
     with ownership_write_lock():
@@ -842,6 +868,10 @@ def reconcile_source_device_tag_claims(
                 "assignments_removed": finalized["assignments_removed"],
                 "total": len(desired_ids),
                 "current": finalized["current"],
+                # Both exits report the same keys. This one is reached when
+                # nothing resolved at all, which is exactly when the caller most
+                # needs to know how many names were skipped.
+                "skipped_absent_devices": len(missing),
             }
 
         _ensure_managed_tag(
@@ -901,6 +931,11 @@ def reconcile_source_device_tag_claims(
             "claims_released": released,
             **materialized,
             "total": len(desired_ids),
+            # Skipping absent devices must not be invisible. A count is
+            # schema-safe where the names are not, and a number that keeps
+            # climbing is the signal that Forward is tagging devices this NetBox
+            # has never had.
+            "skipped_absent_devices": len(missing),
         }
 
 


### PR DESCRIPTION
**This is the customer's live blocker on 2.7.6**, and the conflict catalogue we shipped in that release is what found it — their job named its own rule instead of `unrecognized-ownership-conflict`:

```
OwnershipConflictError: tag-mutation-identity-unresolved
```

## The defect

```python
identities, missing, ambiguous = resolve_device_identities(...)
if missing or ambiguous:
    raise OwnershipConflictError("Refusing name-only tag mutation ...")
```

`missing` = names Forward reports that have **no device of that name in NetBox**. Their own audit reported `scope_tag_targets_missing_in_netbox: 11` — eleven absent devices out of ~3400 refused the **entire** scope-tag and status-tag domains, every run, with no remedy short of creating those devices or editing Forward's tags.

Their support bundle for ingestion 2726 confirms it: `failed_domains: ['scope_tags','status_tags']`, `virtual_parents` **completed**, all **3525 claims stale**, `current_managed_device_tags: 0`, `complete: False`.

## The two failures are not equally dangerous

- **`missing`** — no such device exists. Nothing to tag, nothing to release; skipping changes no NetBox row. **Now skipped and counted** (`skipped_absent_devices`).
- **`ambiguous`** — several devices share a name. `desired_ids` drives **both** the add and the remove, so dropping the key could release a claim from a device that holds one, and resolving it could tag the wrong device. **Still refuses**, now reporting counts rather than device names.

Treating them alike is what made an absent device fatal.

## The pattern was already in the codebase

`reconcile_virtual_parent_claims` uses the *same resolver* and skips unresolved names per key, counting them — and `virtual_parents` is the one ownership domain that kept completing for the customer while these two failed.

## Two more defects, surfaced by the tests

- The "nothing resolved" exit returned a **different dict shape**, so a caller could not rely on the new key.
- The first ambiguity fixture **could not be built at all**: NetBox scopes device-name uniqueness to the site, so genuine ambiguity means the same name in two sites — which is also how it arises in a real estate.

**Verification:** 6 new tests; the three missing-device tests confirmed to **error** with the previous `if missing or ambiguous` restored, while the ambiguity tests pass either way — exactly the split the fix is built on. Full plugin suite **2020 tests OK** (4 skipped), `invoke lint` rc=0 before and after the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5Ax5f23uwWLmjGMtQq39p