### PR TITLE
chore: advance the release provenance anchor to 2.7.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git fetch --no-tags origin main:refs/remotes/origin/main
-          git fetch --force origin refs/tags/v2.7.6:refs/tags/v2.7.6
+          git fetch --force origin refs/tags/v2.7.8:refs/tags/v2.7.8
           set -o pipefail
           for attempt in $(seq 1 120); do
             provenance_log="$(mktemp)"

--- a/docs/03_Plans/active/2026-08-10-anchor-2.7.8.md
+++ b/docs/03_Plans/active/2026-08-10-anchor-2.7.8.md
@@ -1,0 +1,82 @@
+# Advance the release provenance anchor to 2.7.8
+
+## Goal
+
+Move the provenance anchor past two commits whose PR association was destroyed
+by the history rewrite, so that releases are possible again.
+
+## Contract
+
+- The anchor pins `v2.7.8` and the documentation-only bridge that follows it.
+- The five hand-maintained copies of the prior tag move together.
+- An anchor that disagrees with the compatibility table is accepted only for a
+  tag explicitly recorded as having published nothing.
+
+## Constraints
+
+- `v2.7.8` published nothing, so it must NOT be promoted to "Current release"
+  in the table. `v2.7.6` remains the current release, because it is what
+  operators can actually install.
+- The bridge slot is the first commit after the tag and cannot be reclaimed, so
+  the anchor can only ever pin the commit already merged as `0f4a4a7`.
+- Local `verify_release_provenance.py` cannot run to completion on this host;
+  the publish workflow runs the identical verifier and is fail-closed.
+
+## Touched Surfaces
+
+- `scripts/verify_release_provenance.py` (anchor pair, unpublished-tag list)
+- `scripts/check_harness.py` (anchor rule, prior-tag literal)
+- `scripts/tests/test_tasks.py`, `scripts/tests/test_check_harness.py`
+- `.github/workflows/release.yml` (tag fetch)
+
+## Approach
+
+The reviewed lineage is measured from the anchor bridge forward, and every
+commit in it must map to a merged `main` pull request. The rewrite that removed
+a customer name from the history rebuilt two commits, and GitHub associates
+pull requests by commit SHA, so `215f186` and `0eafbba` lost theirs. Their
+CONTENT is unchanged from the reviewed originals - each differs from its
+predecessor by exactly the two fixture lines - but that is not something the
+verifier can establish, and it correctly refuses.
+
+Anchoring to `v2.7.8` moves both commits behind the anchor, so future lineages
+start after them.
+
+The harness previously required the anchor and the table's current release to
+be equal. That cannot hold here: `v2.7.8` is the newest tag but `v2.7.6` is the
+newest published release, and promoting `v2.7.8` would tell operators to
+install something that does not exist. The rule now accepts a disagreement only
+when the anchor tag appears in `UNPUBLISHED_RELEASE_TAGS`, so the forgotten
+promotion it was written to catch still fails.
+
+## Validation
+
+`invoke ci` locally, which runs the harness and the full `scripts/tests` suite
+including the four anchor-rule cases. The publish workflow re-runs the real
+verifier against the next tag.
+
+## Rollback
+
+Revert the pull request. The anchor returns to `v2.7.6` and releases stay
+blocked, which is the state this change exists to leave.
+
+## Decision Log
+
+- **Anchor past the commits rather than re-land them.** The alternative was a
+  second force-push of `main` to restore genuine PR provenance. That would have
+  produced stronger provenance; it was declined in favour of not touching the
+  branch again. The consequence is recorded honestly here: two commits on
+  `main` will never be verifiable, and the anchor is what stops that from
+  blocking every future release.
+- **Record unpublished tags explicitly instead of loosening the comparison.**
+  Allowing any anchor ahead of the table would have silently retired the
+  forgotten-promotion check. A named list keeps every other disagreement fatal
+  and forces a reviewed edit to excuse a tag.
+- **`v2.7.3` is included in the list** for the same reason, so the record is
+  complete rather than only covering what this change needed.
+
+## Open
+
+- `v2.7.7` and `v2.7.8` are burned. The next release is `2.7.9`.
+- The two rewritten commits remain unverifiable in perpetuity. Anything that
+  re-walks history from before the anchor will fail on them.

--- a/scripts/check_harness.py
+++ b/scripts/check_harness.py
@@ -197,7 +197,7 @@ REQUIRED_TEXT = {
     ],
     ".github/workflows/release.yml": [
         "fetch-depth: 0",
-        "refs/tags/v2.7.6",
+        "refs/tags/v2.7.8",
         "verify_release_provenance.py",
         "--git-files",
         "--protected-history",
@@ -762,7 +762,8 @@ def _check_release_toolchain_lock(failures: list[str]) -> None:
 
 
 def _check_release_anchor_tracks_current_release(failures: list[str]) -> None:
-    """The provenance anchor must name the release the table calls current.
+    """The provenance anchor must not fall BEHIND the release the table calls
+    current.
 
     Two post-release steps are easy to skip because nothing failed when they
     were: advancing `PRIOR_RELEASE_TAG`, and promoting the shipped release in
@@ -776,6 +777,21 @@ def _check_release_anchor_tracks_current_release(failures: list[str]) -> None:
     in this file, so the checks moved only when someone remembered to move them.
     Tying the two together removes the hand-maintained copy and makes skipping
     either step fail here instead of at a tag months later.
+
+    This required the two to be EQUAL, which cannot hold when a tag is cut and
+    then fails to publish. `v2.7.7` and `v2.7.8` were both refused at the
+    publish gate, so the newest annotated tag is ahead of the newest PUBLISHED
+    release, and the anchor must follow the tag rather than the table: the
+    reviewed lineage is measured from a tag, and anchoring to a published-but-
+    older release would leave the unpublishable commits inside every future
+    lineage.
+
+    The exception is declared, not inferred. An anchor that differs from the
+    table is accepted only when the tag is listed in `UNPUBLISHED_RELEASE_TAGS`,
+    which is a hand-maintained record of tags that published nothing. Anything
+    else - including the forgotten promotion this check was written to catch -
+    still fails, and a tag cannot be quietly excused without a reviewed edit to
+    that list saying so.
     """
     provenance_path = REPO_ROOT / "scripts/verify_release_provenance.py"
     readme_path = REPO_ROOT / "README.md"
@@ -805,13 +821,30 @@ def _check_release_anchor_tracks_current_release(failures: list[str]) -> None:
         )
         return
 
-    if anchor_match.group("tag") != current[0]:
-        failures.append(
-            "release provenance anchor "
-            f"{anchor_match.group('tag')} does not match the current release "
-            f"{current[0]} in the README table: advance the anchor after a "
-            "release, or promote the shipped release in the table"
-        )
+    anchor_tag = anchor_match.group("tag")
+    if anchor_tag == current[0]:
+        return
+
+    unpublished = re.search(
+        r"^UNPUBLISHED_RELEASE_TAGS = \((?P<tags>[^)]*)\)",
+        provenance_path.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    declared = (
+        set(re.findall(r"v[0-9]+\.[0-9]+\.[0-9]+", unpublished.group("tags")))
+        if unpublished
+        else set()
+    )
+    if anchor_tag in declared:
+        return
+
+    failures.append(
+        "release provenance anchor "
+        f"{anchor_tag} does not match the current release "
+        f"{current[0]} in the README table: advance the anchor after a "
+        "release, promote the shipped release in the table, or record the tag "
+        "in UNPUBLISHED_RELEASE_TAGS if it never published"
+    )
 
 
 def _documentation_bridge_rule():

--- a/scripts/tests/test_check_harness.py
+++ b/scripts/tests/test_check_harness.py
@@ -750,13 +750,17 @@ class ReleaseAnchorTracksCurrentReleaseTest(unittest.TestCase):
         "| `v2.6.9` | `4.6.x` | Superseded by `{current}`; shipped. |\n"
     )
 
-    def _run(self, *, tag, current, table=None):
+    def _run(self, *, tag, current, table=None, unpublished=None):
         failures = []
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             (root / "scripts").mkdir()
+            provenance = self.PROVENANCE.format(tag=tag)
+            if unpublished is not None:
+                listed = ", ".join(f'"{entry}"' for entry in unpublished)
+                provenance = f"UNPUBLISHED_RELEASE_TAGS = ({listed})\n" + provenance
             (root / "scripts/verify_release_provenance.py").write_text(
-                self.PROVENANCE.format(tag=tag), encoding="utf-8"
+                provenance, encoding="utf-8"
             )
             (root / "README.md").write_text(
                 table if table is not None else self.TABLE.format(current=current),
@@ -785,6 +789,24 @@ class ReleaseAnchorTracksCurrentReleaseTest(unittest.TestCase):
         failures = self._run(tag="v2.7.0", current="v2.6.12")
         self.assertEqual(len(failures), 1)
         self.assertIn("does not match the current release", failures[0])
+
+    def test_an_anchor_on_a_tag_that_never_published_is_accepted(self):
+        # A tag refused at the publish gate is still a valid anchor - it exists
+        # and is annotated - but it must never be promoted in the table, so the
+        # two legitimately disagree. v2.7.8 is the case that forced this.
+        self.assertEqual(
+            self._run(tag="v2.7.8", current="v2.7.6", unpublished=("v2.7.8",)),
+            [],
+        )
+
+    def test_an_unlisted_anchor_is_reported_even_when_others_are_listed(self):
+        # The excuse is per-tag. Recording one unpublished tag must not blanket-
+        # accept every anchor that disagrees with the table, or the forgotten
+        # promotion this check exists for comes back.
+        failures = self._run(tag="v2.7.9", current="v2.7.6", unpublished=("v2.7.8",))
+        self.assertEqual(len(failures), 1)
+        self.assertIn("does not match the current release", failures[0])
+        self.assertIn("UNPUBLISHED_RELEASE_TAGS", failures[0])
 
     def test_a_table_without_exactly_one_current_release_is_reported(self):
         # The promotion step edits this column, so a botched edit is the likely

--- a/scripts/tests/test_tasks.py
+++ b/scripts/tests/test_tasks.py
@@ -175,7 +175,7 @@ class ReleaseArtifactTaskTest(unittest.TestCase):
 
         self.assertIn("--require-hashes", workflow)
         self.assertIn("requirements-release.txt", workflow)
-        self.assertIn("refs/tags/v2.7.6", workflow)
+        self.assertIn("refs/tags/v2.7.8", workflow)
         self.assertIn("scripts/build_reproducible_distribution.py", workflow)
         self.assertIn("python -m invoke artifact-test", workflow)
         self.assertIn("sbom/", workflow)

--- a/scripts/verify_release_provenance.py
+++ b/scripts/verify_release_provenance.py
@@ -18,8 +18,19 @@ GITHUB_API_URL = "https://api.github.com"
 # sensitive-content scan still runs - `release.yml` invokes
 # `check_sensitive_content.py` directly, and pre-commit runs it locally - but
 # there is no longer a GitHub check run or commit status to verify.
-PRIOR_RELEASE_TAG = "v2.7.6"
-PRIOR_POST_RELEASE_DOC_COMMIT = "4deb989f2dffb514027f0b0426ed918cccc24fb7"
+# Tags that were cut and then refused at the publish gate. They exist and are
+# annotated, so they are valid provenance anchors, but they published nothing
+# and must never be promoted in the compatibility table. The harness consults
+# this list so that an anchor ahead of the current release is accepted ONLY for
+# a tag recorded here - a forgotten promotion is still a failure everywhere else.
+#
+# v2.7.7: the sensitive-content guard matched a customer name in a test fixture.
+# v2.7.8: the history rewrite that removed that name stripped PR association
+#         from two commits, so their provenance could not be verified.
+UNPUBLISHED_RELEASE_TAGS = ("v2.7.3", "v2.7.7", "v2.7.8")
+
+PRIOR_RELEASE_TAG = "v2.7.8"
+PRIOR_POST_RELEASE_DOC_COMMIT = "0f4a4a7b9fb7bc95e729e69ca9c63513e071d61d"
 BOOTSTRAP_REQUIRED_FILES = (
     "scripts/check_sensitive_content.py",
     "scripts/sensitive_content.py",


### PR DESCRIPTION
The history rewrite that removed a customer name rebuilt two commits. GitHub associates pull requests by SHA, so `215f186` and `0eafbba` lost theirs — their content is unchanged from the reviewed originals (each differs by exactly the two fixture lines), but the verifier cannot establish that and correctly refuses. That blocked **every** release, not just 2.7.8.

Anchoring to `v2.7.8` puts both commits behind the anchor.

## The harness rule

`v2.7.8` published nothing, so it must not be promoted to "Current release" — `v2.7.6` stays current because it is what operators can install. The harness previously required the anchor and the table to be **equal**, which cannot hold once a tag is cut and then refused.

Rather than drop that check, a disagreement is now accepted only when the anchor tag is listed in `UNPUBLISHED_RELEASE_TAGS`. The forgotten-promotion case it was written to catch still fails, and excusing a tag takes a reviewed edit. Two new tests cover both directions.

- harness: pass
- `scripts/tests`: 302 tests, OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPmp33tVZYDSeuBL4seyw8