### PR TITLE
fix: run the release-time sensitive scan before the tag exists

### DIFF
--- a/docs/03_Plans/active/2026-08-10-pattern-feed-parity.md
+++ b/docs/03_Plans/active/2026-08-10-pattern-feed-parity.md
@@ -1,0 +1,84 @@
+# Run the release-time sensitive scan before the tag
+
+## Goal
+
+Stop a customer identifier in the tree from being discovered only after the tag
+is immutable.
+
+## Contract
+
+- The scan the publish workflow runs is the scan the preflight runs, superset
+  feed included.
+- A checkout that cannot verify parity says so loudly and is recorded, rather
+  than passing quietly.
+
+## Constraints
+
+- `FORWARD_SENSITIVE_PATTERNS` is a repository SECRET. It cannot be read by
+  `gh`, it is not on the release host, and it must not be committed. Any design
+  that requires the feed's contents locally is unavailable to a checkout that
+  does not already have it.
+- The local `.sensitive-patterns.local.txt` is gitignored and will always be a
+  subset unless someone maintains it by hand.
+- The preflight is the fast, sub-second stage of the gate; the scan must stay
+  cheap enough to belong there.
+
+## Touched Surfaces
+
+- `scripts/check_release_preflight.py`
+- `scripts/check_release_authorization.py` (accept the acknowledgement in
+  exact-environment matching)
+- `scripts/tests/test_release_preflight.py`
+
+## Approach
+
+The guard already supports the superset feed through `--require-env-patterns`;
+the publish workflow passes it and nothing else ever did. The check is
+unchanged - only its timing is. `check_sensitive_pattern_parity` runs the same
+command the workflow runs, at preflight, where a refusal costs nothing.
+
+Three outcomes, all explicit:
+
+- feed present and the tree is clean: `verified`.
+- feed present and the tree matches: hard failure, quoting the guard's own line.
+- feed absent: hard failure, unless `FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED`
+  is set, in which case the result string says `UNVERIFIED` and instructs that
+  it be recorded in the release authorization.
+
+The acknowledgement is added to the authorization checker's optional-environment
+set so a release that used it still matches the recorded command exactly. This
+mirrors `FORWARD_NETBOX_UPGRADE_FROM_VERSION`, which is already carried in the
+evidence rather than hidden.
+
+## Validation
+
+`scripts/tests` covers all four branches: refused without the feed, allowed and
+labelled with the acknowledgement, refused when the scan matches, and verified
+when it does not - the last asserting that the command actually carries
+`--require-env-patterns` and `--protected-history`, so the check cannot decay
+into a weaker scan.
+
+## Rollback
+
+Revert. The scan returns to running only in the publish workflow, and a customer
+identifier again costs a version number instead of a preflight second.
+
+## Decision Log
+
+- **Move the existing scan rather than replicate the feed.** Mirroring the
+  secret into the repository, or committing a digest of it, both put customer
+  names closer to the tree. The feed stays where it is; the scan comes earlier.
+- **Fail closed when parity cannot be checked.** The alternative - passing
+  silently when the feed is absent - is the exact behaviour that spent
+  `v2.7.7`, since every local run was in that state and none of them said so.
+- **Allow an explicit acknowledgement.** A hard requirement would make this
+  host unable to cut any release at all, since the secret is not available
+  here. A recorded gap is honest and reviewable; an unrecorded one is what we
+  had.
+
+## Open
+
+- The acknowledgement path is the one this host must use, so on this machine the
+  gap is narrowed but not closed: the publish gate remains the first place the
+  superset feed is applied. Closing it fully means giving the release host the
+  feed.

--- a/scripts/check_release_authorization.py
+++ b/scripts/check_release_authorization.py
@@ -177,7 +177,15 @@ URL_VARIABLES = frozenset({"FORWARD_NETBOX_HOST_PORT", "NETBOX_URL"})
 # it is treated like the host-port pair: optional, value-bounded, and visible in
 # the evidence rather than hidden from it.
 UPGRADE_FROM_VARIABLE = "FORWARD_NETBOX_UPGRADE_FROM_VERSION"
-OPTIONAL_ENVIRONMENT_VARIABLES = URL_VARIABLES | {UPGRADE_FROM_VARIABLE}
+# Set when the release-time pattern feed - a repository secret - is not present
+# in the checkout, so the preflight could not run the superset scan before the
+# tag. Recorded in the evidence rather than hidden, exactly like the offline
+# upgrade discovery above.
+PATTERN_PARITY_VARIABLE = "FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED"
+OPTIONAL_ENVIRONMENT_VARIABLES = URL_VARIABLES | {
+    UPGRADE_FROM_VARIABLE,
+    PATTERN_PARITY_VARIABLE,
+}
 
 
 def _environment_matches(

--- a/scripts/check_release_preflight.py
+++ b/scripts/check_release_preflight.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -35,6 +36,10 @@ RUNTIME_VERSION_TEST = (
 )
 PACKAGE_JSON = REPO_ROOT / "package.json"
 NODE_MODULES = REPO_ROOT / "node_modules"
+
+
+PATTERN_FEED_VARIABLE = "FORWARD_SENSITIVE_PATTERNS"
+PATTERN_PARITY_ACKNOWLEDGEMENT = "FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED"
 
 
 class PreflightError(Exception):
@@ -247,6 +252,67 @@ def check_release_plan_evidence_base(version: str) -> str:
     return f"{recorded[:12]} matches {reference}"
 
 
+def check_sensitive_pattern_parity(environment: dict[str, str] | None = None) -> str:
+    """Run the RELEASE-TIME sensitive scan before the tag exists.
+
+    The guard matches against whatever pattern feed it is handed. Locally that
+    is `.sensitive-patterns.local.txt`; the publish workflow additionally
+    supplies `FORWARD_SENSITIVE_PATTERNS`, a repository SECRET that is a strict
+    superset of it. Nothing local could see the difference, so a customer name
+    used as a test fixture passed every local gate and was caught only by the
+    publish workflow - after the tag was pushed and therefore immutable. That
+    spent `v2.7.7`.
+
+    The scan itself is unchanged; only its timing is. Running it here makes the
+    same refusal cost nothing instead of a version number.
+
+    The feed is a secret, so a checkout that does not have it cannot verify
+    parity. That case is not silently tolerated: it fails unless the operator
+    acknowledges it explicitly, and the acknowledgement is meant to be recorded
+    in the release authorization the way the offline upgrade discovery already
+    is - visible in the evidence rather than hidden in someone's shell.
+    """
+    environment = dict(os.environ if environment is None else environment)
+    if not environment.get(PATTERN_FEED_VARIABLE, "").strip():
+        if environment.get(PATTERN_PARITY_ACKNOWLEDGEMENT, "").strip():
+            return (
+                f"UNVERIFIED - {PATTERN_FEED_VARIABLE} is not available in this "
+                f"checkout and {PATTERN_PARITY_ACKNOWLEDGEMENT} was set; the "
+                "release gate will apply the superset feed and can still refuse "
+                "the tag. Record this in the release authorization."
+            )
+        raise PreflightError(
+            f"{PATTERN_FEED_VARIABLE} is not set, so the release-time sensitive "
+            "scan cannot run and this checkout cannot tell whether the tree "
+            "carries customer data the release gate will refuse. That refusal "
+            "happens after the tag is pushed, and a tag is immutable. Export the "
+            f"feed to verify parity, or set {PATTERN_PARITY_ACKNOWLEDGEMENT}=1 to "
+            "proceed with the gap recorded."
+        )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_sensitive_content.py",
+            "--git-files",
+            "--protected-history",
+            "--require-env-patterns",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=environment,
+    )
+    if completed.returncode != 0:
+        detail = (completed.stdout + completed.stderr).strip().splitlines()
+        raise PreflightError(
+            "the release-time sensitive scan refused this tree: "
+            + (detail[-1] if detail else "no output")
+        )
+    return f"verified against {PATTERN_FEED_VARIABLE}"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", action="store_true", help="emit the results as JSON")
@@ -257,6 +323,7 @@ def main() -> int:
         dependencies = check_ui_harness_dependencies()
         advisories = check_dependency_advisories()
         evidence_base = check_release_plan_evidence_base(version)
+        pattern_parity = check_sensitive_pattern_parity()
     except PreflightError as exc:
         print(f"release preflight failed: {exc}", file=sys.stderr)
         return 1
@@ -266,6 +333,7 @@ def main() -> int:
         "ui_harness_dependencies": dependencies,
         "dependency_advisories": advisories,
         "evidence_base_commit": evidence_base,
+        "sensitive_pattern_parity": pattern_parity,
     }
     if arguments.json:
         print(json.dumps(result, sort_keys=True))
@@ -276,6 +344,7 @@ def main() -> int:
         )
         print(f"release preflight passed: {advisories}")
         print(f"release preflight passed: evidence base commit {evidence_base}")
+        print(f"release preflight passed: sensitive pattern parity {pattern_parity}")
     return 0
 
 

--- a/scripts/tests/test_release_preflight.py
+++ b/scripts/tests/test_release_preflight.py
@@ -244,3 +244,56 @@ class EvidenceBaseCommitTest(unittest.TestCase):
                     "records no evidence base commit",
                     preflight.check_release_plan_evidence_base("9.9.9"),
                 )
+
+
+class SensitivePatternParityTest(unittest.TestCase):
+    """The gap that spent v2.7.7.
+
+    The release feed is a repository secret and a strict superset of the local
+    pattern file, so a local run cannot see what the publish gate will refuse.
+    Moving that scan ahead of the tag is only useful if its absence is loud.
+    """
+
+    def test_a_checkout_without_the_feed_is_refused(self):
+        with self.assertRaises(preflight.PreflightError) as caught:
+            preflight.check_sensitive_pattern_parity(environment={})
+
+        message = str(caught.exception)
+        self.assertIn(preflight.PATTERN_FEED_VARIABLE, message)
+        # The reason the timing matters has to survive in the message.
+        self.assertIn("immutable", message)
+
+    def test_an_acknowledged_gap_is_allowed_and_says_so(self):
+        result = preflight.check_sensitive_pattern_parity(
+            environment={preflight.PATTERN_PARITY_ACKNOWLEDGEMENT: "1"}
+        )
+
+        self.assertIn("UNVERIFIED", result)
+        # It must direct the operator to record it, not merely pass quietly.
+        self.assertIn("release authorization", result)
+
+    def test_a_present_feed_runs_the_real_scan_and_refuses_a_match(self):
+        environment = {preflight.PATTERN_FEED_VARIABLE: "definitely-a-customer-name"}
+        with mock.patch.object(preflight.subprocess, "run") as run:
+            run.return_value = mock.Mock(
+                returncode=1,
+                stdout="path:x.py:1: env literal pattern line 1\n",
+                stderr="",
+            )
+            with self.assertRaises(preflight.PreflightError) as caught:
+                preflight.check_sensitive_pattern_parity(environment=environment)
+
+        self.assertIn("refused this tree", str(caught.exception))
+        self.assertIn("env literal pattern", str(caught.exception))
+
+    def test_a_present_feed_that_scans_clean_reports_verified(self):
+        environment = {preflight.PATTERN_FEED_VARIABLE: "definitely-a-customer-name"}
+        with mock.patch.object(preflight.subprocess, "run") as run:
+            run.return_value = mock.Mock(returncode=0, stdout="", stderr="")
+            result = preflight.check_sensitive_pattern_parity(environment=environment)
+
+        self.assertIn("verified", result)
+        # The scan must be the release-time one, superset feed included.
+        arguments = run.call_args.args[0]
+        self.assertIn("--require-env-patterns", arguments)
+        self.assertIn("--protected-history", arguments)


### PR DESCRIPTION
The root cause behind the v2.7.7 burn.

`check_sensitive_content.py` matches against whatever pattern feed it is handed. Locally that is `.sensitive-patterns.local.txt`; the publish workflow additionally supplies `FORWARD_SENSITIVE_PATTERNS`, a repository **secret** that is a strict superset. A customer name used as a test fixture therefore passed every local gate and was caught only at publish — after the tag was pushed, and a tag is immutable.

The scan is unchanged. Only its timing is: the preflight now runs the same command the workflow runs, where a refusal costs a second instead of a version number.

Three explicit outcomes:

| state | result |
|---|---|
| feed present, tree clean | `verified` |
| feed present, tree matches | hard failure, quoting the guard's own line |
| feed absent | hard failure unless `FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED` is set, which reports `UNVERIFIED` and must be recorded in the release authorization |

The acknowledgement joins the authorization checker's optional-environment set so a release that used it still matches its recorded command exactly — the same treatment `FORWARD_NETBOX_UPGRADE_FROM_VERSION` already gets.

Four new tests cover every branch, including asserting the command still carries `--require-env-patterns` and `--protected-history` so it cannot decay into a weaker scan.

- harness: pass
- `scripts/tests`: 306 tests, OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPmp33tVZYDSeuBL4seyw8