### PR TITLE
fix: recognise the pattern-parity acknowledgement in recorded gate commands

### DIFF
--- a/docs/03_Plans/active/2026-08-10-pattern-feed-parity.md
+++ b/docs/03_Plans/active/2026-08-10-pattern-feed-parity.md
@@ -82,3 +82,17 @@ identifier again costs a version number instead of a preflight second.
   gap is narrowed but not closed: the publish gate remains the first place the
   superset feed is applied. Closing it fully means giving the release host the
   feed.
+
+## Follow-up: the acknowledgement had to be allowed as a recorded value
+
+Adding `FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED` to the authorization
+checker's optional-environment set was necessary but not sufficient. Exact
+environment matching runs in two stages: `_rtk_parts` first rejects any
+assignment that `_safe_environment_assignment` does not recognise, and only
+then is the optional set used to filter what must equal the canonical release
+environment. An unrecognised name fails at the first stage, so the whole
+recorded command was discarded and both evidence entries read as placeholders.
+
+The variable is now recognised, and only as the bare affirmative `1`. It is an
+acknowledgement rather than a configuration, so accepting an arbitrary value
+would let it carry state into the recorded command without saying so.

--- a/scripts/check_release_authorization.py
+++ b/scripts/check_release_authorization.py
@@ -130,6 +130,13 @@ def _safe_environment_assignment(assignment: str) -> bool:
         # A release version, and nothing else. This names which published
         # release the upgrade gate seeds from when it cannot ask the index.
         return bool(re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", value))
+    if name == PATTERN_PARITY_VARIABLE:
+        # An acknowledgement, not a configuration. It records that the
+        # release-time pattern feed was absent from the checkout, so the
+        # preflight could not run the superset scan; it changes nothing about
+        # what the gate executed. Only the bare affirmative is accepted, so it
+        # cannot be used to smuggle a value into the recorded command.
+        return value == "1"
     return (name, value) in {
         ("NETBOX_VER", "v4.6.6"),
         ("FORWARD_NETBOX_WORKER_AUTORELOAD", "0"),

--- a/scripts/tests/test_release_authorization.py
+++ b/scripts/tests/test_release_authorization.py
@@ -274,6 +274,32 @@ class ReleaseAuthorizationTest(unittest.TestCase):
                 self._plan(evidence_overrides={"final-tree-full-gate": evidence})
             )
 
+    def test_accepts_the_pattern_parity_acknowledgement(self):
+        # FORWARD_SENSITIVE_PATTERNS is a repository secret, so a checkout
+        # without it cannot run the release-time scan at preflight. The
+        # acknowledgement records that gap in the evidence instead of hiding it,
+        # and must not invalidate the recorded command.
+        evidence = self.VALID_EVIDENCE["final-tree-full-gate"].replace(
+            "rtk env ",
+            "rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 ",
+        )
+        result = release_authorization.check_release_authorization(
+            self._plan(evidence_overrides={"final-tree-full-gate": evidence})
+        )
+
+        self.assertIn("final-tree-full-gate", result["authorized_evidence_ids"])
+
+    def test_rejects_a_pattern_parity_value_other_than_the_bare_affirmative(self):
+        # It is an acknowledgement, not a configuration channel.
+        evidence = self.VALID_EVIDENCE["final-tree-full-gate"].replace(
+            "rtk env ",
+            "rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=whatever ",
+        )
+        with self.assertRaisesRegex(ValueError, "placeholder_evidence"):
+            release_authorization.check_release_authorization(
+                self._plan(evidence_overrides={"final-tree-full-gate": evidence})
+            )
+
     def test_rejects_a_half_declared_host_port_pair(self):
         evidence = self.VALID_EVIDENCE["final-tree-full-gate"].replace(
             "invoke ci`", "FORWARD_NETBOX_HOST_PORT=18080 invoke ci`"


### PR DESCRIPTION
Follow-up to #177, caught while authorizing 2.7.9.

Adding `FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED` to `OPTIONAL_ENVIRONMENT_VARIABLES` was necessary but not sufficient. Exact environment matching runs in two stages: `_rtk_parts` rejects any assignment `_safe_environment_assignment` does not recognise, and only *then* is the optional set used to filter what must equal the canonical release environment. An unrecognised name fails at the first stage, so the entire recorded command was discarded and both evidence entries reported as `placeholder_evidence`.

The variable is recognised now, and only as the bare affirmative `1` — it is an acknowledgement, not a configuration channel, so an arbitrary value must not be able to ride along in the recorded command.

Two tests: the acknowledgement is accepted, and any other value is rejected.

- harness: pass
- `scripts/tests`: 308 tests, OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPmp33tVZYDSeuBL4seyw8