### PR TITLE
release: authorize 2.7.11

### DIFF
--- a/docs/03_Plans/active/2026-08-11-release-2.7.11.md
+++ b/docs/03_Plans/active/2026-08-11-release-2.7.11.md
@@ -1,0 +1,109 @@
+# Release 2.7.11
+
+## Goal
+
+Ship the ownership hold and the out-of-scope absence classification, both driven
+by one customer report against 2.7.9.
+
+## Constraints
+
+- The four version surfaces move in ONE commit. Splitting them reverts the fast
+  baseline from ~6 min to ~15 h.
+- `FORWARD_SENSITIVE_PATTERNS` is not available on this host, so the preflight
+  pattern-parity check is acknowledged rather than verified. The release-time
+  scan still runs fail-closed in the publish workflow.
+- The prior-release anchor stays at `v2.7.9` until the post-release anchor
+  change; the bridge commit after the tag must be documentation-only.
+- The lineage from the recorded bridge to the release commit must hold at
+  least four commits. `v2.7.10` was refused for exactly this and the number
+  is spent; `scripts/check_release_lineage.py` proves it before tagging now.
+
+## Touched Surfaces
+
+- Version: `pyproject.toml`, `forward_netbox/__init__.py`,
+  `forward_netbox/utilities/fast_baseline.py`,
+  `forward_netbox/tests/test_runtime_dependency_check.py`
+- Fix: `forward_netbox/utilities/ownership.py`,
+  `forward_netbox/utilities/scope_reconciliation.py`,
+  `forward_netbox/utilities/vsys_parent.py`,
+  `forward_netbox/utilities/diagnostics.py`
+- UI: `forward_netbox/templates/forward_netbox/forwardsync_scope_reconciliation.html`
+- Commands: `forward_device_name_ambiguity_audit` (new),
+  `forward_device_scope_reconciliation_audit`
+- Docs: three READMEs, `CHANGELOG.md`, and the two feature plans in
+  `docs/03_Plans/active/`
+
+## Approach
+
+Two changes, both described in their own plans
+(`2026-08-11-ambiguous-device-name-hold.md` and this release's classification
+work), plus the mechanical release surfaces.
+
+What is NOT in this release, deliberately: the customer's `ipam.ipaddress`
+ingestion issue. It is `primary-ip-reassignment-blocked` - NetBox refusing to
+move an IP while it is still the previous parent's primary - and it is already
+recorded and skipped, so it neither fails the sync nor wedges the baseline. One
+row in 655. The residual gap is that the record does not name WHICH address, so
+an operator cannot locate it; that is worth an audit command if asked for, and
+was not worth inventing unprompted.
+
+## Validation
+
+`invoke ci` and `invoke artifact-test` against NetBox 4.6.6 with a real
+2.7.9 -> 2.7.11 upgrade, plus `scripts/tests` and the harness check.
+
+## Rollback
+
+The tag cannot be withdrawn. A defect found after publication needs 2.7.12; the
+prior release stays installable from PyPI.
+
+## Decision Log
+
+- **Ship the classification with the fix rather than after it.** The customer
+  reported three symptoms; two are fixed here and the third is correct
+  behaviour that merely looks wrong. Shipping only the fixes would have left him
+  looking at the same 49 devices with the same unexplained label, which reads as
+  the report being ignored.
+- **Classify only when orphans exist.** Forward engineering has objected to
+  call volume, and a converged sync is the common case; it now pays nothing.
+- **Advisory, never fail-closed.** The scope report is what an operator reads
+  before deciding to delete devices. An extra query that cannot answer must not
+  be able to take that report away.
+
+## Supersedes
+
+`v2.7.10` carried this same tree and was tagged, then refused by the publish
+workflow for a three-commit lineage where four are required - the whole tranche
+had been squashed into one commit, removing the control position the rule needs.
+Nothing published, and a tag cannot be reclaimed, so the number is spent and is
+recorded in `UNPUBLISHED_RELEASE_TAGS`. 2.7.11 is that tree with the version
+moved and the lineage restored by landing the version bump as its own reviewed
+pull request.
+
+## Open
+
+- Whether the customer's ownership actually completes is unverifiable from here
+  and has had two wrong hypotheses already. Confirmed only when his next sync
+  shows the job green and drift measuring.
+
+## Release Authorization
+
+- Evidence base commit: `b8d8d9f90c985d7953b4ceb35b3991690604349a`
+
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.7.9 invoke ci` passed on the final 2.7.11 tree with exit status 0: 313 harness tests OK, 70 scenario tests OK, 2047 Django tests OK with 4 skipped, and 1 UI test OK. The upgrade leg seeded under 2.7.9 on NetBox v4.6.5 and upgraded 2.7.9 -> 2.7.11 across NetBox v4.6.5 -> v4.6.6.
+
+  The gated tree is the release tree apart from this authorization record
+  itself, which is Markdown in a single plan file and is appended after the
+  gate by construction.
+
+  `FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1` records that the release-time
+  sensitive-pattern feed is not present on this host, so the preflight parity
+  check acknowledged the gap rather than scanning against it. The same scan
+  runs fail-closed in the publish workflow, which is what refused v2.7.7.
+
+- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke artifact-test` passed with exit status 0 against the installed `forward_netbox-2.7.11-py3-none-any.whl` on NetBox 4.6.6, Branching 1.1.2, Python 3.14, with 7 authenticated menu routes returning 200, all plugin migrations applying cleanly with no drift, and a validated SBOM of 156 components.
+
+The optional evidence ids are not recorded. This release is five customer-
+reported corrections and the root cause behind the last of them; the proof is
+in the gate. The release owner's 2026-07-27 proportionality decision applies;
+see `docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md`.


### PR DESCRIPTION
The 2.7.10 tree, re-versioned, with the release lineage restored.

`v2.7.10` was tagged and refused for a three-commit lineage where four are required; nothing published and the number is spent. #183 landed the version move as its own reviewed pull request, which restores the control position the rule needs. This PR carries the release plan and its authorization record.

Projected lineage from the recorded 2.7.9 bridge:

```
9c3a37b  post-release bridge
d81e238  anchor (#181)
691f67a  fix tranche (#182)
b8d8d9f  version bump + lineage guard (#183)
<this>   release
```

Five commits, with the last two being the production and evidence pair as required. `scripts/check_release_lineage.py` will be run against the merge commit before any tag is pushed.

## Gate

`invoke ci` and `invoke artifact-test` both exit 0 on this tree:

- 313 harness, 70 scenario, 2047 Django (4 skipped), 1 UI
- real upgrade: seeded under 2.7.9 on NetBox 4.6.5, upgraded 2.7.9 → 2.7.11 across 4.6.5 → 4.6.6
- artifact: `forward_netbox-2.7.11-py3-none-any.whl` on NetBox 4.6.6, Branching 1.1.2, Python 3.14, 7 authenticated routes returning 200, migrations clean, SBOM of 156 components