### PR TITLE
release: authorize 2.7.12

### DIFF
--- a/docs/03_Plans/active/2026-08-12-release-2.7.12.md
+++ b/docs/03_Plans/active/2026-08-12-release-2.7.12.md
@@ -1,0 +1,97 @@
+# Release 2.7.12
+
+## Goal
+
+Ship the collection-collapse guard, the corrected hardware-notice
+reconciliation, and acceptance of netbox-dlm 0.8.0.
+
+## Constraints
+
+- The four version surfaces moved together in the production commit. Splitting
+  them reverts the fast baseline from ~6 min to ~15 h.
+- The lineage from the recorded bridge to the release commit must hold at least
+  four commits; `v2.7.10` was refused for exactly this and the number is spent.
+  `scripts/check_release_lineage.py` proves it before tagging.
+- The prior-release anchor stays at `v2.7.11` until the post-release anchor
+  change; the bridge commit after the tag must be documentation-only.
+- `FORWARD_SENSITIVE_PATTERNS` is not on this host, so preflight records the
+  parity gap rather than scanning against the superset feed. The release
+  workflow still applies it and can refuse the tag.
+
+## Touched Surfaces
+
+Landed in the production commit (#187): `utilities/validation.py`,
+`utilities/dlm_notice_audit.py`, `utilities/full_removal_reconciliation.py`,
+`utilities/query_fetch_execution.py`, `jobs.py`, `views.py`, the Scope
+Reconciliation template, the optional-plugin version sites, and
+`scripts/validate_sbom.py`.
+
+This commit adds only this plan and its authorization record.
+
+## Approach
+
+Three changes, each with its own plan:
+`2026-08-12-collection-collapse-guard` behaviour is described in
+`validation.py` itself, `2026-08-11-dlm-hardware-notice-leftovers.md` covers the
+notice reconciliation, and `2026-08-12-accept-netbox-dlm-0.8.0.md` covers the
+plugin version.
+
+What ties them together is one incident. A cancelled Forward collection
+produced a green, processed snapshot that had collected almost nothing; the
+estate read as departed and a deployment lost tens of thousands of objects with
+validation reporting PASSED. The guard closes the hole that let a diff run
+escape every collapse check. The notice work is the same failure in miniature -
+absence read as evidence - and the version acceptance is what the customer had
+already done before any of it.
+
+## Validation
+
+`invoke ci` and `invoke artifact-test`, both exit 0, on the exact tree tagged
+here apart from this authorization record.
+
+## Rollback
+
+The tag cannot be withdrawn. A defect found after publication needs 2.7.13; the
+prior release stays installable from PyPI.
+
+## Decision Log
+
+- **Guard on snapshot collection health, not snapshot state.** The snapshot
+  that caused the incident was `PROCESSED` and green. State says Forward
+  finished processing, not that anything was collected.
+- **Refuse rather than warn.** The alternative to a refused run is a deletion
+  that is only visible after it has happened.
+- **Do not auto-delete hardware notices on inferred ownership.** Reconciliation
+  runs against an authoritative result; the operator-facing cleanup is a button
+  with a confirmation, not a silent sync-path deletion.
+
+## Open
+
+- The 407 devices carrying neither include tag at one deployment are not
+  explained yet, and are not addressed here. They are console servers and SNMP
+  endpoints rather than network devices; separating "Forward has no tag" from
+  "the tag was not applied" needs the device list exported from the UI.
+
+## Release Authorization
+
+- Evidence base commit: `07d0b8ecad10d3729ca6558dd734fe4671358e41`
+
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.7.11 invoke ci` passed on the final 2.7.12 tree with exit status 0: 314 harness tests OK, 70 scenario tests OK, 2058 Django tests OK with 4 skipped, and 1 UI test OK. The upgrade leg seeded under 2.7.11 on NetBox v4.6.5 and upgraded 2.7.11 -> 2.7.12 across NetBox v4.6.5 -> v4.6.6, with netbox-dlm moving 0.7.0 -> 0.8.0 across that upgrade - which is simultaneously the proof that the split between `constraints.txt` and `constraints-upgrade-from.txt` resolves, and a rehearsal of the upgrade a customer had already performed.
+
+  The gated tree is the release tree apart from this authorization record, which
+  is Markdown in a single plan file and is appended after the gate by
+  construction.
+
+  `FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1` records that the release-time
+  sensitive-pattern feed is not present on this host, so the preflight parity
+  check acknowledged the gap rather than scanning against it. That local feed
+  did refuse an earlier revision of this tree - it caught customer snapshot
+  identifiers written into a test comment - and the superset feed still runs
+  fail-closed in the publish workflow.
+
+- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke artifact-test` passed with exit status 0 against the installed `forward_netbox-2.7.12-py3-none-any.whl` on NetBox 4.6.6, Branching 1.1.2, Python 3.14, with 7 authenticated menu routes returning 200, all plugin migrations applying cleanly with no drift, and a validated SBOM of 156 components.
+
+The optional evidence ids are not recorded. This release is one incident's
+corrections plus an optional-plugin version acceptance; the proof is in the
+gate. The release owner's 2026-07-27 proportionality decision applies; see
+`docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md`.


### PR DESCRIPTION
Carries the 2.7.12 release plan and its authorization record. The production content landed in #187.

Projected lineage from the recorded 2.7.11 bridge:

```
087a15c  post-release bridge
92adbbf  anchor (#186)
07d0b8e  collection-collapse guard, notice reconciliation, netbox-dlm 0.8.0 (#187)
<this>   release
```

Four commits, with the last two being the production and evidence pair. `scripts/check_release_lineage.py` is run against the merge commit before any tag is pushed.

## Gate

Both stages exit 0 on this tree:

- 314 harness, 70 scenario, 2058 Django (4 skipped), 1 UI
- real upgrade: seeded under 2.7.11 with netbox-dlm 0.7.0, upgraded to 2.7.12 with 0.8.0 across NetBox 4.6.5 → 4.6.6
- artifact: `forward_netbox-2.7.12-py3-none-any.whl` on NetBox 4.6.6, Branching 1.1.2, Python 3.14, 7 routes returning 200, migrations clean, SBOM of 156 components