### PR TITLE
release: authorize 2.7.13

### DIFF
--- a/docs/03_Plans/active/2026-08-13-release-2.7.13.md
+++ b/docs/03_Plans/active/2026-08-13-release-2.7.13.md
@@ -1,0 +1,89 @@
+# Release 2.7.13
+
+## Goal
+
+Ship the baseline-removal allowlist - the fix for a regression of this
+repository's own making that let a full sync delete devices - and the
+untagged-device ownership split.
+
+## Constraints
+
+- The four version surfaces moved together in the production commit.
+- The lineage from the recorded bridge to the release commit must hold at least
+  four commits; `scripts/check_release_lineage.py` proves it before tagging.
+- The prior-release anchor stays at `v2.7.12` until the post-release anchor
+  change; the bridge commit after the tag must be documentation-only.
+- `FORWARD_SENSITIVE_PATTERNS` is not on this host, so preflight records the
+  parity gap rather than scanning against the superset feed. The release
+  workflow still applies it and can refuse the tag.
+
+## Touched Surfaces
+
+Landed in the production commit (#191):
+`utilities/full_removal_reconciliation.py` (the allowlist),
+`utilities/scope_reconciliation.py` (the ownership split), the Scope
+Reconciliation template, their tests, and the four version surfaces.
+
+This commit adds only this plan and its authorization record.
+
+## Approach
+
+The regression: the removal reconciliation added in 2.7.11 compared every model
+against the promoted baseline with no exclusions, so a full run staged deletion
+for any row absent from the current result - including devices - bypassing the
+operator-gated prune flow unattended. A deployment on 2.7.12 applied 54 such
+deletions in one sync. The fix is a fail-closed allowlist of models the plugin
+solely authors, with tests pinning the negative space: the gated models are
+asserted NOT removed, so the exclusion cannot erode silently.
+
+The split: 407 devices carrying neither include tag while orphans read zero is
+not a contradiction, but neither number was actionable. The panel now separates
+devices this sync created from devices it never claimed.
+
+## Validation
+
+`invoke ci` and `invoke artifact-test`, both exit 0, on the exact tree tagged
+here apart from this authorization record: 314 harness, 70 scenario, 2067
+Django with 4 skipped, 1 UI, and a real 2.7.12 -> 2.7.13 upgrade across NetBox
+4.6.5 -> 4.6.6.
+
+## Rollback
+
+The tag cannot be withdrawn. A defect found after publication needs 2.7.14; the
+prior release stays installable from PyPI - though 2.7.12 carries the
+regression this release removes, so rolling back to it would be wrong.
+
+## Decision Log
+
+- **Allowlist, not denylist, not threshold.** A denylist reproduces the failure
+  for every model added later, and no percentage makes deleting a device
+  without operator review correct.
+- **Ship immediately rather than batching.** 2.7.12 deletes devices on every
+  full run; every day it remains the installed version is exposure.
+
+## Open
+
+- The affected deployment re-syncs its deleted objects from Forward; rows
+  referencing them by id do not come back. Accepted by the operator.
+
+## Release Authorization
+
+- Evidence base commit: `6e3bbb1aa6508a8f370a751cfb90e5f484ba3817`
+
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.7.12 invoke ci` passed on the final 2.7.13 tree with exit status 0: 314 harness tests OK, 70 scenario tests OK, 2067 Django tests OK with 4 skipped, and 1 UI test OK. The upgrade leg seeded under 2.7.12 on NetBox v4.6.5 and upgraded 2.7.12 -> 2.7.13 across NetBox v4.6.5 -> v4.6.6.
+
+  The gated tree is the release tree apart from this authorization record, which
+  is Markdown in a single plan file and is appended after the gate by
+  construction.
+
+  `FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1` records that the release-time
+  sensitive-pattern feed is not present on this host, so the preflight parity
+  check acknowledged the gap rather than scanning against it. The superset feed
+  still runs fail-closed in the publish workflow.
+
+- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke artifact-test` passed with exit status 0 against the installed `forward_netbox-2.7.13-py3-none-any.whl` on NetBox 4.6.6, Branching 1.1.2, Python 3.14, with 7 authenticated menu routes returning 200, all plugin migrations applying cleanly with no drift, and a validated SBOM of 156 components.
+
+The optional evidence ids are not recorded. This release removes a regression of
+this repository's own making; the proof is in the gate and in the negative-space
+tests. The release owner's 2026-07-27 proportionality decision applies; see
+`docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md`.


### PR DESCRIPTION
Carries the 2.7.13 release plan and its authorization record. Production content landed in #191.

Projected lineage from the recorded 2.7.12 bridge: `b9f5b76` → `95efb5e` → `6e3bbb1` → this = 4, with the last two the production/release pair. `check_release_lineage.py` runs against the merge commit before any tag.

Gate: 314 / 70 / 2067 (4 skipped) / 1, both stages exit 0, real 2.7.12 → 2.7.13 upgrade across NetBox 4.6.5 → 4.6.6.