### PR TITLE
fix: retire a departed source key when its device is re-bound under a rename

### DIFF
--- a/docs/03_Plans/active/2026-08-13-retire-renamed-source-keys.md
+++ b/docs/03_Plans/active/2026-08-13-retire-renamed-source-keys.md
@@ -1,0 +1,77 @@
+# Retire a departed source key when its device is re-bound under a rename
+
+## Goal
+
+Stop a Forward-side rename freezing a device's tags permanently. A renamed
+device kept its old identity row, so under the new name every candidate read as
+bound to a different key and the device was held on every run, with no operator
+remedy.
+
+## Constraints
+
+- A binding must never be retired without evidence the old key is genuinely
+  gone from Forward's current result - absence from one mutation's keys is not
+  that evidence, which is precisely the bug.
+- No live set, no retirement: `live_source_keys=None` preserves the hold
+  exactly as it was. Holding is the safe reading when evidence is incomplete.
+- A tie retires nothing. If adoption cannot pick a single candidate, no binding
+  may be deleted on the strength of a guess either.
+- The `(sync, device)` uniqueness constraint means the stale row MUST be
+  deleted in the same locked step as the re-bind, or the re-bind itself raises.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/ownership.py` - `resolve_device_identities` gains
+  `live_source_keys`; the adoption path retires the predecessor row;
+  `reconcile_source_device_tag_claims` and `reconcile_sync_scope_tag_claims`
+  thread the parameter.
+- `forward_netbox/utilities/scope_reconciliation.py` - `tag_backfilled_devices`
+  passes the report's full tag-scope result as the live set.
+- `forward_netbox/tests/test_absent_device_does_not_block_tag_domain.py` - the
+  characterization test that pinned the permanent hold becomes the regression
+  test for the fix, plus three safety pins.
+
+## Approach
+
+The blocking rule asked "is this binding's key in this mutation?", and a
+mutation is one tag's slice of the estate - so a rename was indistinguishable
+from another live device. The right question is "does Forward still report this
+key anywhere?", and `tag_backfilled_devices` already holds the answer: the
+scope report's `_tagged_names` is the full tag-scope result.
+
+A binding whose key is absent from that set is evidence of a rename. It is
+retired at exactly one moment: when its device is about to be re-bound as the
+single free candidate for the name Forward now reports, inside the ownership
+write lock, immediately before the new row is created. Departed keys whose
+devices are not being re-bound stay untouched - this is deliberately NOT a
+general prune of departed identities, which remains unbuilt because a departed
+key with no successor carries no evidence about what its device now is.
+
+The vsys resolution path passes no live set and keeps the hold.
+
+## Validation
+
+Four tests: the rename binds under the new name and the old row is gone; no
+live set means the hold remains (the pre-fix behaviour, kept on purpose); a key
+still present in the live set keeps blocking (two devices, not a rename); and a
+tie retires nothing.
+
+## Rollback
+
+Revert. Renamed devices return to being held forever, which is the defect.
+
+## Decision Log
+
+- **Retire on re-bind, not as a sweep.** A general prune of departed keys was
+  attempted once before and produced dead code; a departed key with no
+  successor name carries no evidence about its device. The rename case is the
+  one place the evidence is complete: the old key is gone from the full result
+  AND its device is the unique match for a name that is present.
+- **Default to the old behaviour.** Every caller that cannot supply the full
+  live set keeps the hold. The fix narrows the hold where evidence exists; it
+  does not weaken it where evidence is absent.
+
+## Open
+
+- The customer's held devices clear on their next scope reconciliation run
+  after upgrading; no operator step.

--- a/forward_netbox/tests/test_absent_device_does_not_block_tag_domain.py
+++ b/forward_netbox/tests/test_absent_device_does_not_block_tag_domain.py
@@ -317,20 +317,22 @@ class AbsentDeviceDoesNotBlockTagDomainTest(TestCase):
         self.assertTrue(ForwardDeviceTagClaim.objects.filter(device=other).exists())
 
 
-class DepartedSourceKeyHoldsForeverTest(AbsentDeviceDoesNotBlockTagDomainTest):
-    """A Forward-side rename freezes the device's tags permanently.
+class DepartedSourceKeyRenameTest(AbsentDeviceDoesNotBlockTagDomainTest):
+    """A Forward-side rename no longer freezes the device's tags permanently.
 
-    `resolve_device_identities` excludes any candidate already bound to a
-    DIFFERENT source key, because the `(sync, device)` uniqueness constraint
-    makes it ineligible. That is right when the other key is a live Forward
-    device and wrong when it is the SAME device's previous name: departed source
-    keys are never pruned, so the old binding outlives the name.
+    A binding blocks resolution only while its key is plausibly live. Judged
+    against the mutation's own keys alone - which is all this did before - a
+    rename was indistinguishable from another live device, so a renamed device
+    was held on every run, forever, with no operator remedy.
 
-    The device is then held on every run - never tagged, never released - and no
-    operator action clears it, because nothing retires the stale identity.
+    With the full live result in hand, a binding whose key Forward no longer
+    reports anywhere is evidence of a rename, and it is retired at the single
+    narrow moment its device is re-bound under the new name. Without the live
+    set (``live_source_keys=None``), every binding stays blocking - holding
+    remains the safe reading when the evidence is incomplete.
     """
 
-    def test_a_renamed_device_is_held_on_every_run(self):
+    def _rename_fixture(self):
         renamed = self._device("new-forward-name")
         ForwardDeviceIdentity.objects.create(
             sync=self.sync,
@@ -339,20 +341,98 @@ class DepartedSourceKeyHoldsForeverTest(AbsentDeviceDoesNotBlockTagDomainTest):
             ingestion_id=self.ingestion.pk,
             snapshot_id=self.ingestion.snapshot_id,
         )
+        return renamed
 
-        first = self._reconcile({"present-device", "new-forward-name"})
-        second = self._reconcile({"present-device", "new-forward-name"})
-
-        # Held both times, and the hold never converges to a claim.
-        self.assertEqual(first["ambiguous_device_names"], 1)
-        self.assertEqual(second["ambiguous_device_names"], 1)
-        self.assertFalse(
-            ForwardDeviceTagClaim.objects.filter(device=renamed).exists(),
-            "the renamed device is never tagged, on any run",
+    def _reconcile_live(self, names, live):
+        return reconcile_source_device_tag_claims(
+            self.sync,
+            names,
+            slug=SLUG,
+            name="S.Example",
+            color="9e9e9e",
+            description="",
+            claim_type="scope",
+            generation=self.ingestion.pk,
+            snapshot_id=self.ingestion.snapshot_id,
+            live_source_keys=live,
         )
+
+    def test_a_renamed_device_binds_under_its_new_name(self):
+        renamed = self._rename_fixture()
+        live = {"present-device", "new-forward-name"}
+
+        result = self._reconcile_live(live, live)
+
+        self.assertEqual(result["ambiguous_device_names"], 0)
+        self.assertTrue(
+            ForwardDeviceTagClaim.objects.filter(device=renamed).exists(),
+            "the renamed device was not tagged under its new name",
+        )
+        self.assertFalse(
+            ForwardDeviceIdentity.objects.filter(
+                sync=self.sync, source_device_key="old-forward-name"
+            ).exists(),
+            "the stale binding was not retired",
+        )
+        self.assertTrue(
+            ForwardDeviceIdentity.objects.filter(
+                sync=self.sync,
+                source_device_key="new-forward-name",
+                device=renamed,
+            ).exists(),
+            "no binding exists under the name Forward now reports",
+        )
+
+    def test_without_the_live_set_the_hold_remains(self):
+        # None means the caller cannot vouch for the full result, and holding
+        # is the safe reading. This is the pre-fix behaviour, kept on purpose.
+        renamed = self._rename_fixture()
+
+        result = self._reconcile({"present-device", "new-forward-name"})
+
+        self.assertEqual(result["ambiguous_device_names"], 1)
+        self.assertFalse(ForwardDeviceTagClaim.objects.filter(device=renamed).exists())
         self.assertTrue(
             ForwardDeviceIdentity.objects.filter(
                 sync=self.sync, source_device_key="old-forward-name"
             ).exists(),
-            "the stale binding survives, which is what keeps the hold alive",
+            "a binding must never be retired without the live evidence",
         )
+
+    def test_a_binding_whose_key_is_still_live_keeps_blocking(self):
+        # The old key is still in the live set: this is NOT a rename, it is two
+        # Forward devices, and resolving the new name onto the bound device
+        # would steal it. The hold is correct here and must survive the fix.
+        renamed = self._rename_fixture()
+        live = {"present-device", "new-forward-name", "old-forward-name"}
+
+        result = self._reconcile_live({"present-device", "new-forward-name"}, live)
+
+        self.assertEqual(result["ambiguous_device_names"], 1)
+        self.assertFalse(ForwardDeviceTagClaim.objects.filter(device=renamed).exists())
+        self.assertTrue(
+            ForwardDeviceIdentity.objects.filter(
+                sync=self.sync, source_device_key="old-forward-name"
+            ).exists()
+        )
+
+    def test_retirement_never_happens_on_a_tie(self):
+        # Two free candidates for the new name: adoption cannot pick one, so
+        # no binding may be retired on the strength of a guess either.
+        renamed = self._rename_fixture()
+        second_site = Site.objects.create(
+            name="rename-twin-site", slug="rename-twin-site"
+        )
+        self._device("new-forward-name", site=second_site)
+        live = {"present-device", "new-forward-name"}
+
+        result = self._reconcile_live(live, live)
+
+        self.assertEqual(result["ambiguous_device_names"], 1)
+        self.assertTrue(
+            ForwardDeviceIdentity.objects.filter(
+                sync=self.sync, source_device_key="old-forward-name"
+            ).exists(),
+            "a tie must hold everything, including the stale binding",
+        )
+        self.assertFalse(ForwardDeviceTagClaim.objects.filter(device=renamed).exists())

--- a/forward_netbox/tests/test_absent_device_does_not_block_tag_domain.py
+++ b/forward_netbox/tests/test_absent_device_does_not_block_tag_domain.py
@@ -315,3 +315,44 @@ class AbsentDeviceDoesNotBlockTagDomainTest(TestCase):
         self.assertEqual(result["skipped_absent_devices"], 0)
         self.assertEqual(result["total"], 2)
         self.assertTrue(ForwardDeviceTagClaim.objects.filter(device=other).exists())
+
+
+class DepartedSourceKeyHoldsForeverTest(AbsentDeviceDoesNotBlockTagDomainTest):
+    """A Forward-side rename freezes the device's tags permanently.
+
+    `resolve_device_identities` excludes any candidate already bound to a
+    DIFFERENT source key, because the `(sync, device)` uniqueness constraint
+    makes it ineligible. That is right when the other key is a live Forward
+    device and wrong when it is the SAME device's previous name: departed source
+    keys are never pruned, so the old binding outlives the name.
+
+    The device is then held on every run - never tagged, never released - and no
+    operator action clears it, because nothing retires the stale identity.
+    """
+
+    def test_a_renamed_device_is_held_on_every_run(self):
+        renamed = self._device("new-forward-name")
+        ForwardDeviceIdentity.objects.create(
+            sync=self.sync,
+            source_device_key="old-forward-name",
+            device=renamed,
+            ingestion_id=self.ingestion.pk,
+            snapshot_id=self.ingestion.snapshot_id,
+        )
+
+        first = self._reconcile({"present-device", "new-forward-name"})
+        second = self._reconcile({"present-device", "new-forward-name"})
+
+        # Held both times, and the hold never converges to a claim.
+        self.assertEqual(first["ambiguous_device_names"], 1)
+        self.assertEqual(second["ambiguous_device_names"], 1)
+        self.assertFalse(
+            ForwardDeviceTagClaim.objects.filter(device=renamed).exists(),
+            "the renamed device is never tagged, on any run",
+        )
+        self.assertTrue(
+            ForwardDeviceIdentity.objects.filter(
+                sync=self.sync, source_device_key="old-forward-name"
+            ).exists(),
+            "the stale binding survives, which is what keeps the hold alive",
+        )

--- a/forward_netbox/utilities/ownership.py
+++ b/forward_netbox/utilities/ownership.py
@@ -173,13 +173,32 @@ def finalize_device_identities_locked(ingestion):
     return len(desired)
 
 
-def resolve_device_identities(sync, source_device_keys, *, generation, snapshot_id):
+def resolve_device_identities(
+    sync,
+    source_device_keys,
+    *,
+    generation,
+    snapshot_id,
+    live_source_keys=None,
+):
     """Resolve exact device PKs and persist globally unique pre-identity rows.
 
     Returns ``(identities, missing, ambiguous, ambiguous_device_ids)``. The
     fourth value maps each ambiguous name to the device PKs that tie for it,
     which callers need in order to hold those devices rather than act on a
     guess - see `reconcile_source_device_tag_claims`.
+
+    ``live_source_keys``, when provided, is the FULL set of device names the
+    current Forward result reports - not merely the names in this mutation.
+    It exists to break a permanent hold: a device whose Forward name changed
+    keeps its old identity row (departed source keys are never pruned), so
+    under the new name every candidate reads as bound to a different key and
+    the device is held on every run, forever, with no operator remedy. With
+    the live set in hand, a binding whose key Forward no longer reports at all
+    is evidence of a RENAME rather than of another live device, and the stale
+    binding is retired so the new name can bind. ``None`` means the caller
+    cannot vouch for the full set, and every binding stays blocking - holding
+    is the safe reading when the evidence is incomplete.
     """
     from dcim.models import Device
 
@@ -207,12 +226,26 @@ def resolve_device_identities(sync, source_device_keys, *, generation, snapshot_
     # name where one is already spoken for is the common shape, because NetBox
     # scopes device-name uniqueness to the site, so a device that moves site or
     # is re-created alongside its predecessor leaves exactly this pair.
+    #
+    # A binding blocks only while its key is plausibly LIVE. Judged against the
+    # mutation's own keys alone - which is all this did before - a rename is
+    # indistinguishable from another live device, which is how a renamed device
+    # came to be held permanently.
     tied_ids = {device_id for values in candidates.values() for device_id in values}
-    claimed_elsewhere = set(
-        ForwardDeviceIdentity.objects.filter(sync=sync, device_id__in=tied_ids)
-        .exclude(source_device_key__in=keys)
-        .values_list("device_id", flat=True)
-    )
+    claimed_elsewhere = set()
+    stale_binding_by_device = {}
+    for device_id, bound_key in ForwardDeviceIdentity.objects.filter(
+        sync=sync, device_id__in=tied_ids
+    ).values_list("device_id", "source_device_key"):
+        if bound_key in keys:
+            continue
+        if live_source_keys is not None and bound_key not in live_source_keys:
+            # Forward no longer reports this key anywhere in the current
+            # result: the binding outlived its name. Eligible for retirement
+            # if its device becomes the single adoptable candidate below.
+            stale_binding_by_device[device_id] = bound_key
+            continue
+        claimed_elsewhere.add(device_id)
     free = {
         key: [device_id for device_id in values if device_id not in claimed_elsewhere]
         for key, values in candidates.items()
@@ -238,6 +271,20 @@ def resolve_device_identities(sync, source_device_keys, *, generation, snapshot_
     if adoptable:
         with ownership_write_lock():
             for source_key, device_id in adoptable.items():
+                # A rename retires its predecessor row here, and ONLY here: the
+                # `(sync, device)` uniqueness constraint would otherwise refuse
+                # the new binding outright. This is the single narrow place a
+                # departed source key is pruned - when its device is about to be
+                # re-bound under the name Forward now reports, on the evidence
+                # of the full live result. Departed keys whose devices are not
+                # being re-bound stay exactly as they were.
+                stale_key = stale_binding_by_device.get(device_id)
+                if stale_key is not None:
+                    ForwardDeviceIdentity.objects.filter(
+                        sync=sync,
+                        source_device_key=stale_key,
+                        device_id=device_id,
+                    ).delete()
                 ForwardDeviceIdentity.objects.update_or_create(
                     sync=sync,
                     source_device_key=source_key,
@@ -888,8 +935,14 @@ def reconcile_source_device_tag_claims(
     snapshot_id=None,
     mark_domain=True,
     materialize=True,
+    live_source_keys=None,
 ):
-    """Replace this sync's claims for one managed tag from exact snapshot data."""
+    """Replace this sync's claims for one managed tag from exact snapshot data.
+
+    ``live_source_keys`` is the full set of device names the current Forward
+    result reports, when the caller has it; see `resolve_device_identities` for
+    what it unlocks and why ``None`` stays safe.
+    """
     from extras.models import Tag
 
     from ..models import ForwardDeviceTagClaim
@@ -900,6 +953,7 @@ def reconcile_source_device_tag_claims(
         device_names,
         generation=generation,
         snapshot_id=snapshot_id,
+        live_source_keys=live_source_keys,
     )
     # A name Forward reports that NetBox does not have is SKIPPED, not fatal.
     #
@@ -1160,7 +1214,12 @@ def finalize_device_tag_domain(
 
 
 def reconcile_sync_scope_tag_claims(
-    sync, matched_tags_by_device, *, generation, snapshot_id
+    sync,
+    matched_tags_by_device,
+    *,
+    generation,
+    snapshot_id,
+    live_source_keys=None,
 ):
     """Replace every configured managed-scope tag claim for one sync generation."""
     from ..models import ForwardDeviceTagClaim
@@ -1228,6 +1287,7 @@ def reconcile_sync_scope_tag_claims(
                 snapshot_id=snapshot_id,
                 mark_domain=False,
                 materialize=False,
+                live_source_keys=live_source_keys,
             )
             added += result["claims_added"]
             released += result["claims_released"]

--- a/forward_netbox/utilities/scope_reconciliation.py
+++ b/forward_netbox/utilities/scope_reconciliation.py
@@ -802,6 +802,7 @@ def _apply_maintained_device_tag(
     snapshot_id,
     mark_domain=True,
     materialize=True,
+    live_source_keys=None,
 ):
     """Reconcile one sync generation's claims for a maintained status tag."""
     from .ownership import reconcile_source_device_tag_claims
@@ -818,6 +819,7 @@ def _apply_maintained_device_tag(
         snapshot_id=snapshot_id,
         mark_domain=mark_domain,
         materialize=materialize,
+        live_source_keys=live_source_keys,
     )
     # `_ambiguous_names` carries device names. It is dropped here rather than
     # relied on to go unread: this dict is spread into a job payload, and a
@@ -858,6 +860,10 @@ def tag_backfilled_devices(
         snapshot_id,
         ingestion_id=ingestion_id,
     ) as generation:
+        # The full tag-scope result. It is what makes stale-binding retirement
+        # safe: a key absent from THIS set is absent from everything Forward
+        # currently reports under these tags, not merely from one tag's slice.
+        live_source_keys = report["_tagged_names"]
         backfilled = _apply_maintained_device_tag(
             sync,
             report["_present_backfilled"],
@@ -870,6 +876,7 @@ def tag_backfilled_devices(
             snapshot_id=generation["snapshot_id"],
             mark_domain=False,
             materialize=False,
+            live_source_keys=live_source_keys,
         )
         out_of_scope = _apply_maintained_device_tag(
             sync,
@@ -883,6 +890,7 @@ def tag_backfilled_devices(
             snapshot_id=generation["snapshot_id"],
             mark_domain=False,
             materialize=False,
+            live_source_keys=live_source_keys,
         )
         source_parameters = getattr(sync.source, "parameters", None) or {}
         managed_scope_cleanup = {
@@ -917,6 +925,7 @@ def tag_backfilled_devices(
                 ),
                 generation=generation["generation"],
                 snapshot_id=generation["snapshot_id"],
+                live_source_keys=live_source_keys,
             )
         from .ownership import finalize_device_tag_domain
 


### PR DESCRIPTION
A device whose Forward name changed kept its old identity row, so under the new name every candidate read as bound to a different key and the device was **held on every run** — never tagged, never released, no operator remedy. The blocking rule asked *"is this binding's key in this mutation?"*, and a mutation is one tag's slice of the estate, so a rename was indistinguishable from another live device.

The right question is *"does Forward still report this key anywhere?"*, and the scope report already holds the answer (`_tagged_names`, the full tag-scope result — no new Forward call). A binding whose key is absent from it is evidence of a rename, retired at exactly one moment: when its device is about to be re-bound as the single free candidate for the name Forward now reports, inside the write lock, delete-then-bind — an ordering the `(sync, device)` uniqueness constraint makes mandatory.

Safety properties, each pinned by a test:

- **no live set → no retirement** — callers that cannot vouch for the full result (the vsys path) keep the hold unchanged
- **key still live → still blocks** — two devices, not a rename; resolving would steal the bound one
- **a tie retires nothing** — adoption cannot pick a candidate, so deletion does not guess either

Deliberately NOT a general prune of departed identities: a departed key with no successor carries no evidence about what its device now is. That version of this task produced dead code once before; the rename case is the one place the evidence is complete.

Full suite: 2085 tests OK (4 skipped). Harness passed, scripts suite 314 OK.