### PR TITLE
fix: stop a wrapped template comment rendering as visible text

### DIFF
--- a/docs/03_Plans/active/2026-08-13-template-comment-leak.md
+++ b/docs/03_Plans/active/2026-08-13-template-comment-leak.md
@@ -1,0 +1,68 @@
+# Stop a multi-line template comment rendering as visible text
+
+## Goal
+
+Remove explanatory notes that Django emitted verbatim into the Scope
+Reconciliation panel and the ingestion merge button, and make the mistake
+impossible to repeat.
+
+## Constraints
+
+- The fix must not change any rendered output other than removing the leaked
+  text.
+- The guard has to run somewhere that fails a change before it ships. The full
+  suite passed with the comment on screen, so a test asserting the page renders
+  is not sufficient.
+
+## Touched Surfaces
+
+- `forward_netbox/templates/forward_netbox/forwardsync_scope_reconciliation.html`
+- `forward_netbox/templates/forward_netbox/partials/ingestion_merge_button.html`
+- `scripts/check_harness.py` - `_check_template_comments_are_parseable`
+- `scripts/tests/test_check_harness.py`
+
+## Approach
+
+Django's `{# #}` comment syntax is single-line only. A comment broken across two
+lines is not parsed as a comment; the engine emits it as literal text. Both
+offenders were written as wrapped prose, which is exactly the shape that trips
+it - a short comment stays on one line and works, and a considered one wraps and
+leaks.
+
+A customer screenshot of the panel showed the note about absence classification
+rendered as body copy beside the badge it was explaining. The other instance, in
+the merge button partial, predates this work and had been leaking unnoticed.
+
+Both become `{% comment %}...{% endcomment %}`, which is multi-line by design.
+
+The guard is a harness check rather than a rendering test. Nothing about the
+page was broken: the template rendered, the view returned 200, and 2085 tests
+passed with the text on screen. Only reading the output catches it, and no test
+reads the output looking for template syntax. A lint over the template source is
+cheap, exact, and fails before review.
+
+## Validation
+
+`scripts/check_harness.py` reports both offenders before the fix and none after;
+tests in `scripts/tests/test_check_harness.py` pin that a wrapped comment is
+reported and a single-line one is not.
+
+The scan looks at the LAST `{#` on a line, not the first. Splitting on the first
+lets a closed comment vouch for an unclosed one beside it - `{# a #} {# b` would
+pass - which is a hole in a guard whose whole value is having none.
+
+## Rollback
+
+Revert. The notes leak again and the guard stops running.
+
+## Decision Log
+
+- **Harness check, not a template test.** The defect is invisible to every
+  signal the suite already produces; the only reliable detector is the source
+  itself.
+- **Keep the comments rather than delete them.** They explain why the badges
+  exist, which is worth more than the two lines cost.
+
+## Open
+
+- Nothing. Both instances are fixed and the class is now guarded.

--- a/forward_netbox/templates/forward_netbox/forwardsync_scope_reconciliation.html
+++ b/forward_netbox/templates/forward_netbox/forwardsync_scope_reconciliation.html
@@ -156,8 +156,8 @@
       <div class="card-body">
         {% if payload.out_of_scope_sample %}
           {% if payload.out_of_scope_absence.available %}
-            {# Which kind of absence, because all three look identical here and
-               only one of them means the device really left. #}
+            {% comment %} Which kind of absence, because all three look identical here and
+               only one of them means the device really left. {% endcomment %}
             <p class="mb-2">
               {% if payload.out_of_scope_absence.absent_from_snapshot %}
                 <span class="badge text-bg-secondary">{% blocktrans count counter=payload.out_of_scope_absence.absent_from_snapshot %}{{ counter }} gone from Forward{% plural %}{{ counter }} gone from Forward{% endblocktrans %}</span>

--- a/forward_netbox/templates/forward_netbox/partials/ingestion_merge_button.html
+++ b/forward_netbox/templates/forward_netbox/partials/ingestion_merge_button.html
@@ -19,10 +19,10 @@
 {% endif %}
 
 {% if perms.forward_netbox.merge_forwardingestion and object.can_accept_merge_failures %}
-  {# A failed row returns the branch to READY without attesting, so the baseline
+  {% comment %} A failed row returns the branch to READY without attesting, so the baseline
      never promotes and every retry hits the same rows. When the failure is
      deterministic that is a dead end, and this is the way out. Separate button,
-     separate confirmation: it must never be reachable by clicking Merge twice. #}
+     separate confirmation: it must never be reachable by clicking Merge twice. {% endcomment %}
   <form method="post"
         action="{% url 'plugins:forward_netbox:forwardingestion_accept_failures' pk=object.pk %}"
         class="d-inline"

--- a/scripts/check_harness.py
+++ b/scripts/check_harness.py
@@ -229,6 +229,37 @@ def _check_agents_entrypoint(failures: list[str]) -> None:
         )
 
 
+def _check_template_comments_are_parseable(failures: list[str]) -> None:
+    """Refuse a `{# #}` comment that spans lines - Django renders it verbatim.
+
+    Django's `{# #}` comment syntax is SINGLE-LINE ONLY. A comment broken across
+    two lines is not parsed as a comment at all, so the template engine emits it
+    as literal text into the page. Two of these reached a customer's Scope
+    Reconciliation panel, where an explanatory note about absence classification
+    rendered as visible body copy next to the badge it was explaining.
+
+    Nothing else catches it: the template renders, the view returns 200, and the
+    full suite passes with the comment on screen. Use
+    `{% comment %}...{% endcomment %}` for anything multi-line.
+    """
+    template_root = REPO_ROOT / "forward_netbox" / "templates"
+    if not template_root.is_dir():
+        return
+    for path in sorted(template_root.rglob("*.html")):
+        for number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            if "{#" not in line:
+                continue
+            if "#}" in line.rsplit("{#", 1)[1]:
+                continue
+            failures.append(
+                f"{path.relative_to(REPO_ROOT)}:{number}: a `{{# #}}` comment "
+                "must close on the same line or Django renders it as visible "
+                "text; use `{% comment %}` for multi-line notes"
+            )
+
+
 def _check_knowledge_freshness(
     failures: list[str],
     *,
@@ -1034,6 +1065,7 @@ def main() -> int:
     _check_post_release_bridge_is_documentation_only(failures)
     _check_standard_release_tag_flow(failures)
     _check_publish_gate_placement(failures)
+    _check_template_comments_are_parseable(failures)
     if args.base:
         _check_per_commit_plan_lifecycle(failures, args.base)
 

--- a/scripts/tests/test_check_harness.py
+++ b/scripts/tests/test_check_harness.py
@@ -914,3 +914,65 @@ class PostReleaseBridgeIsDocumentationOnlyTest(unittest.TestCase):
 
         self.assertEqual(len(failures), 1)
         self.assertIn("PRIOR_POST_RELEASE_DOC_COMMIT", failures[0])
+
+
+class TemplateCommentsAreParseableTest(unittest.TestCase):
+    """A `{# #}` comment that wraps is not a comment - Django prints it.
+
+    Two of these reached a customer's UI, one of them in a panel shipped the day
+    before. Nothing in the suite could see it: the template rendered, the view
+    returned 200, and 2085 tests passed with the text on screen.
+    """
+
+    def _failures(self, template_body):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            template_dir = root / "forward_netbox" / "templates" / "forward_netbox"
+            template_dir.mkdir(parents=True)
+            (template_dir / "page.html").write_text(template_body, encoding="utf-8")
+            original = check_harness.REPO_ROOT
+            check_harness.REPO_ROOT = root
+            try:
+                failures = []
+                check_harness._check_template_comments_are_parseable(failures)
+                return failures
+            finally:
+                check_harness.REPO_ROOT = original
+
+    def test_a_wrapped_comment_is_reported(self):
+        failures = self._failures(
+            "<div>\n  {# this explanation is long enough that it\n"
+            "     wrapped onto a second line #}\n  <p>body</p>\n</div>\n"
+        )
+
+        self.assertEqual(len(failures), 1)
+        self.assertIn("page.html:2", failures[0])
+        self.assertIn("comment", failures[0])
+
+    def test_a_single_line_comment_is_accepted(self):
+        failures = self._failures("<div>\n  {# short and closed #}\n</div>\n")
+
+        self.assertEqual(failures, [])
+
+    def test_a_comment_block_is_accepted(self):
+        failures = self._failures(
+            "<div>\n  {% comment %}\n  wrapped prose is fine here\n"
+            "  {% endcomment %}\n</div>\n"
+        )
+
+        self.assertEqual(failures, [])
+
+    def test_a_second_comment_on_the_line_is_still_checked(self):
+        """The closed one must not vouch for the open one beside it."""
+        failures = self._failures(
+            "<div>\n  {# closed #} {# but this one runs on\n"
+            "     to the next line #}\n</div>\n"
+        )
+
+        self.assertEqual(len(failures), 1)
+        self.assertIn("page.html:2", failures[0])
+
+    def test_a_template_with_no_comments_is_accepted(self):
+        failures = self._failures("<div><p>body</p></div>\n")
+
+        self.assertEqual(failures, [])


### PR DESCRIPTION
## What

Django's `{# #}` comment syntax is **single-line only**. A comment broken across two lines is not parsed as a comment at all — the engine emits it as literal text into the page.

Two instances were leaking:

- `forwardsync_scope_reconciliation.html` — a note about absence classification, rendered as body copy beside the badge it was explaining. Visible in a customer screenshot of 2.7.13.
- `partials/ingestion_merge_button.html` — predates this work, leaking unnoticed.

Both become `{% comment %}`, which is multi-line by design.

## Why a harness check and not a test

Nothing about the page was broken. The template rendered, the view returned 200, and the full suite passed with the text on screen. Only *reading* the output catches it, and no test reads the output looking for template syntax.

`_check_template_comments_are_parseable` lints the template source instead. It inspects the **last** `{#` on a line rather than the first, so a closed comment cannot vouch for an unclosed one beside it (`{# a #} {# b`).

## Validation

- `scripts/check_harness.py` reports both offenders before the fix, none after
- `Ran 319 tests ... OK` (scripts suite, +5 new)
- `pre-commit run --all-files` clean

Plan: `docs/03_Plans/active/2026-08-13-template-comment-leak.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szq9We9tRZAoSU2L8LjyQN