### PR TITLE
feat: support netbox-dlm 0.9.1

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -8,7 +8,7 @@
 cryptography==50.0.0
 httpx==0.28.1
 netbox-cisco-aci==0.4.0
-netbox-dlm==0.8.0
+netbox-dlm==0.9.1
 netboxlabs-netbox-branching==1.1.2
 netbox-peering-manager==0.3.0
 netbox-routing==0.4.3

--- a/development/constraints-upgrade-from.txt
+++ b/development/constraints-upgrade-from.txt
@@ -17,15 +17,15 @@
 #
 # `netbox-dlm` is pinned here but NOT to the same version as `constraints.txt`,
 # for the same underlying reason. When a release widens the supported range of
-# an optional plugin, the previous release still caps it: 2.7.11 declares
-# `netbox-dlm >=0.4.1,<0.8.0`, so constraining its install to 0.8.0 is
+# an optional plugin, the previous release still caps it: 2.7.13 declares
+# `netbox-dlm >=0.4.1,<0.9.0`, so constraining its install to 0.9.1 is
 # unsatisfiable rather than merely old. This side therefore holds the newest
 # version the FROM release supports, and the upgrade exercises the plugin
 # version moving with the upgrade - which is what a customer actually does.
 cryptography==50.0.0
 httpx==0.28.1
 netbox-cisco-aci==0.4.0
-netbox-dlm==0.7.0
+netbox-dlm==0.8.0
 netbox-peering-manager==0.3.0
 netbox-routing==0.4.3
 pyzipper==0.4.0

--- a/docs/03_Plans/active/2026-08-14-netbox-dlm-0-9-1.md
+++ b/docs/03_Plans/active/2026-08-14-netbox-dlm-0-9-1.md
@@ -1,0 +1,121 @@
+# Move the optional netbox-dlm pin to 0.9.1
+
+## Goal
+
+Support netbox-dlm 0.9.1 across every gate that reads an optional-plugin
+version, so a customer who upgrades the plugin keeps the fast baseline, the
+set-based merge and the COPY/SQL path instead of silently dropping to the slow
+paths.
+
+## Why
+
+Blake released 0.9.1 on 2026-08-14. We pinned 0.8.0. Every runtime gate in this
+plugin compares the installed optional-plugin version against an explicit
+validated set and fails closed, so until 0.9.1 is in those sets an upgrade is
+not merely unsupported - it turns off the fast baseline with no error an
+operator can see, which is the failure this repo has already been bitten by
+once.
+
+## Constraints
+
+- The validated sets are additive and fail closed. Widening them is a claim
+  that a version was inspected, so each addition needs a stated reason.
+- Both of `registry.py`'s version fields move together, and
+  `constraints-upgrade-from.txt` must stay one release behind in lockstep -
+  the FROM side has to hold the newest version the FROM release supports, or
+  the upgrade gate is unsatisfiable rather than merely old.
+- No production behaviour changes here. This is a pin move; the only way it can
+  be wrong is by admitting a version that breaks the adapter.
+
+## Approach
+
+### Is 0.9.1 safe for the surface we bind to
+
+Yes, and the check is the same schema-delta inspection used to admit 0.5.0.
+The `models.py` delta from 0.8.0 to 0.9.1 is entirely direct model imports
+becoming lazy string references - `to=Platform` becomes `to='dcim.Platform'`
+and so on for Device, DeviceType, ModuleType, InventoryItemRole. Django
+resolves both forms to the same model and neither generates a migration. No
+field, model, or constraint changed. `SoftwareVersion.platform`, `.version`,
+`.alias`, the `(platform, version)` coalesce key, `DeviceSoftware.device` and
+`.software_version` are all untouched.
+
+The rest of the release is `urls.py`, `views.py`, `navigation.py` and
+`filtersets.py` - his own UI, which we do not consume.
+
+### What 0.9.1 changes about the runtime, which is not nothing
+
+- `min_version` 4.1.0 -> 4.5.0. Below our own 4.6.5 floor, so no effect.
+- **`max_version = "4.6.99"` is new.** It matches ours exactly, so there is no
+  conflict today. It does mean netbox-dlm now moves in lockstep with us on the
+  NetBox ceiling rather than trailing it, and whichever of us raises the
+  ceiling first will be blocked by the other.
+- `requires-python` 3.10 -> 3.12. Below the 3.14 the container runs.
+- An entry point `[project.entry-points."netbox.plugins"]` is now declared.
+
+### The python marker is the part that is easy to miss
+
+Without it, `poetry update netbox-dlm --lock` resolves to **0.8.0 and reports
+success**. Our project declares `python = ">=3.10,<3.15"`, so poetry has to
+satisfy this dependency down to 3.10, and 0.9.1 requires 3.12. The three
+sibling optional plugins already carry exactly this marker for exactly this
+reason; netbox-dlm did not need one until 0.9.1 raised its floor.
+
+This was observed, not predicted: the first re-lock produced 0.8.0 with a clean
+exit code and a "Writing lock file" line.
+
+### 0.9.0 is deliberately skipped
+
+0.9.0 shipped roughly half an hour before 0.9.1 with a NoReverseMatch on every
+one of its view URLs; 0.9.1 is that fix. It is excluded from every validated
+set and a test pins its exclusion, so widening to 0.9.1 cannot sweep it in.
+
+## Touched Surfaces
+
+- `pyproject.toml` - range widened to `<0.10.0`, **and** a
+  `python = ">=3.12,<3.15"` marker added
+- `poetry.lock`
+- `constraints.txt` - 0.9.1
+- `development/constraints-upgrade-from.txt` - 0.8.0, being the newest version
+  the FROM release (2.7.13, which declares `<0.9.0`) supports
+- `forward_netbox/utilities/plugin_integrations/registry.py` - both version
+  fields, `required_package_version` and `supported_package_versions`
+- `forward_netbox/utilities/fast_baseline.py`
+- `forward_netbox/utilities/merge_set_based.py`
+- `forward_netbox/utilities/apply_engine_decision.py`
+- `scripts/validate_sbom.py`, `tasks.py`
+- tests
+
+## Validation
+
+- `test_optional_plugin_versions` asserts 0.9.1 is in every gate's set and that
+  0.9.0 is not.
+- `test_plugin_integrations` asserts the registry reports 0.9.1 as required and
+  lists it as supported.
+- `scripts/tests` covers the constraints/upgrade-from invariant.
+- The full Django suite, run against 0.9.1 actually installed, is what proves
+  the DLM adapter still round-trips. The version sets are only a gate; they do
+  not exercise a single write.
+
+## Rollback
+
+Revert. The pin returns to 0.8.0 and the gates refuse 0.9.1 again, which is the
+fail-closed direction.
+
+## Decision Log
+
+- **Skip 0.9.0.** It cannot render any of its own views. Admitting a version we
+  know is broken to keep the set contiguous would be recording a fiction.
+- **Add the python marker rather than raise our own floor.** Dropping 3.10/3.11
+  support to satisfy an optional plugin would be the tail wagging the dog; the
+  marker is what the three sibling plugins already do.
+- **Move `constraints-upgrade-from.txt` to 0.8.0, not 0.9.1.** That side pins
+  what the FROM release supports, and 2.7.13 caps netbox-dlm below 0.9.0.
+- **Widen to `<0.10.0`, not `<0.9.2`.** The gates already enumerate exact
+  validated versions and fail closed, so the range does not need to be the
+  thing that refuses an unvalidated 0.9.x.
+
+## Open
+
+- Our `max_version` and Blake's are now identical at 4.6.99. Worth telling him
+  before either side moves to 4.7, because whoever goes first blocks the other.

--- a/forward_netbox/tests/test_optional_plugin_versions.py
+++ b/forward_netbox/tests/test_optional_plugin_versions.py
@@ -13,6 +13,18 @@
 # non-empty. This plugin never sets it, so its rows carry '' and the constraint
 # cannot apply to them; the coalesce key it does use, (platform, version), is
 # unchanged.
+#
+# 0.9.1 qualifies on the same inspection against 0.8.0: its `models.py` delta is
+# entirely direct model imports becoming lazy string references
+# (`to=Platform` -> `to='dcim.Platform'`), which Django resolves identically and
+# which generates no migration. No field, model or constraint changed, so the
+# whole surface this plugin binds to - `SoftwareVersion.platform`, `.version`,
+# `.alias`, and the (platform, version) coalesce key - is untouched.
+#
+# 0.9.0 is deliberately absent, and the test below pins its absence. It shipped
+# roughly half an hour before 0.9.1 with a NoReverseMatch on every one of its
+# view URLs; 0.9.1 is that fix. Skipping a version that cannot render is not the
+# same as failing to validate it.
 from unittest.mock import patch
 
 from django.test import SimpleTestCase
@@ -37,6 +49,7 @@ class OptionalDistributionVersionSetTest(SimpleTestCase):
                 self.assertIn("0.5.0", supported["netbox-dlm"])
                 self.assertIn("0.6.0", supported["netbox-dlm"])
                 self.assertIn("0.8.0", supported["netbox-dlm"])
+                self.assertIn("0.9.1", supported["netbox-dlm"])
 
     def test_an_unvalidated_version_is_still_refused(self):
         # The gates fail closed; widening must not become "any version".
@@ -46,6 +59,9 @@ class OptionalDistributionVersionSetTest(SimpleTestCase):
         ):
             self.assertNotIn("0.6.1", supported["netbox-dlm"])
             self.assertNotIn("0.3.3", supported["netbox-dlm"])
+            # Released, and still refused: 0.9.0 cannot render any of its own
+            # views. Widening to 0.9.1 must not sweep it in by proximity.
+            self.assertNotIn("0.9.0", supported["netbox-dlm"])
 
     def test_the_other_distributions_stay_single_valued(self):
         # Only netbox-dlm has a second validated version so far.
@@ -166,7 +182,7 @@ class FastBaselineRuntimeTupleTest(SimpleTestCase):
         json.dumps(detail)
         self.assertEqual(
             detail["expected"]["optional_plugins"]["netbox-dlm"],
-            ["0.4.1", "0.5.0", "0.6.0", "0.7.0", "0.8.0"],
+            ["0.4.1", "0.5.0", "0.6.0", "0.7.0", "0.8.0", "0.9.1"],
         )
 
 

--- a/forward_netbox/tests/test_plugin_integrations.py
+++ b/forward_netbox/tests/test_plugin_integrations.py
@@ -67,7 +67,7 @@ class OptionalPluginIntegrationRegistryTest(TestCase):
                 "netbox-routing": "0.4.3",
                 "netbox-peering-manager": "0.3.0",
                 "netbox-cisco-aci": "0.3.9",
-                "netbox-dlm": "0.8.0",
+                "netbox-dlm": "0.9.1",
             }
             return versions[package_name]
 
@@ -110,10 +110,10 @@ class OptionalPluginIntegrationRegistryTest(TestCase):
             "netbox-cisco-aci",
         )
         self.assertEqual(summary["aci.netbox_cisco_aci"]["required_version"], "0.4.0")
-        self.assertEqual(summary["lifecycle.netbox_dlm"]["required_version"], "0.8.0")
+        self.assertEqual(summary["lifecycle.netbox_dlm"]["required_version"], "0.9.1")
         self.assertEqual(
             summary["lifecycle.netbox_dlm"]["supported_versions"],
-            ["0.4.1", "0.5.0", "0.6.0", "0.7.0", "0.8.0"],
+            ["0.4.1", "0.5.0", "0.6.0", "0.7.0", "0.8.0", "0.9.1"],
         )
 
     def test_dlm_supported_versions_are_available_and_not_dropped(self):
@@ -161,7 +161,7 @@ class OptionalPluginIntegrationRegistryTest(TestCase):
             self.assertEqual(
                 capability["availability_reason"],
                 "Installed plugin version must equal one of: 0.4.1, 0.5.0, 0.6.0, 0.7.0, "
-                "0.8.0.",
+                "0.8.0, 0.9.1.",
             )
             fetcher = ForwardQueryFetcher(sync=Mock(), client=Mock(), logger_=Mock())
             self.assertEqual(

--- a/forward_netbox/utilities/apply_engine_decision.py
+++ b/forward_netbox/utilities/apply_engine_decision.py
@@ -65,7 +65,7 @@ COPY_SQL_SUPPORTED_NETBOX_SERIES = "4.6"
 COPY_SQL_SUPPORTED_BRANCHING_SERIES = "1.1"
 COPY_SQL_SUPPORTED_OPTIONAL_DISTRIBUTIONS = {
     "netbox-cisco-aci": frozenset({"0.4.0"}),
-    "netbox-dlm": frozenset({"0.4.1", "0.5.0", "0.6.0", "0.7.0", "0.8.0"}),
+    "netbox-dlm": frozenset({"0.4.1", "0.5.0", "0.6.0", "0.7.0", "0.8.0", "0.9.1"}),
     "netbox-peering-manager": frozenset({"0.3.0"}),
     "netbox-routing": frozenset({"0.4.3"}),
 }

--- a/forward_netbox/utilities/fast_baseline.py
+++ b/forward_netbox/utilities/fast_baseline.py
@@ -208,7 +208,9 @@ def _runtime_decision():
         # tuple stopped matching.
         "optional_plugins": {
             "netbox-cisco-aci": frozenset({"0.4.0"}),
-            "netbox-dlm": frozenset({"0.4.1", "0.5.0", "0.6.0", "0.7.0", "0.8.0"}),
+            "netbox-dlm": frozenset(
+                {"0.4.1", "0.5.0", "0.6.0", "0.7.0", "0.8.0", "0.9.1"}
+            ),
             "netbox-peering-manager": frozenset({"0.3.0"}),
             "netbox-routing": frozenset({"0.4.3"}),
         },

--- a/forward_netbox/utilities/merge_set_based.py
+++ b/forward_netbox/utilities/merge_set_based.py
@@ -31,7 +31,7 @@ SET_BASED_MERGE_SUPPORTED_NETBOX_SERIES = "4.6"
 SET_BASED_MERGE_SUPPORTED_BRANCHING_SERIES = "1.1"
 SET_BASED_MERGE_SUPPORTED_OPTIONAL_DISTRIBUTIONS = {
     "netbox-cisco-aci": frozenset({"0.4.0"}),
-    "netbox-dlm": frozenset({"0.4.1", "0.5.0", "0.6.0", "0.7.0", "0.8.0"}),
+    "netbox-dlm": frozenset({"0.4.1", "0.5.0", "0.6.0", "0.7.0", "0.8.0", "0.9.1"}),
     "netbox-peering-manager": frozenset({"0.3.0"}),
     "netbox-routing": frozenset({"0.4.3"}),
 }

--- a/forward_netbox/utilities/plugin_integrations/registry.py
+++ b/forward_netbox/utilities/plugin_integrations/registry.py
@@ -219,13 +219,16 @@ DLM_INTEGRATION = OptionalPluginIntegration(
     ),
     package_name="netbox-dlm",
     adapter_module="forward_netbox.utilities.sync_dlm",
-    required_package_version="0.8.0",
+    required_package_version="0.9.1",
     supported_package_versions=(
         "0.4.1",
         "0.5.0",
         "0.6.0",
         "0.7.0",
         "0.8.0",
+        # 0.9.0 is skipped on purpose: it shipped with a NoReverseMatch on every
+        # one of its view URLs and 0.9.1, half an hour later, is that fix.
+        "0.9.1",
     ),
     enabled_by_default=False,
     status="supported",

--- a/poetry.lock
+++ b/poetry.lock
@@ -233,7 +233,7 @@ files = [
     {file = "charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5"},
     {file = "charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b"},
 ]
-markers = {main = "extra == \"dlm\" or extra == \"integrations\""}
+markers = {main = "python_version >= \"3.12\" and (extra == \"dlm\" or extra == \"integrations\")"}
 
 [[package]]
 name = "click"
@@ -790,15 +790,15 @@ test = ["coverage[toml] (>=7.4)", "pytest (>=8.0)", "pytest-cov (>=4.1)", "pytes
 
 [[package]]
 name = "netbox-dlm"
-version = "0.7.0"
+version = "0.9.1"
 description = "Device/software/hardware lifecycle management plugin for NetBox"
 optional = true
-python-versions = ">=3.10"
+python-versions = ">=3.12"
 groups = ["main"]
-markers = "extra == \"dlm\" or extra == \"integrations\""
+markers = "python_version >= \"3.12\" and (extra == \"dlm\" or extra == \"integrations\")"
 files = [
-    {file = "netbox_dlm-0.7.0-py3-none-any.whl", hash = "sha256:09d05148b248b6d2e3be2a7648094789dfbf31bb4898e5c29f6350b85d6127bb"},
-    {file = "netbox_dlm-0.7.0.tar.gz", hash = "sha256:90bb8bca598dae197464f30df0a7276beb7393ddd8fd0f47eee39f2b9576caec"},
+    {file = "netbox_dlm-0.9.1-py3-none-any.whl", hash = "sha256:5104730d03eb2c5836789f037cb0aa7d24f9f8a6cb5fc5e60e18ce84657f7356"},
+    {file = "netbox_dlm-0.9.1.tar.gz", hash = "sha256:67a3782a7e9a15187b1b1963126f76a87458efc578ec99f21aec55718a9d10e1"},
 ]
 
 [package.dependencies]
@@ -1217,7 +1217,7 @@ files = [
     {file = "requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"},
     {file = "requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed"},
 ]
-markers = {main = "extra == \"dlm\" or extra == \"integrations\""}
+markers = {main = "python_version >= \"3.12\" and (extra == \"dlm\" or extra == \"integrations\")"}
 
 [package.dependencies]
 certifi = ">=2023.5.7"
@@ -1382,7 +1382,7 @@ files = [
     {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
     {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
-markers = {main = "extra == \"dlm\" or extra == \"integrations\""}
+markers = {main = "python_version >= \"3.12\" and (extra == \"dlm\" or extra == \"integrations\")"}
 
 [package.extras]
 brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
@@ -1498,4 +1498,4 @@ routing = ["netbox-routing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "f08ce1ed3485a4a506a9a5ce07a2b8338c4bc48ecf3338682d7d1ef3e02bb6d4"
+content-hash = "3202d2ba65c170852392bb0ff1d35a2ac7d694acb5a13cfa36df3433918bdc1a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,11 @@ python = ">=3.10,<3.15"
 # them with an extra, e.g. `pip install forward-netbox[integrations]` (all) or a
 # single one like `forward-netbox[dlm]`. You must still add each plugin to
 # PLUGINS in configuration.py and run migrations — see the release notes.
-netbox-dlm = {version = ">=0.4.1,<0.9.0", optional = true}
+# The `python` marker joins its siblings at 0.9.1: that release raised
+# `requires-python` to >=3.12. Without the marker poetry has to satisfy this
+# dependency all the way down to our own 3.10 floor and therefore resolves to
+# 0.8.0, pinning us a release behind with no error to read.
+netbox-dlm = {version = ">=0.4.1,<0.10.0", optional = true, python = ">=3.12,<3.15"}
 netbox-routing = {version = "0.4.3", optional = true, python = ">=3.12,<3.15"}
 netbox-cisco-aci = {version = "0.4.0", optional = true, python = ">=3.12,<3.15"}
 netbox-peering-manager = {version = "0.3.0", optional = true, python = ">=3.12,<3.15"}

--- a/scripts/validate_sbom.py
+++ b/scripts/validate_sbom.py
@@ -12,7 +12,7 @@ REQUIRED_COMPONENTS = {
     "httpx": "0.28.1",
     "netbox": "4.6.6",
     "netbox-cisco-aci": "0.4.0",
-    "netbox-dlm": "0.8.0",
+    "netbox-dlm": "0.9.1",
     "netbox-peering-manager": "0.3.0",
     "netbox-routing": "0.4.3",
     "netboxlabs-netbox-branching": "1.1.2",

--- a/tasks.py
+++ b/tasks.py
@@ -1213,7 +1213,7 @@ def artifact_test(context):
             "'dependencies = [' "
             f"'  \"forward-netbox=={version}\",' "
             "'  \"netbox-cisco-aci==0.4.0\",' "
-            "'  \"netbox-dlm==0.7.0\",' "
+            "'  \"netbox-dlm==0.9.1\",' "
             "'  \"netbox-peering-manager==0.3.0\",' "
             "'  \"netbox-routing==0.4.3\",' "
             "']' "


### PR DESCRIPTION
netbox-dlm `0.9.1` was released upstream on 2026-08-14. We pinned `0.8.0`, and `pyproject.toml` capped the range at `<0.9.0`, so it was excluded outright.

Every runtime gate here compares the installed optional-plugin version against an explicit validated set and fails closed. Until `0.9.1` is in those sets an upgrade does not merely go unsupported — it turns the fast baseline off with no error an operator can see, which is a failure this repo has already been bitten by once.

## Is it safe for the surface we bind to

Yes, on the same schema-delta inspection that admitted `0.5.0`. The `models.py` delta from `0.8.0` is entirely direct model imports becoming lazy string references (`to=Platform` → `to='dcim.Platform'`), which Django resolves identically and which generates no migration. No field, model or constraint moved, so `SoftwareVersion.platform` / `.version` / `.alias`, the `(platform, version)` coalesce key and `DeviceSoftware's two FKs are untouched. The rest of the release is his own UI, which we do not consume.

## 0.9.0 is deliberately excluded

It shipped roughly half an hour before `0.9.1` with a `NoReverseMatch` on every one of its view URLs; `0.9.1` is that fix. A test pins the exclusion so widening cannot sweep it in by proximity.

## The python marker

`pyproject.toml` gains `python = ">=3.12,<3.15"` alongside the range widening. Without it, `poetry update netbox-dlm --lock` resolves to **0.8.0 and reports success** — `0.9.1` raised its `requires-python` to 3.12 and our project declares `>=3.10`. Observed, not predicted. The three sibling optional plugins already carry this marker.

## Notes

- Thirteen sites carry the version. Two are tests that spell the validated set out literally — the rendered refusal message and the serialised rejection evidence — and those only surface in the Django suite.
- `constraints-upgrade-from.txt` moves to `0.8.0`, being the newest version the FROM release (2.7.13, capped `<0.9.0`) supports.
- `0.9.1` declares `max_version = "4.6.99"`, identical to ours. No conflict today, but netbox-dlm now shares our NetBox ceiling instead of trailing it, so whichever side raises it first blocks the other.

Verified in the built artifact rather than inferred from the pin: the generated SBOM records `netbox-dlm 0.9.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
