### PR TITLE
docs: state the NQE call-volume rule as a constraint, not an objection

### DIFF
--- a/skills/forward-netbox/SKILL.md
+++ b/skills/forward-netbox/SKILL.md
@@ -141,8 +141,9 @@ Two consequences worth knowing:
 
 - Execution is **asynchronous**: submit, poll, then page the result. A single unpaginated
   fetch silently truncates.
-- **Query volume matters.** Forward engineering has objected to unnecessary NQE runs;
-  audit call volume when changing anything on the sync path.
+- **Every NQE run costs.** Treat call volume as a budget: reuse a report the sync has
+  already computed rather than re-querying, and audit `forward_api_usage` when changing
+  anything on the sync path.
 - The query language is restrictive — no list comprehensions, and `contains` is not
   infix. Write queries device-parallel.
 - Queries can be pinned by ID or resolved by name; a pinned ID going stale is a real


### PR DESCRIPTION
The skill said Forward engineering had objected to unnecessary NQE runs. That is internal friction, it ships in a public repo, and it is the wrong reason to give an agent anyway — it reads as "someone will be annoyed" rather than "this is a budget you are spending".

Stated directly instead: every run costs, reuse a report the sync already computed, and audit `forward_api_usage` when touching the sync path. Same rule, actionable without the backstory, and it now names the command that measures it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)