### PR TITLE
Name the NetBox row a recorded merge rejection is about

### DIFF
--- a/docs/03_Plans/active/2026-08-15-name-the-merge-rejected-row.md
+++ b/docs/03_Plans/active/2026-08-15-name-the-merge-rejected-row.md
@@ -1,0 +1,118 @@
+# Name the row a merge rejection was about
+
+## Goal
+
+An operator reading a recorded merge rejection can open the NetBox object it is
+about. Today the record names the model and the rule and stops there, so the
+remedy - editing the offending row - starts with a hunt.
+
+The field report in #206 reads:
+
+> Merge for ipam.ipaddress failed (ValidationError) violating
+> primary-ip-reassignment-blocked. Recorded and skipped: re-running cannot
+> change a NetBox validation rejection, so the baseline was promoted over this
+> row.
+
+Accurate, unactionable. One `ipam.ipaddress` row out of a 4,000-device sync is
+being talked about and nothing says which.
+
+## Constraints
+
+- **No customer value may be persisted.** This module refuses that deliberately
+  and in three places: `diagnostic_shape` keeps field names and discards their
+  values, `redacted_message_shape` exists for the same reason, and the merge
+  recorder's own comment says the key values a Postgres `DETAIL` line embeds
+  "are deliberately still not captured". An IP address, a device name and an
+  interface name are customer values. Whatever names the row must not be one.
+- **No message may change for a caller that has no row in hand.** The
+  orchestration paths record whole-model failures, and `MergeIssueRecorderTest`
+  pins one such message by exact equality.
+- **`raw_data` keys must stay disjoint from the diagnosis** so anything already
+  reading them is unaffected.
+- No migration: `ForwardIngestionIssue.raw_data` is already a `JSONField`.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/merge.py` - `_row_identity` (new),
+  `_MergeIssueRecorder.record`, `_record_failed`
+- `forward_netbox/tests/test_merge_rule_rejection.py` - `MergeRowIdentityTests`
+  (new), one end-to-end assertion on the field-reported rejection
+- `forward_netbox/tests/test_ingestion_merge.py` - `MergeIssueRecorderTest`
+
+## Approach
+
+The identity was never missing. `_record_failed` already holds the
+`CollapsedChange`, whose `key` is `(label_lower, pk)` - the same `key[1]` the
+authoritative-delete guard logs in the clear forty lines below. It simply was
+not passed to `record()`, which took `model_string` and `exc` and nothing else.
+
+`record()` gains two optional keyword arguments, `pk` and `change_data`, both
+defaulting to `None`. `_row_identity(pk, change_data)` returns `None` when there
+is no pk, and the whole feature is then a no-op - that is what keeps the
+whole-model messages byte-identical.
+
+**What is reported is the NetBox primary key, not the row's values.** The pk is
+a NetBox-assigned surrogate; it resolves to the object page in the operator's
+own NetBox, which is exactly where the edit has to happen. It answers "which
+row" completely while disclosing nothing, so the redaction boundary above stays
+intact. The message gains one sentence:
+
+    ... over this row. Affected NetBox row: pk 900002.
+
+`raw_data` gains `row_pk` (the pk, as a string - some models key on a UUID) and
+`row` (the change data through `diagnostic_shape`, so field names only). That is
+the same split the sync-phase recorder already uses, where `raw_data` is
+`{**diagnostic_shape(row), **diagnosis}`.
+
+A branch-native DELETE carries no `postchange_data`, so it records the pk and no
+shape.
+
+## Validation
+
+- `MergeRowIdentityTests` (`SimpleTestCase`, no database): no pk leaves the
+  message unchanged; an int pk renders and the change data reduces to field
+  names; **no customer value reaches the message or the shape**, asserted
+  directly; a UUID pk survives and a delete records no shape.
+- `test_the_skipped_row_names_the_netbox_object_to_edit` drives the real
+  `sync_merge` path with the field-reported `primary-ip-reassignment-blocked`
+  and asserts the pk reaches both `message` and `raw_data["row_pk"]`, that the
+  rule is still named, and that the ValidationError's own text still is not.
+- `test_a_recorded_row_names_its_pk_and_records_its_shape` pins the exact
+  message and the exact `raw_data`.
+- `MergeIssueRecorderTest.test_module_bay_failures_...` is unchanged and still
+  asserts `"Merge for dcim.modulebay failed (Exception)."` by equality, which is
+  the regression test for the no-pk path.
+- `invoke lint` (black 25.9.0, flake8 7.3.0), `invoke harness-check`,
+  `invoke test`.
+
+## Rollback
+
+Revert. `record()`'s new arguments are optional and nothing else calls it, so
+the previous messages and `raw_data` return exactly.
+
+## Decision Log
+
+- **The pk, not the address.** #206 asks for the address, device and interface.
+  Naming the value would put customer data into a record that reaches support
+  bundles, against an invariant this module enforces everywhere else. The pk
+  gets the operator to the same page. If Forward decides the value is wanted
+  too, `_row_identity` is the one function to change and the tests that assert
+  the absence are the ones to update - deliberately, not by accident.
+- **A generic identity, not an `ipam.ipaddress` special case.** The report came
+  from one model; the gap is in the recorder, and every merge rejection has the
+  same question behind it.
+- **Appended, not interpolated into the prefix.** `safe_operation_failure`
+  writes the machine-readable head that `recovered_classifiers` reads back out.
+  Adding to it would change every merge message and break readback; a trailing
+  sentence is additive.
+
+## Open
+
+- **The Drift Summary half of #206 is NOT addressed here.** `EXACT_COMPARISON`
+  is defined and never produced, so `In sync` / `Drifted models` / `Total drift`
+  read "Not measured" on every run - confirmed: the only producer,
+  `_dependency_dry_run_payload`, hardcodes `workload_upper_bound`
+  (`views.py:507-508,563`) and `drift_report.py:136,176` gates on the constant.
+  #206's own fix direction offers two answers - compute a real comparison, or
+  relabel the panel as the workload estimate it is - and choosing between them
+  is Forward's call, not a drive-by. #206 should stay open for it.

--- a/forward_netbox/tests/test_ingestion_merge.py
+++ b/forward_netbox/tests/test_ingestion_merge.py
@@ -1229,6 +1229,37 @@ class MergeIssueRecorderTest(TestCase):
         self.assertNotIn("Save with update_fields", str(issue.raw_data))
         self.assertTrue(has_blocking_issues(self.ingestion))
 
+    def test_a_recorded_row_names_its_pk_and_records_its_shape(self):
+        from forward_netbox.utilities.merge import _MergeIssueRecorder
+
+        recorder = _MergeIssueRecorder(self.ingestion, None)
+        recorder.record(
+            model_string="ipam.ipaddress",
+            exc=Exception("Save with update_fields did not affect any rows."),
+            pk=900002,
+            change_data={"address": "10.0.0.1/24", "assigned_object_id": 7},
+        )
+
+        issue = self.ingestion.issues.get()
+        # The message keeps its machine-readable prefix and gains the one thing
+        # an operator needs to act: which object to open in NetBox.
+        self.assertEqual(
+            "Merge for ipam.ipaddress failed (Exception). "
+            "Affected NetBox row: pk 900002.",
+            issue.message,
+        )
+        self.assertEqual("900002", issue.raw_data["row_pk"])
+        self.assertEqual(
+            {"type": "mapping", "fields": ["address", "assigned_object_id"]},
+            issue.raw_data["row"],
+        )
+        # The diagnosis keys are untouched, so anything already reading
+        # `raw_data` keeps working.
+        self.assertEqual("Exception", issue.raw_data["exception_type"])
+        # And the row's own values still never land in either surface.
+        self.assertNotIn("10.0.0.1", issue.message)
+        self.assertNotIn("10.0.0.1", str(issue.raw_data))
+
     def test_synced_model_failures_recorded_per_change(self):
         from forward_netbox.utilities.merge import _MergeIssueRecorder
 

--- a/forward_netbox/tests/test_merge_rule_rejection.py
+++ b/forward_netbox/tests/test_merge_rule_rejection.py
@@ -34,6 +34,68 @@ from forward_netbox.utilities.forward_api import LATEST_PROCESSED_SNAPSHOT
 from forward_netbox.utilities.health_checks import ingestion_check_message
 from forward_netbox.utilities.health_checks import ingestion_check_status
 from forward_netbox.utilities.merge import _is_destination_rule_rejection
+from forward_netbox.utilities.merge import _row_identity
+
+
+class MergeRowIdentityTests(SimpleTestCase):
+    """A recorded rejection has to say which row, without saying what is in it.
+
+    Resolving an unsatisfiable row means editing it in NetBox, and the record
+    named the model and the rule but never the object - so the operator had to
+    hunt for it. The identity reported is the NetBox pk, which resolves to the
+    object page; the address, device name and interface are customer values
+    this module does not persist anywhere else.
+    """
+
+    def test_no_pk_leaves_the_message_exactly_as_it_was(self):
+        # Whole-model failures have no row in hand. They must keep the message
+        # they always had, byte for byte.
+        self.assertIsNone(_row_identity(None, None))
+        self.assertIsNone(_row_identity(None, {"address": "10.0.0.1/24"}))
+        self.assertIsNone(_row_identity("   ", {}))
+
+    def test_the_pk_is_named_and_the_row_is_recorded_as_a_shape(self):
+        identity = _row_identity(
+            900002,
+            {
+                "address": "10.0.0.1/24",
+                "assigned_object_id": 7,
+                "assigned_object_type": 42,
+                "description": "core uplink",
+            },
+        )
+        self.assertEqual("900002", identity["pk"])
+        self.assertEqual("Affected NetBox row: pk 900002.", identity["sentence"])
+        self.assertEqual(
+            {
+                "type": "mapping",
+                "fields": [
+                    "address",
+                    "assigned_object_id",
+                    "assigned_object_type",
+                    "description",
+                ],
+            },
+            identity["shape"],
+        )
+
+    def test_no_customer_value_reaches_the_message_or_the_shape(self):
+        # The invariant, asserted rather than assumed: the pk is a NetBox
+        # surrogate, everything else about the row stays out.
+        identity = _row_identity(
+            900002, {"address": "10.0.0.1/24", "description": "core uplink"}
+        )
+        recorded = repr(identity)
+        self.assertNotIn("10.0.0.1", recorded)
+        self.assertNotIn("core uplink", recorded)
+
+    def test_a_uuid_pk_survives_and_a_delete_records_no_shape(self):
+        # Some NetBox models key on a UUID, and a branch-native DELETE carries
+        # no `postchange_data` at all.
+        pk = uuid4()
+        identity = _row_identity(pk, None)
+        self.assertEqual(str(pk), identity["pk"])
+        self.assertIsNone(identity["shape"])
 
 
 class DestinationRuleRejectionTests(SimpleTestCase):
@@ -460,6 +522,20 @@ class UnsatisfiableRowDispositionTest(TestCase):
         self.assertEqual("ipam.ipaddress", model)
         self.assertIn("primary-ip-reassignment-blocked", message)
         self.assertIn("Recorded and skipped", message)
+
+    def test_the_skipped_row_names_the_netbox_object_to_edit(self):
+        # Naming the rule told the operator what to do; it did not tell them
+        # where. The pk is the whole remedy: it resolves straight to the
+        # ipam.ipaddress page where the reassignment has to be cleared.
+        self._merge([PRIMARY_IP_REJECTION], applied=509)
+
+        issue = self.ingestion.issues.get()
+        self.assertIn("Affected NetBox row: pk 1.", issue.message)
+        self.assertEqual("1", issue.raw_data["row_pk"])
+        # The rule is still named, and the row's own values still are not.
+        self.assertIn("primary-ip-reassignment-blocked", issue.message)
+        self.assertNotIn("Cannot reassign IP address", issue.message)
+        self.assertNotIn("Cannot reassign IP address", str(issue.raw_data))
 
     def test_drift_evidence_no_longer_reports_the_run_as_failed(self):
         self._merge([PRIMARY_IP_REJECTION], applied=509)

--- a/forward_netbox/utilities/merge.py
+++ b/forward_netbox/utilities/merge.py
@@ -39,6 +39,7 @@ from .bulk_delete import lock_related_writes_for_delete
 from .bulk_merge import _ApplyOneFailure
 from .bulk_merge import bulk_merge_changes
 from .diagnostics import describe_failure
+from .diagnostics import diagnostic_shape
 from .diagnostics import exception_type
 from .diagnostics import is_caused_rule_rejection
 from .diagnostics import safe_operation_failure
@@ -116,6 +117,31 @@ def _replication_side_effect_exists(collapsed_change) -> bool:
     return model_class.objects.filter(device_id=device_id, name=name).exists()
 
 
+def _row_identity(pk, change_data):
+    """Name the failed row by its NetBox pk, never by its own values.
+
+    Returns ``None`` when there is no pk to report, so a caller that has no
+    row in hand — the orchestration paths that record a whole-model failure —
+    keeps the message it always had, byte for byte.
+    """
+    if pk is None:
+        return None
+    # `CollapsedChange.key` is `(label_lower, pk)` and the pk can be an int or a
+    # UUID depending on the model. `str` is what makes it both readable in the
+    # message and safe to store in a JSONField; nothing downstream does
+    # arithmetic on it.
+    rendered = str(pk).strip()
+    if not rendered:
+        return None
+    return {
+        "pk": rendered,
+        # The row's fields, not their values — same treatment the sync-phase
+        # recorder gives `raw_data`.
+        "shape": diagnostic_shape(change_data) if change_data is not None else None,
+        "sentence": f"Affected NetBox row: pk {rendered}.",
+    }
+
+
 class _MergeIssueRecorder:
     """Record merge-time change failures as ForwardIngestionIssue rows."""
 
@@ -123,7 +149,7 @@ class _MergeIssueRecorder:
         self._ingestion = ingestion
         self._sync_logger = sync_logger
 
-    def record(self, *, model_string, exc):
+    def record(self, *, model_string, exc, pk=None, change_data=None):
         # The diagnosis has always been stored in `raw_data`, but the issue list
         # shows only the message — so the constraint or field sat one click away
         # while the list said nothing but the exception class. The sync-phase
@@ -143,6 +169,24 @@ class _MergeIssueRecorder:
                 "NetBox validation rejection, so the baseline was promoted "
                 "over this row."
             )
+        # An unsatisfiable row is resolved by editing it in NetBox, so "which
+        # row" is the one thing the operator has to know and the only thing the
+        # record did not say. A rejection reading "Merge for ipam.ipaddress
+        # failed ... violating primary-ip-reassignment-blocked" left them
+        # hunting for the address by hand.
+        #
+        # The identity is the NetBox primary key, NOT the row's own values. The
+        # pk is a NetBox-assigned surrogate that resolves to the object page in
+        # the operator's own NetBox, which is exactly where the edit has to
+        # happen; the address, device name and interface are customer data that
+        # this module refuses to persist anywhere else (`diagnostic_shape` keeps
+        # field names only, and the note below says the same about DETAIL
+        # values). Naming the pk answers the question without opening a hole in
+        # that boundary — and the pk was already being logged in the clear a few
+        # frames down, in the authoritative-delete guard.
+        row_identity = _row_identity(pk, change_data)
+        if row_identity:
+            message = f"{message} {row_identity['sentence']}"
         logger.error(
             "Merge row failed for %s (%s).",
             model_string,
@@ -156,13 +200,21 @@ class _MergeIssueRecorder:
         # bundle — to learn which constraint they violated. The diagnosis holds
         # schema identifiers only; the key values a Postgres DETAIL line embeds
         # are deliberately still not captured.
+        raw_data = dict(diagnosis)
+        if row_identity:
+            # Same split the sync recorder uses: the pk is an identifier, the
+            # change data is recorded as a shape. Keys stay disjoint from the
+            # diagnosis so anything already reading `raw_data` is unaffected.
+            raw_data["row_pk"] = row_identity["pk"]
+            if row_identity["shape"] is not None:
+                raw_data["row"] = row_identity["shape"]
         ForwardIngestionIssue.objects.create(
             ingestion=self._ingestion,
             phase=ForwardIngestionPhaseChoices.MERGE,
             model=model_string,
             message=message,
             exception=exc.__class__.__name__,
-            raw_data=diagnosis,
+            raw_data=raw_data,
         )
 
 
@@ -525,9 +577,12 @@ def merge_branch(
         nonlocal progress_failed, progress_unsatisfiable
         nonlocal last_heartbeat_at, last_log_at
         model_string = _model_string(collapsed_change.model_class)
+        key = getattr(collapsed_change, "key", None)
         issue_recorder.record(
             model_string=model_string,
             exc=exc,
+            pk=key[1] if isinstance(key, (tuple, list)) and len(key) > 1 else None,
+            change_data=getattr(collapsed_change, "postchange_data", None),
         )
         unsatisfiable = _is_destination_rule_rejection(exc)
         if unsatisfiable:


### PR DESCRIPTION
Closes the second half of #206.

## What an operator sees

The field report in #206 quotes this record verbatim:

> Merge for ipam.ipaddress failed (ValidationError) violating primary-ip-reassignment-blocked. Recorded and skipped: re-running cannot change a NetBox validation rejection, so the baseline was promoted over this row.

Accurate, and unactionable — resolving it means editing the offending row in NetBox, and
one `ipam.ipaddress` row out of ~4,000 devices is being talked about with nothing saying
which. After this patch the same record ends:

> … so the baseline was promoted over this row. **Affected NetBox row: pk 900002.**

`raw_data` gains `row_pk` and `row` alongside the existing diagnosis keys.

## The identity was never missing

`_record_failed` already holds the `CollapsedChange`, whose `key` is `(label_lower, pk)`
— the same `key[1]` the authoritative-delete guard logs in the clear a few frames below.
It just was not passed to `record()`, which took `model_string` and `exc` and nothing
else. `record()` gains `pk` and `change_data`, both optional.

## It names the pk, not the address — deliberately

#206 asks for the address, "and ideally the device and interface". I did not do that, and
the reason is your own invariant rather than an oversight:

- `diagnostic_shape` keeps field *names* and discards their values;
- `redacted_message_shape` exists for the same reason;
- `_MergeIssueRecorder`'s own comment says the key values a Postgres `DETAIL` line embeds
  "are deliberately still not captured".

An address, a device name and an interface name are customer values, and ingestion issues
reach support bundles. The NetBox pk is a surrogate you assigned; it resolves to the
object page, which is exactly where the edit has to happen, and it discloses nothing. So
it answers "which row" completely and leaves the boundary intact.

**If you want the value as well, that is one function.** `_row_identity` is the only place
to change, and `MergeRowIdentityTests.test_no_customer_value_reaches_the_message_or_the_shape`
plus the two `assertNotIn` pairs in the recorder tests are the assertions that would need
to be retired — knowingly, which is the point of putting them there.

## The Drift Summary half of #206 is *not* addressed here

I confirmed the diagnosis and stopped. `EXACT_COMPARISON` is defined and never produced:
`_dependency_dry_run_payload` hardcodes `workload_upper_bound`
(`views.py:507-508`, `:563`) and `drift_report.py:136,176` gates on the constant, with
`all(...)` across models, so one upper-bound model disables the whole report.

Your fix direction offers two answers — compute a real per-model comparison, or stop
presenting a drift measurement on a path that cannot produce one and relabel the panel.
That is a product decision. Picking one uninvited on a first contribution seemed worse
than leaving it, so **please keep #206 open for it**; I am happy to take whichever
direction you choose.

## Compatibility

`pk` defaults to `None` and `_row_identity` returns `None` for it, so a caller with no row
in hand — the orchestration paths that record a whole-model failure — gets the message it
always had, byte for byte. `MergeIssueRecorderTest.test_module_bay_failures_are_recorded_as_blocking_merge_issues`
still asserts `"Merge for dcim.modulebay failed (Exception)."` by equality, unchanged, and
is the regression test for that path. New `raw_data` keys are disjoint from the diagnosis
keys. No migration — `raw_data` is already a `JSONField`.

The trailing sentence is appended rather than folded into the prefix, because
`safe_operation_failure` writes the head that `recovered_classifiers` reads back out.

`docs/03_Plans/active/2026-08-15-name-the-merge-rejected-row.md` is in the diff because
`scripts/check_harness.py` requires a plan for a high-risk surface; it failed on the change
without one.

## What I verified, and what I could not

Ran and green: `black 25.9.0 --check`, `flake8 7.3.0`, `scripts/check_harness.py`,
`scripts/check_sensitive_content.py`. `_row_identity` is exercised against your real
`diagnostic_shape` — no pk leaves the message untouched, an int pk renders, a UUID pk
survives, a DELETE with no `postchange_data` records no shape, and no customer value
reaches either surface.

**I could not run `invoke test`.** It needs NetBox, PostgreSQL and Redis, and I do not have
that runtime — so the four tests added here are written against the suite's existing
fixtures and conventions but have not been executed. Please treat CI, not this PR body, as
the authority on them.

Tests added: `MergeRowIdentityTests` (4, `SimpleTestCase`),
`test_the_skipped_row_names_the_netbox_object_to_edit` (end-to-end through `sync_merge`
with the field-reported `primary-ip-reassignment-blocked`), and
`test_a_recorded_row_names_its_pk_and_records_its_shape` (pins the exact message and
`raw_data`).
