### PR TITLE
feat(drift): measure real drift for the bulk-ORM models

### DIFF
--- a/docs/03_Plans/active/2026-08-15-measure-real-drift.md
+++ b/docs/03_Plans/active/2026-08-15-measure-real-drift.md
@@ -124,6 +124,52 @@ drift over the measured models plus an explicit count of the unmeasured ones.
   for this feature, and it is the assertion that would have caught the
   side-effecting design.
 
+## Slice one, as built
+
+`compare_model_rows` in `utilities/drift_comparison.py` calls
+`bulk_orm_apply_simple_models(..., preview=True)`. Covers `dcim.site`,
+`dcim.manufacturer`, `dcim.devicetype`, `ipam.vlan`, `ipam.vrf` and
+`ipam.prefix`.
+
+Making it read-only took **six** suppressions, not the one hidden write this
+plan predicted. The two extra classes were both found by running it, not by
+reading it:
+
+1. `:563` creates missing manufacturers - predicted.
+2. `:602` creates missing VRFs - predicted.
+3. Three non-dict exits (`return False` for an unknown model, `return True`
+   when every row was rejected, and the `bulk_orm_apply_tree_models`
+   delegation) would each have surfaced as **zero drift** rather than "not
+   compared". A bool is falsy and a caller reading counts off it reports a
+   confident zero.
+4. `full_clean` on creates rejects a row whose required dependency was
+   deliberately not created - a device type whose manufacturer is absent fails
+   on a null FK while still being, plainly, a row NetBox does not have. A
+   preview counts what would change; validation belongs to the apply.
+
+`compare_model_rows` additionally refuses anything that is not a count mapping,
+so a path this work has not audited can never surface as zero drift.
+
+### Reporting
+
+`comparison_available` is now `any`, not `all`, and the report carries
+`measured_model_count`, `unmeasured_model_count` and `unmeasured_models`.
+
+`in_sync` deliberately stays `None` until every model is compared. Zero drift
+across a measured subset is reported as `total_drift`, which states its
+coverage; answering "Yes" off a partial measurement would tell an operator they
+are in sync when nothing checked the rest, which is the same confident-zero
+failure as (3) above wearing a different hat.
+
+### Still to do
+
+The bespoke bulk paths - `device`, `interface`, `ipaddress`, `macaddress`,
+`virtualchassis` - return `None` and keep their upper bound. They are the
+reporting deployment's highest-volume models, so slice two is where this
+becomes useful to them rather than merely correct. Each needs the same audit
+for hidden writes before being wired up; do not assume the pattern found here
+is the only one.
+
 ## Rollback
 
 Revert. The report returns to "Not measured", which is where it has always been.

--- a/docs/03_Plans/active/2026-08-15-measure-real-drift.md
+++ b/docs/03_Plans/active/2026-08-15-measure-real-drift.md
@@ -161,14 +161,60 @@ coverage; answering "Yes" off a partial measurement would tell an operator they
 are in sync when nothing checked the rest, which is the same confident-zero
 failure as (3) above wearing a different hat.
 
+## Slice two: the bespoke paths, audited
+
+The audit was run before any of them was wired up, and it justified itself.
+Slice one's hidden writes were dependency creates. These are worse - they are
+writes to models the function does not own, and one of them is a delete:
+
+| path | writes beyond its own rows |
+| --- | --- |
+| `macaddress` | none - **cleared** |
+| `interface` | **`cable.delete()`**, plus two recursive self-calls |
+| `device` | creates `Tag` and `TaggedItem` rows |
+| `ipaddress` | `Device.objects.bulk_update` (primary-IP assignment) |
+| `virtualchassis` | `Device.objects.bulk_update` |
+
+A preview on `interface` would have deleted cables. On `device` it would have
+created tags and tag assignments. "Return before the final `bulk_create`" is
+not sufficient for any of the four, and the dispatch now carries this table as
+a comment so nobody assumes otherwise.
+
+Only `macaddress` is wired up. The other four return `None` and keep their
+upper bound.
+
+### The shim is the cost of coverage
+
+Routing a preview through the apply path means satisfying whatever slice of the
+runner that path touches. `macaddress` alone needed `_content_type_for`,
+`_get_unique_or_raise`, `_lookup_interface`, `_dependency_failed`,
+`_mark_dependency_failed`, `_record_aggregated_skip_warning` and five caches -
+each checked for writes, each delegated to the same primitive the real runner
+uses so the preview resolves objects exactly as the apply would.
+
+That is the honest per-path cost, and it grows. `_record_issue` is now
+signature-agnostic rather than being widened every time a caller passes a new
+keyword.
+
+### Counting is uniform now
+
+Counts come from the per-row outcomes the classification already reports, not
+from arithmetic per function. Every path increments `applied` for a row it
+would write and `unchanged` for one it would not, so there is one definition
+instead of one per path - and the paths differ enough (skips, per-row
+rejections, in-memory duplicates) that row-total arithmetic quietly disagreed
+with them.
+
+`rejected` reads from the outcomes alone. Summing it with the issue count
+double-counted, because a single unusable row both files an issue and
+increments `failed`.
+
 ### Still to do
 
-The bespoke bulk paths - `device`, `interface`, `ipaddress`, `macaddress`,
-`virtualchassis` - return `None` and keep their upper bound. They are the
-reporting deployment's highest-volume models, so slice two is where this
-becomes useful to them rather than merely correct. Each needs the same audit
-for hidden writes before being wired up; do not assume the pattern found here
-is the only one.
+`interface`, `device`, `ipaddress` and `virtualchassis` - the reporting
+deployment's highest-volume models. Each needs its cross-model writes
+suppressed individually, and `interface`'s cable delete needs care rather than
+a guard: the classification may depend on it having happened.
 
 ## Rollback
 

--- a/forward_netbox/tests/test_drift_comparison.py
+++ b/forward_netbox/tests/test_drift_comparison.py
@@ -131,12 +131,18 @@ class UncoveredModelsReportNoComparisonTest(TestCase):
     failure mode here that leads somewhere bad.
     """
 
-    def test_the_bespoke_bulk_paths_return_none_under_preview(self):
+    def test_the_unaudited_bespoke_paths_return_none_under_preview(self):
+        """Each of these writes to a model other than its own.
+
+        `interface` deletes cables, `device` creates Tag and TaggedItem rows,
+        and `ipaddress` and `virtualchassis` both bulk_update Device. Returning
+        before their final write would not make them read-only, so until each is
+        handled they must decline to answer rather than answer wrongly.
+        """
         for model_string in (
             "dcim.device",
             "dcim.interface",
             "ipam.ipaddress",
-            "dcim.macaddress",
             "dcim.virtualchassis",
         ):
             with self.subTest(model=model_string):
@@ -151,6 +157,37 @@ class UncoveredModelsReportNoComparisonTest(TestCase):
             compare_model_rows(None, "dcim.site", []),
             {"creates": 0, "updates": 0, "unchanged": 0, "rejected": 0},
         )
+
+
+class MacAddressComparisonTest(TestCase):
+    """macaddress was the one bespoke path the write audit cleared."""
+
+    def test_a_macaddress_preview_writes_nothing(self):
+        from dcim.models import MACAddress
+
+        before = MACAddress.objects.count()
+
+        compare_model_rows(
+            None,
+            "dcim.macaddress",
+            [
+                {
+                    "mac_address": "00:11:22:33:44:55",
+                    "device": "no-such-device",
+                    "interface": "eth0",
+                }
+            ],
+        )
+
+        self.assertEqual(MACAddress.objects.count(), before)
+
+    def test_it_answers_rather_than_declining(self):
+        # The point of auditing it: a clean path should report a comparison, not
+        # be lumped in with the ones that cannot.
+        result = compare_model_rows(None, "dcim.macaddress", [])
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["creates"], 0)
 
 
 class PartialCoverageIsReportedTest(TestCase):

--- a/forward_netbox/tests/test_drift_comparison.py
+++ b/forward_netbox/tests/test_drift_comparison.py
@@ -1,0 +1,241 @@
+# The drift report called every fetched row a change, so `In sync` and
+# `Total drift` read "Not measured" on every run for every deployment. These
+# tests cover the comparison that replaces that estimate.
+#
+# The first class is the one that matters. Routing a preview through the apply
+# path is what keeps the comparison honest, and it is also what makes it
+# dangerous: `bulk_orm_apply_simple_models` writes during dependency resolution
+# before it classifies anything, creating missing manufacturers for device types
+# and missing VRFs for prefixes. A preview that inherited those writes would
+# create rows in an operator's NetBox as a side effect of looking at it.
+from dcim.models import DeviceType
+from dcim.models import Manufacturer
+from dcim.models import Site
+from django.test import TestCase
+from ipam.models import Prefix
+from ipam.models import VRF
+
+from forward_netbox.utilities.drift_comparison import compare_model_rows
+
+
+class PreviewWritesNothingTest(TestCase):
+    """The negative space: looking must never change anything."""
+
+    def test_a_prefix_preview_does_not_create_the_missing_vrf(self):
+        # apply_engine_bulk creates absent VRFs before classifying prefixes.
+        # Under preview that must not happen.
+        before = set(VRF.objects.values_list("name", flat=True))
+
+        compare_model_rows(
+            None,
+            "ipam.prefix",
+            [{"prefix": "10.99.0.0/24", "vrf": "vrf-that-does-not-exist"}],
+        )
+
+        self.assertEqual(set(VRF.objects.values_list("name", flat=True)), before)
+        self.assertFalse(VRF.objects.filter(name="vrf-that-does-not-exist").exists())
+        self.assertFalse(Prefix.objects.filter(prefix="10.99.0.0/24").exists())
+
+    def test_a_devicetype_preview_does_not_create_the_missing_manufacturer(self):
+        before = set(Manufacturer.objects.values_list("name", flat=True))
+
+        compare_model_rows(
+            None,
+            "dcim.devicetype",
+            [
+                {
+                    "manufacturer": "Mfr That Does Not Exist",
+                    "manufacturer_slug": "mfr-that-does-not-exist",
+                    "model": "DT-1",
+                    "slug": "dt-1",
+                }
+            ],
+        )
+
+        self.assertEqual(
+            set(Manufacturer.objects.values_list("name", flat=True)), before
+        )
+        self.assertFalse(DeviceType.objects.filter(slug="dt-1").exists())
+
+    def test_a_site_preview_creates_no_site(self):
+        before = Site.objects.count()
+
+        result = compare_model_rows(
+            None,
+            "dcim.site",
+            [{"name": "Preview Site", "slug": "preview-site"}],
+        )
+
+        self.assertEqual(Site.objects.count(), before)
+        self.assertEqual(result["creates"], 1)
+
+
+class PreviewCountsMatchRealityTest(TestCase):
+    """The counts are the product; they have to be right, not merely cheap."""
+
+    def setUp(self):
+        Site.objects.create(name="Existing Site", slug="existing-site")
+
+    def test_an_unchanged_row_is_not_counted_as_drift(self):
+        result = compare_model_rows(
+            None,
+            "dcim.site",
+            [{"name": "Existing Site", "slug": "existing-site"}],
+        )
+
+        self.assertEqual(result["unchanged"], 1)
+        self.assertEqual(result["creates"], 0)
+        self.assertEqual(result["updates"], 0)
+
+    def test_a_changed_row_counts_as_an_update(self):
+        result = compare_model_rows(
+            None,
+            "dcim.site",
+            [{"name": "Renamed Site", "slug": "existing-site"}],
+        )
+
+        self.assertEqual(result["updates"], 1)
+        self.assertEqual(result["creates"], 0)
+
+    def test_a_mixed_batch_is_not_all_or_nothing(self):
+        result = compare_model_rows(
+            None,
+            "dcim.site",
+            [
+                {"name": "Existing Site", "slug": "existing-site"},
+                {"name": "Renamed Later", "slug": "existing-site-2"},
+                {"name": "Brand New", "slug": "brand-new"},
+            ],
+        )
+
+        self.assertEqual(result["creates"], 2)
+        self.assertEqual(result["unchanged"], 1)
+
+    def test_a_row_missing_identity_is_rejected_not_counted_as_drift(self):
+        result = compare_model_rows(
+            None,
+            "dcim.site",
+            [{"name": "", "slug": ""}],
+        )
+
+        self.assertEqual(result["rejected"], 1)
+        self.assertEqual(result["creates"], 0)
+        self.assertEqual(result["updates"], 0)
+
+
+class UncoveredModelsReportNoComparisonTest(TestCase):
+    """A model with no comparison must say so, never report a confident zero.
+
+    Returning ``{"creates": 0, ...}`` for something that was never compared
+    would tell an operator they are in sync when nothing checked - the one
+    failure mode here that leads somewhere bad.
+    """
+
+    def test_the_bespoke_bulk_paths_return_none_under_preview(self):
+        for model_string in (
+            "dcim.device",
+            "dcim.interface",
+            "ipam.ipaddress",
+            "dcim.macaddress",
+            "dcim.virtualchassis",
+        ):
+            with self.subTest(model=model_string):
+                self.assertIsNone(
+                    compare_model_rows(None, model_string, [{"name": "x"}]),
+                    f"{model_string} has no comparison yet and must not claim one",
+                )
+
+    def test_an_empty_row_set_is_zero_drift_rather_than_unmeasured(self):
+        # Nothing fetched genuinely is nothing to change, for any model.
+        self.assertEqual(
+            compare_model_rows(None, "dcim.site", []),
+            {"creates": 0, "updates": 0, "unchanged": 0, "rejected": 0},
+        )
+
+
+class PartialCoverageIsReportedTest(TestCase):
+    """Drift over the compared models, and never a whole-estate claim.
+
+    The old report withheld every figure until all models could be compared.
+    Since the adapter-only models cannot be, that meant "Not measured" forever.
+    Reporting the measured subset is the fix - but it must not slide into
+    implying the subset is the estate.
+    """
+
+    def _report(self, *model_results):
+        from forward_netbox.utilities.drift_report import compute_drift_report
+
+        return compute_drift_report(
+            {"generated_at": "t", "model_results": list(model_results)}
+        )
+
+    def _exact(self, model, changes, deletes=0, rows=10):
+        return {
+            "model": model,
+            "row_count": rows,
+            "estimated_changes": changes,
+            "delete_count": deletes,
+            "change_estimate_kind": "exact_comparison",
+        }
+
+    def _upper_bound(self, model, rows=7):
+        return {
+            "model": model,
+            "row_count": rows,
+            "estimated_changes": rows,
+            "delete_count": 0,
+            "change_estimate_kind": "workload_upper_bound",
+        }
+
+    def test_one_uncompared_model_no_longer_silences_the_whole_report(self):
+        report = self._report(
+            self._exact("dcim.site", 3),
+            self._upper_bound("netbox_dlm.softwareversion"),
+        )
+
+        self.assertTrue(report["comparison_available"])
+        self.assertEqual(report["total_drift"], 3)
+        self.assertEqual(report["measured_model_count"], 1)
+        self.assertEqual(report["unmeasured_model_count"], 1)
+        self.assertEqual(report["unmeasured_models"], ["netbox_dlm.softwareversion"])
+
+    def test_an_uncompared_model_is_not_counted_as_a_drifted_model(self):
+        # It is unknown, not clean and not dirty; counting it either way is a
+        # statement nothing measured.
+        report = self._report(
+            self._exact("dcim.site", 0),
+            self._upper_bound("dcim.cable"),
+        )
+
+        self.assertEqual(report["drifted_model_count"], 0)
+
+    def test_in_sync_stays_unanswered_while_any_model_is_uncompared(self):
+        """The whole point: zero drift over half the estate is not "in sync"."""
+        report = self._report(
+            self._exact("dcim.site", 0),
+            self._upper_bound("dcim.cable"),
+        )
+
+        self.assertEqual(report["total_drift"], 0)
+        self.assertIsNone(report["in_sync"])
+        self.assertFalse(report["fully_measured"])
+
+    def test_in_sync_is_answered_once_every_model_is_compared(self):
+        report = self._report(
+            self._exact("dcim.site", 0),
+            self._exact("ipam.vlan", 0),
+        )
+
+        self.assertTrue(report["fully_measured"])
+        self.assertIs(report["in_sync"], True)
+
+    def test_all_upper_bound_still_reports_nothing_measured(self):
+        # The pre-existing behaviour for a preview that compared nothing.
+        report = self._report(
+            self._upper_bound("dcim.cable"),
+            self._upper_bound("dcim.module"),
+        )
+
+        self.assertFalse(report["comparison_available"])
+        self.assertIsNone(report["total_drift"])
+        self.assertIsNone(report["in_sync"])

--- a/forward_netbox/utilities/apply_engine_bulk.py
+++ b/forward_netbox/utilities/apply_engine_bulk.py
@@ -453,8 +453,22 @@ def bulk_orm_apply_simple_models(
     from django.db import transaction
     from django.db.models import Q
 
+    # Each bespoke path was audited for writes it performs on models other than
+    # its own before being given a preview mode, because a preview that
+    # inherited them would change an operator's NetBox while claiming to
+    # measure it. Only macaddress came back clean. The others are listed with
+    # what they do, so nobody wires one up on the assumption that returning
+    # before the final bulk_create is sufficient - it is not:
+    #
+    #   interface       `cable.delete()`, plus two recursive self-calls
+    #   device          creates Tag and TaggedItem rows
+    #   ipaddress       Device.objects.bulk_update (primary-IP assignment)
+    #   virtualchassis  Device.objects.bulk_update
+    #
+    # Until each is handled they report no comparison, which keeps their
+    # upper-bound estimate rather than a confident zero.
     if model_string == "dcim.macaddress":
-        return None if preview else bulk_orm_apply_macaddress(runner, rows)
+        return bulk_orm_apply_macaddress(runner, rows, preview=preview)
     if model_string == "dcim.virtualchassis":
         return None if preview else bulk_orm_apply_virtualchassis(runner, rows)
     if model_string == "ipam.ipaddress":
@@ -821,13 +835,7 @@ def bulk_orm_apply_simple_models(
         # writes. The counts come from the same normalisation, the same lookup
         # and the same field comparison the apply uses, which is the whole point
         # of routing the preview through here.
-        return {
-            "creates": len(create_objects),
-            "updates": len(update_objects),
-            "unchanged": len(normalized_rows)
-            - len(create_objects)
-            - len(update_objects),
-        }
+        return {"creates": len(create_objects), "updates": len(update_objects)}
 
     from django.db import IntegrityError
 
@@ -933,7 +941,7 @@ def _is_parseable_mac(value) -> bool:
     return True
 
 
-def bulk_orm_apply_macaddress(runner, rows: list[dict[str, Any]]):
+def bulk_orm_apply_macaddress(runner, rows: list[dict[str, Any]], *, preview=False):
     from dcim.models import Device
     from dcim.models import Interface
     from dcim.models import MACAddress
@@ -1227,6 +1235,13 @@ def bulk_orm_apply_macaddress(runner, rows: list[dict[str, Any]]):
             update_objects[mac.pk] = mac
         runner.logger.increment_statistics("dcim.macaddress", outcome="applied")
         runner.events_clearer.increment()
+
+    if preview:
+        # Audited for hidden writes before being wired up: unlike the other
+        # bespoke paths, this one touches no model but its own - no cross-model
+        # bulk_update, no dependency creation, no deletes - so classifying and
+        # returning here leaves NetBox untouched.
+        return {"creates": len(create_objects), "updates": len(update_objects)}
 
     from django.db import IntegrityError
 

--- a/forward_netbox/utilities/apply_engine_bulk.py
+++ b/forward_netbox/utilities/apply_engine_bulk.py
@@ -422,20 +422,47 @@ def bulk_orm_delete_prefixes(runner, rows: list[dict[str, Any]]):
     return True
 
 
-def bulk_orm_apply_simple_models(runner, model_string: str, rows: list[dict[str, Any]]):
+def bulk_orm_apply_simple_models(
+    runner,
+    model_string: str,
+    rows: list[dict[str, Any]],
+    *,
+    preview: bool = False,
+):
+    """Apply rows, or - with ``preview`` - classify them and write nothing.
+
+    ``preview`` exists so the drift report can state how many objects actually
+    differ instead of counting every fetched row as a change. It reuses this
+    function rather than reimplementing the comparison, because a second
+    normaliser drifts from this one and the symptom is a drift figure that is
+    wrong in whichever direction is least noticeable.
+
+    Read-only is not simply "return before the write". This function writes
+    twice during dependency resolution, before it has classified anything: it
+    creates missing manufacturers for device types and platforms, and missing
+    VRFs for prefixes. Both are suppressed under ``preview``, which is safe AND
+    accurate - a row whose dependency is absent from NetBox cannot itself exist
+    in NetBox, so counting it as a create is the right answer rather than an
+    approximation.
+
+    Returns a ``{"creates", "updates", "unchanged"}`` mapping under ``preview``,
+    or ``None`` for a model whose bespoke path does not support it yet, so the
+    caller can fall back to the upper-bound estimate rather than report a
+    confident zero for something never compared.
+    """
     from django.db import transaction
     from django.db.models import Q
 
     if model_string == "dcim.macaddress":
-        return bulk_orm_apply_macaddress(runner, rows)
+        return None if preview else bulk_orm_apply_macaddress(runner, rows)
     if model_string == "dcim.virtualchassis":
-        return bulk_orm_apply_virtualchassis(runner, rows)
+        return None if preview else bulk_orm_apply_virtualchassis(runner, rows)
     if model_string == "ipam.ipaddress":
-        return bulk_orm_apply_ipaddress(runner, rows)
+        return None if preview else bulk_orm_apply_ipaddress(runner, rows)
     if model_string == "dcim.interface":
-        return bulk_orm_apply_interface(runner, rows)
+        return None if preview else bulk_orm_apply_interface(runner, rows)
     if model_string == "dcim.device":
-        return bulk_orm_apply_device(runner, rows)
+        return None if preview else bulk_orm_apply_device(runner, rows)
 
     from dcim.models import DeviceType
     from dcim.models import DeviceRole
@@ -520,7 +547,9 @@ def bulk_orm_apply_simple_models(runner, model_string: str, rows: list[dict[str,
     }
     spec = specs.get(model_string)
     if not spec:
-        return False
+        # No spec means no comparison either; `None` keeps the caller on the
+        # upper-bound estimate rather than letting `False` read as zero drift.
+        return None if preview else False
 
     model = spec["model"]
     fields = tuple(spec["fields"])
@@ -560,7 +589,12 @@ def bulk_orm_apply_simple_models(runner, model_string: str, rows: list[dict[str,
             for row in rows
             if row.get("manufacturer")
         ]
-        bulk_orm_apply_simple_models(runner, "dcim.manufacturer", manufacturer_rows)
+        # A preview must not create the dependency it is only looking at. Rows
+        # needing an absent manufacturer resolve it to None below and fall out
+        # as creates, which is what they are: NetBox cannot already hold a
+        # device type or platform under a manufacturer it does not have.
+        if not preview:
+            bulk_orm_apply_simple_models(runner, "dcim.manufacturer", manufacturer_rows)
         manufacturer_values = {
             value
             for row in manufacturer_rows
@@ -598,7 +632,9 @@ def bulk_orm_apply_simple_models(runner, model_string: str, rows: list[dict[str,
             {"name": name, "rd": None, "description": "", "enforce_unique": False}
             for name in sorted(requested_vrf_names - existing_vrf_names)
         ]
-        if missing_vrf_rows:
+        # Same as the manufacturer case: a preview leaves the VRF table exactly
+        # as it found it, and a prefix whose VRF is absent counts as a create.
+        if missing_vrf_rows and not preview:
             bulk_orm_apply_simple_models(runner, "ipam.vrf", missing_vrf_rows)
         vrf_by_name = {}
         for batch in _chunks(list(requested_vrf_names)):
@@ -663,10 +699,19 @@ def bulk_orm_apply_simple_models(runner, model_string: str, rows: list[dict[str,
                 lookup_values[field_name].append(value)
 
     if not normalized_rows:
+        # Every row was rejected for missing identity. Nothing to write, and for
+        # a preview nothing to change either - the rejections are reported
+        # separately rather than counted as drift.
+        if preview:
+            return {"creates": 0, "updates": 0, "unchanged": 0}
         return True
 
     if model_string in {"dcim.devicerole", "dcim.platform"}:
-        # These low-volume models retain the adapter-equivalent save path.
+        # These low-volume models retain the adapter-equivalent save path, which
+        # has no preview mode yet, so a preview reports no comparison for them
+        # rather than borrowing this function's answer.
+        if preview:
+            return None
         return bulk_orm_apply_tree_models(
             runner=runner,
             model_string=model_string,
@@ -717,7 +762,14 @@ def bulk_orm_apply_simple_models(runner, model_string: str, rows: list[dict[str,
             # is redundant; a genuine constraint violation still surfaces via the
             # bulk_create IntegrityError -> per-row isolate path. Field validation
             # is kept.
-            obj.full_clean(validate_unique=False, validate_constraints=False)
+            #
+            # A preview skips it. It counts what would change, not whether the
+            # write would validate, and under preview a required dependency was
+            # deliberately not created - so a device type whose manufacturer is
+            # absent fails `full_clean` on a null FK while still being, plainly,
+            # a row NetBox does not have. Validation belongs to the apply.
+            if not preview:
+                obj.full_clean(validate_unique=False, validate_constraints=False)
             create_objects.append(obj)
             if model_string == "ipam.prefix":
                 prefix_vrf_ids.add(getattr(values.get("vrf"), "pk", None))
@@ -763,6 +815,19 @@ def bulk_orm_apply_simple_models(runner, model_string: str, rows: list[dict[str,
             runner.events_clearer.increment()
             continue
         runner.logger.increment_statistics(model_string, outcome="unchanged")
+
+    if preview:
+        # Everything above this line reads and classifies; everything below it
+        # writes. The counts come from the same normalisation, the same lookup
+        # and the same field comparison the apply uses, which is the whole point
+        # of routing the preview through here.
+        return {
+            "creates": len(create_objects),
+            "updates": len(update_objects),
+            "unchanged": len(normalized_rows)
+            - len(create_objects)
+            - len(update_objects),
+        }
 
     from django.db import IntegrityError
 

--- a/forward_netbox/utilities/drift_comparison.py
+++ b/forward_netbox/utilities/drift_comparison.py
@@ -1,0 +1,92 @@
+"""Count how many objects actually differ, by running the apply classification.
+
+The drift report used to call every fetched row a change, because the dependency
+preview had nothing to compare against and said so with
+``change_estimate_kind = "workload_upper_bound"``. That made ``In sync``,
+``Drifted models`` and ``Total drift`` read "Not measured" on every run for
+every deployment, permanently - a promise the UI could not keep.
+
+The comparison here is not a reimplementation. It calls
+``bulk_orm_apply_simple_models(..., preview=True)``, which normalises, resolves
+and compares exactly as the apply does and returns before it writes. A separate
+normaliser would drift from the real one, and the symptom would be a drift
+figure wrong in whichever direction is least noticeable - worse than no figure,
+because an operator would act on it.
+"""
+
+
+class _PreviewStatistics:
+    """Absorb the per-row outcome calls the classification makes."""
+
+    def __init__(self):
+        self.outcomes = {}
+
+    def increment_statistics(self, model_string, *, outcome="applied", amount=1):
+        amount = max(0, int(amount or 0))
+        if amount <= 0:
+            return
+        self.outcomes[outcome] = self.outcomes.get(outcome, 0) + amount
+
+    def log_warning(self, *args, **kwargs):
+        return None
+
+
+class _PreviewEventsClearer:
+    """The classification increments this per row; a preview clears no events."""
+
+    def __init__(self):
+        self.count = 0
+
+    def increment(self):
+        self.count += 1
+
+    def clear(self):
+        return None
+
+
+class PreviewRunner:
+    """A runner that records nothing and writes nothing.
+
+    The classification reports unusable rows through ``_record_issue`` and moves
+    per-model counters through ``logger``. Handing it the real runner would file
+    ingestion issues and move statistics for a sync that never ran, so it gets
+    this instead and the rejected rows are counted rather than persisted.
+    """
+
+    def __init__(self, sync=None):
+        self.sync = sync
+        self.logger = _PreviewStatistics()
+        self.events_clearer = _PreviewEventsClearer()
+        self.rejected_rows = 0
+
+    def _record_issue(self, model_string, message, row, context=None):
+        self.rejected_rows += 1
+
+
+def compare_model_rows(sync, model_string, rows):
+    """Return ``{"creates", "updates", "unchanged", "rejected"}`` or ``None``.
+
+    ``None`` means this model has no comparison yet - the bespoke bulk paths and
+    every adapter-only model - and the caller must keep reporting an upper bound
+    for it. Reporting a confident zero for something never compared is the one
+    failure mode here with a real consequence, because it would tell an operator
+    they are in sync when nothing checked.
+    """
+    from .apply_engine_bulk import bulk_orm_apply_simple_models
+
+    if not rows:
+        return {"creates": 0, "updates": 0, "unchanged": 0, "rejected": 0}
+    runner = PreviewRunner(sync=sync)
+    counts = bulk_orm_apply_simple_models(
+        runner,
+        model_string,
+        list(rows),
+        preview=True,
+    )
+    if not isinstance(counts, dict):
+        # `None` is the documented "no comparison" answer, but the apply path
+        # also has plain-bool exits for its own callers. Anything that is not a
+        # count mapping is treated as "not compared" rather than coerced, so a
+        # path this has not audited can never surface as zero drift.
+        return None
+    return {**counts, "rejected": runner.rejected_rows}

--- a/forward_netbox/utilities/drift_comparison.py
+++ b/forward_netbox/utilities/drift_comparison.py
@@ -57,10 +57,56 @@ class PreviewRunner:
         self.sync = sync
         self.logger = _PreviewStatistics()
         self.events_clearer = _PreviewEventsClearer()
+        self._content_types = {}
+        self._interface_by_device_name_cache = {}
+        self._missing_interface_by_device_name_cache = {}
+        self._device_by_name_cache = {}
+        self._primed_missing_unique_lookup_keys = set()
+        self._unique_lookup_cache = {}
         self.rejected_rows = 0
 
-    def _record_issue(self, model_string, message, row, context=None):
+    def _record_issue(self, *args, **kwargs):
+        # Deliberately signature-agnostic. Callers pass different keyword sets
+        # (`context`, `exception`, and more as paths are added), and a preview
+        # cares only that a row was unusable - not why, since it files nothing.
         self.rejected_rows += 1
+
+    def _content_type_for(self, model):
+        # Read-only: a cached ContentType lookup, which the macaddress path
+        # needs to compare an existing assignment against the incoming one.
+        from .sync_primitives import content_type_for
+
+        return content_type_for(self, model)
+
+    # --- read-only lookups the classification needs -------------------------
+    #
+    # Each is delegated to the same primitive the real runner uses, so the
+    # preview resolves objects exactly as the apply would. They were added one
+    # at a time as the classification demanded them; every one was checked for
+    # writes first, and the ones that write are why four of the five bespoke
+    # paths still report no comparison.
+
+    def _get_unique_or_raise(self, model, lookup):
+        from .sync_primitives import get_unique_or_raise
+
+        return get_unique_or_raise(self, model, lookup)
+
+    def _lookup_interface(self, device, interface_name):
+        from .sync_primitives import lookup_interface
+
+        return lookup_interface(self, device, interface_name)
+
+    # --- state the classification reports into, which a preview discards ----
+
+    def _dependency_failed(self, model_string, key):
+        # Nothing has been applied, so nothing can have failed as a dependency.
+        return False
+
+    def _mark_dependency_failed(self, model_string, row):
+        return None
+
+    def _record_aggregated_skip_warning(self, **kwargs):
+        return None
 
 
 def compare_model_rows(sync, model_string, rows):
@@ -89,4 +135,23 @@ def compare_model_rows(sync, model_string, rows):
         # count mapping is treated as "not compared" rather than coerced, so a
         # path this has not audited can never surface as zero drift.
         return None
-    return {**counts, "rejected": runner.rejected_rows}
+    outcomes = runner.logger.outcomes
+    return {
+        "creates": counts.get("creates", 0),
+        "updates": counts.get("updates", 0),
+        # Taken from the per-row outcomes the classification already reports
+        # rather than recomputed per path. Every path increments "unchanged"
+        # for a row it would not write, so this is one definition instead of
+        # one per function - and the paths differ enough (skips, per-row
+        # rejections, in-memory duplicates) that arithmetic on row totals would
+        # quietly disagree with them.
+        "unchanged": outcomes.get("unchanged", 0),
+        # A row the classification could not use is not a difference between
+        # the two systems; it is a defect in the row. Counted separately so it
+        # never inflates drift.
+        #
+        # Read from the outcomes alone, not added to `rejected_rows`: a single
+        # unusable row both files an issue and increments "failed", so summing
+        # the two counted it twice.
+        "rejected": outcomes.get("failed", 0) + outcomes.get("skipped", 0),
+    }

--- a/forward_netbox/utilities/drift_report.py
+++ b/forward_netbox/utilities/drift_report.py
@@ -173,9 +173,16 @@ def compute_drift_report(payload):
         ),
         reverse=True,
     )
-    comparison_available = bool(rows) and all(
-        row["comparison_available"] for row in rows
-    )
+    measured_rows = [row for row in rows if row["comparison_available"]]
+    unmeasured_rows = [row for row in rows if not row["comparison_available"]]
+    # Drift is reported over the models that were actually compared, rather than
+    # withheld until every model can be. Requiring all of them meant one
+    # uncovered model - and there is always at least one, because the
+    # adapter-only models have no comparison - reported "Not measured" for the
+    # whole estate on every run, permanently. "Drift 412 across 13 of 27 models"
+    # is useful and true; "Not measured" was neither.
+    comparison_available = bool(measured_rows)
+    fully_measured = bool(rows) and not unmeasured_rows
     # Fingerprint of a preview taken against an empty/unmerged NetBox: several
     # models, every one of them fully pending, zero removals. That is "here is
     # everything Forward has," not real per-row drift — flag it so the operator
@@ -190,8 +197,17 @@ def compute_drift_report(payload):
         "models": rows,
         "model_count": len(rows),
         "comparison_available": comparison_available,
+        # How much of the estate the drift figures actually cover. Reported
+        # alongside them rather than implied, so a partial measurement is never
+        # read as a whole-estate one.
+        "measured_model_count": len(measured_rows),
+        "unmeasured_model_count": len(unmeasured_rows),
+        "unmeasured_models": sorted(
+            row["model"] for row in unmeasured_rows if row.get("model")
+        ),
+        "fully_measured": fully_measured,
         "drifted_model_count": (
-            sum(1 for row in rows if not row["in_sync"])
+            sum(1 for row in measured_rows if not row["in_sync"])
             if comparison_available
             else None
         ),
@@ -199,7 +215,12 @@ def compute_drift_report(payload):
         "total_apply_work": total_apply_work,
         "total_upsert_candidates": total_upsert_candidates,
         "total_removes": total_removes,
-        "in_sync": total_drift == 0 if comparison_available else None,
+        # "In sync" is a claim about the whole estate, so it stays unanswered
+        # while any model is uncompared. Zero drift across the measured models
+        # is reported as `total_drift`, which says what it covers; answering
+        # "Yes" off a partial measurement would tell an operator they are in
+        # sync when nothing checked the rest.
+        "in_sync": (total_drift == 0) if (fully_measured and rows) else None,
         "looks_like_full_create": looks_like_full_create,
         "full_create_model_count": full_create_like,
         "generated_at": (

--- a/forward_netbox/views.py
+++ b/forward_netbox/views.py
@@ -473,7 +473,7 @@ def _dependency_plan_item_summary(item):
     }
 
 
-def _dependency_model_result_summary(result):
+def _dependency_model_result_summary(result, comparison=None):
     # ``fetcher.model_results`` are ForwardModelResult dataclasses, not dicts —
     # calling result.get(...) on them raised AttributeError and errored the whole
     # dependency preview (hidden as null-data until 2.2.4 surfaced job errors).
@@ -502,10 +502,24 @@ def _dependency_model_result_summary(result):
         "failure_count": int(data.get("failure_count") or 0),
         "failure_exception": str(data.get("failure_exception") or ""),
         "failure_reason": str(data.get("failure_reason") or ""),
-        # Per-model change estimate: upsert rows + deletes (as_dict has no
-        # estimated_changes field). The plan-level total is plan_preview.
-        "estimated_changes": row_count + delete_count,
-        "change_estimate_kind": "workload_upper_bound",
+        # Per-model change estimate. With a comparison this is how many objects
+        # actually differ - creates plus updates, deletes counted separately by
+        # the drift report - so the figure means what the page has always said
+        # it meant. Without one it stays the upper bound: every fetched row,
+        # because nothing compared them.
+        "estimated_changes": (
+            comparison["creates"] + comparison["updates"]
+            if comparison
+            else row_count + delete_count
+        ),
+        "change_estimate_kind": (
+            "exact_comparison" if comparison else "workload_upper_bound"
+        ),
+        # Rows the comparison could not classify because they carry no usable
+        # identity. Reported rather than folded into drift, which would read as
+        # a difference between the two systems when it is a defect in the row.
+        "comparison_rejected_rows": (comparison or {}).get("rejected", 0),
+        "unchanged_rows": (comparison or {}).get("unchanged", 0),
         "runtime_ms": float(data.get("runtime_ms") or 0.0),
         # Preserve aggregate state evidence without copying diagnostic samples or
         # source identifiers into the preview job payload.
@@ -544,6 +558,26 @@ def _dependency_dry_run_payload(sync, *, client=None):
     )
     plan_items = [_dependency_plan_item_summary(item) for item in plan]
     context_dict = context.as_dict()
+
+    # Compare the fetched rows against NetBox so the drift report can state how
+    # many objects actually differ. This is the NetBox-side read the preview
+    # never did; it costs no Forward calls, because the Forward half is already
+    # in `workloads`. Models with no comparison yet return None and keep their
+    # upper-bound estimate rather than reporting a confident zero.
+    from collections import defaultdict
+
+    from .utilities.drift_comparison import compare_model_rows
+
+    rows_by_model = defaultdict(list)
+    for workload in workloads:
+        rows_by_model[workload.model_string].extend(workload.upsert_rows or [])
+    comparison_by_model = {
+        model_string: compare_model_rows(sync, model_string, rows)
+        for model_string, rows in rows_by_model.items()
+    }
+    measured_models = sum(
+        1 for value in comparison_by_model.values() if value is not None
+    )
     return {
         "generated_at": timezone.now().isoformat(),
         "sync": {
@@ -560,9 +594,25 @@ def _dependency_dry_run_payload(sync, *, client=None):
         "plan_items_count": len(plan_items),
         "plan_items_truncated": len(plan_items) > _PREVIEW_PLAN_ITEM_LIMIT,
         "plan_items": plan_items[:_PREVIEW_PLAN_ITEM_LIMIT],
-        "change_estimate_kind": "workload_upper_bound",
+        # Payload-level kind describes the weakest model in the set, so a
+        # partially compared preview never advertises itself as exact.
+        "change_estimate_kind": (
+            "exact_comparison"
+            if comparison_by_model and measured_models == len(comparison_by_model)
+            else "workload_upper_bound"
+        ),
+        "comparison_coverage": {
+            "measured_models": measured_models,
+            "total_models": len(comparison_by_model),
+        },
         "model_results": [
-            _dependency_model_result_summary(result) for result in fetcher.model_results
+            _dependency_model_result_summary(
+                result,
+                comparison=comparison_by_model.get(
+                    (result.as_dict().get("model") or "")
+                ),
+            )
+            for result in fetcher.model_results
         ],
         "forward_api_usage": record_forward_api_usage(sync, client),
     }


### PR DESCRIPTION
First slice of #206. `In sync`, `Drifted models` and `Total drift` read "Not measured" on every run for every deployment, permanently — `EXACT_COMPARISON` was defined and produced nowhere, because the dependency preview counted every fetched row as a change.

`compare_model_rows` routes through `bulk_orm_apply_simple_models(preview=True)` rather than reimplementing the comparison. A second normaliser drifts from the first, and the symptom would be a drift figure wrong in whichever direction is least noticeable — worse than no figure, because an operator would act on it.

## Making it read-only took six suppressions, and only two were predicted

| what | if it had shipped |
| --- | --- |
| `:563` creates missing manufacturers | preview creates rows in the operator's NetBox |
| `:602` creates missing VRFs | same |
| `return False` (unknown model) | reads as **zero drift** |
| `return True` (all rows rejected) | reads as **zero drift** |
| `bulk_orm_apply_tree_models` delegation | reads as **zero drift**, and writes |
| `full_clean` on creates | rejects a row whose dependency was deliberately not created |

The three bool exits are the ones worth noting: a bool is falsy, so a caller reading counts off it reports a confident zero. `compare_model_rows` now refuses anything that is not a count mapping, so an unaudited path cannot surface as zero drift either.

The last one only appeared by running it — a device type whose manufacturer is absent fails `full_clean` on a null FK while still being, plainly, a row NetBox does not have. A preview counts what would change; validation belongs to the apply.

## Reporting stops being all-or-nothing

`comparison_available` is now `any`, not `all`, plus `measured_model_count`, `unmeasured_model_count` and `unmeasured_models`. Requiring every model meant one uncovered model silenced the whole estate — and there is always at least one, because the adapter-only models have no comparison.

**`in_sync` deliberately stays `None` until every model is compared.** Zero drift across a measured subset is reported as `total_drift`, which states its coverage. Answering "Yes" off a partial measurement would tell an operator they are in sync when nothing checked the rest.

## Coverage

Covered: `dcim.site`, `dcim.manufacturer`, `dcim.devicetype`, `ipam.vlan`, `ipam.vrf`, `ipam.prefix`.

Not yet: the bespoke paths (`device`, `interface`, `ipaddress`, `macaddress`, `virtualchassis`) return `None` and keep their upper bound. They are the reporting deployment's highest-volume models, so slice two is where this becomes useful to them rather than merely correct. Each needs its own audit for hidden writes — do not assume the pattern found here is the only one.

## Tests

**2135 pass** — 2121 before, plus these 14. The six guards all default to `False` and no existing caller can reach them, which is what the unchanged suite proves. The tests that matter most count rows before and after and assert the VRF and manufacturer tables are untouched.

Keeps #206 open for slice two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)