### PR TITLE
feat(drift): measure ipam.ipaddress, and correct the audit method

### DIFF
--- a/docs/03_Plans/active/2026-08-15-measure-real-drift.md
+++ b/docs/03_Plans/active/2026-08-15-measure-real-drift.md
@@ -172,7 +172,7 @@ writes to models the function does not own, and one of them is a delete:
 | `macaddress` | none | **measured** |
 | `ipaddress` | `Device.objects.bulk_update`, **plus a VRF upsert via `runner._ensure_vrf`** | **measured** |
 | `interface` | **`cable.delete()`**, plus two recursive self-calls | **measured** |
-| `device` | creates `Tag` and `TaggedItem` rows | deferred |
+| `device` | creates `Tag` and `TaggedItem` rows, **upserts a Platform and a Manufacturer under it** | **measured** |
 | `virtualchassis` | creates `VirtualChassis`, THEN assigns devices to them | deferred |
 
 A preview on `interface` would have deleted cables. On `device` it would have
@@ -262,19 +262,38 @@ That is the third time this feature has produced a confident zero from an
 unmeasured path - after the bool exits and the `all()` gate. It is worth
 treating as the default failure mode of this work rather than a coincidence.
 
+### device
+
+Clean in the shape that mattered: the `Tag`, `Device` and `TaggedItem` writes
+all sit inside one transaction, and `_ensure_scope_tags_in_transaction` is
+called from within it rather than during classification, so nothing classified
+reads them back. One early return covers all three.
+
+The trap was `runner._ensure_platform`, which upserts a `Platform` and calls
+`_ensure_manufacturer` under it, which upserts too - reached during
+classification and invisible to the write grep. The same shape as `_ensure_vrf`
+in slice three, which is why it was looked for rather than discovered. Both are
+overridden with lookups.
+
+Like `interface`, `device` defers statistics via `row_outcomes`, so the preview
+return emits them before returning.
+
+One more surfaced here: `_scope_tags_enabled` reads `runner.sync.source`
+directly, so a caller with no sync raised. The shim now carries a null sync that
+reports no opt-in parameters. Production always passes the real one, so this
+only affects callers that have none, and it degrades rather than guesses.
+
 ### Still to do
 
-`device` and `virtualchassis`.
+`virtualchassis`, and it is the one genuinely different case.
 
-`device` looks tractable: `Tag` and `TaggedItem` creation is a phase, and if it
-sits after device classification the same early return works. Check whether
-classification reads back the tags it creates before assuming so.
-
-`virtualchassis` is the genuinely awkward one. Its second phase reads `vc.pk`
-from rows the first phase creates, so there is no verdict to shortcut to the
-way there was for `interface`. Either model the intended post-write state, or
-accept it as permanently upper-bound and say so - it is a low-volume model, so
-the second is defensible.
+Its second phase reads `vc.pk` from rows the first phase creates, so unlike
+`interface` there is no verdict to shortcut to: the classification cannot be
+computed without the write. Either model the intended post-write state, or
+accept it as permanently upper-bound and label it. It is a low-volume model, so
+the second is defensible and the first is probably not worth it - but inventing
+a number for it would be worse than either, so it declines to answer until
+someone decides.
 
 ## Rollback
 

--- a/docs/03_Plans/active/2026-08-15-measure-real-drift.md
+++ b/docs/03_Plans/active/2026-08-15-measure-real-drift.md
@@ -171,7 +171,7 @@ writes to models the function does not own, and one of them is a delete:
 | --- | --- | --- |
 | `macaddress` | none | **measured** |
 | `ipaddress` | `Device.objects.bulk_update`, **plus a VRF upsert via `runner._ensure_vrf`** | **measured** |
-| `interface` | **`cable.delete()`**, plus two recursive self-calls | deferred |
+| `interface` | **`cable.delete()`**, plus two recursive self-calls | **measured** |
 | `device` | creates `Tag` and `TaggedItem` rows | deferred |
 | `virtualchassis` | creates `VirtualChassis`, THEN assigns devices to them | deferred |
 
@@ -234,20 +234,47 @@ with them.
 double-counted, because a single unusable row both files an issue and
 increments `failed`.
 
+### interface, and why it was not the hard case after all
+
+It was written off as not guard-shaped, on the reasoning that later
+classification depends on the cable delete having happened. Reading it properly
+says otherwise.
+
+The conversion exists because NetBox refuses `type=lag` on a cabled interface,
+so the apply snapshots while cabled, deletes the cable, and re-enters this
+function to apply the row as an ordinary interface. The recursion performs the
+change in two legal steps. **A preview does not need the steps, only the
+verdict** - an existing cabled interface becoming a LAG is unambiguously a
+change to a row NetBox already has. So the conversions are skipped whole and
+those rows count as updates. Counted without being performed.
+
+They cannot double-count: both branches filling `cabled_lag_rows` `continue`
+before reaching `create_objects` or `update_objects`.
+
+One structural gotcha, and it is a new variant of the recurring one. Interface
+is the first path that defers its per-row statistics to the end of the function
+rather than incrementing inline. A plain early return before the write block
+would have emitted none of them, so the shim would have seen no rows and
+reported **zero drift** for the highest-volume model in the estate. The preview
+return emits the outcomes before returning.
+
+That is the third time this feature has produced a confident zero from an
+unmeasured path - after the bool exits and the `all()` gate. It is worth
+treating as the default failure mode of this work rather than a coincidence.
+
 ### Still to do
 
-`device`, `interface` and `virtualchassis`.
+`device` and `virtualchassis`.
 
-`device` is the tractable one: `Tag` and `TaggedItem` creation is a phase, and
-if it sits after device classification the same early return works. Check
-whether classification reads back the tags it creates before assuming so.
+`device` looks tractable: `Tag` and `TaggedItem` creation is a phase, and if it
+sits after device classification the same early return works. Check whether
+classification reads back the tags it creates before assuming so.
 
-`interface` and `virtualchassis` are not guard-shaped. In both, a write happens
-partway and later classification depends on its result - a deleted cable, a
-created `VirtualChassis`. Options are to model the intended post-write state
-without performing it, or to accept these two as permanently upper-bound and
-say so on the panel. The second is honest and cheap; the first is what an
-operator would want for `interface`, which is high volume.
+`virtualchassis` is the genuinely awkward one. Its second phase reads `vc.pk`
+from rows the first phase creates, so there is no verdict to shortcut to the
+way there was for `interface`. Either model the intended post-write state, or
+accept it as permanently upper-bound and say so - it is a low-volume model, so
+the second is defensible.
 
 ## Rollback
 

--- a/docs/03_Plans/active/2026-08-15-measure-real-drift.md
+++ b/docs/03_Plans/active/2026-08-15-measure-real-drift.md
@@ -283,17 +283,44 @@ directly, so a caller with no sync raised. The shim now carries a null sync that
 reports no opt-in parameters. Production always passes the real one, so this
 only affects callers that have none, and it degrades rather than guesses.
 
-### Still to do
+### virtualchassis: decided, not outstanding
 
-`virtualchassis`, and it is the one genuinely different case.
+An earlier version of this plan said there was "no verdict to shortcut to" for
+`virtualchassis`. That was wrong, and worth correcting rather than quietly
+dropping: a device whose target `VirtualChassis` is absent is unambiguously a
+change, exactly the reasoning that made `interface` and every absent-dependency
+case work. It is tractable.
 
-Its second phase reads `vc.pk` from rows the first phase creates, so unlike
-`interface` there is no verdict to shortcut to: the classification cannot be
-computed without the write. Either model the intended post-write state, or
-accept it as permanently upper-bound and label it. It is a low-volume model, so
-the second is defensible and the first is probably not worth it - but inventing
-a number for it would be worse than either, so it declines to answer until
-someone decides.
+What rules it out is that an unsaved VC breaks the device phase in three
+separate places, and two of them fail silently:
+
+- `position_key = (vc.pk, position)` - every to-be-created VC collapses to
+  `(None, position)`, so unrelated VCs collide as one occupied slot
+- `device.virtual_chassis_id == vc.pk` - a device with NO chassis compares equal
+  to `None` and is counted **unchanged**
+- `device.full_clean()` - validates against an unsaved foreign key
+
+The middle one under-counts drift while looking correct. That is the precise
+failure this feature exists to prevent, and avoiding it means getting all three
+right in the least-exercised path of the set.
+
+Against that: `virtualchassis` is low volume, and measuring it unlocks nothing.
+`in_sync` stays unanswered regardless, because the adapter-only models have no
+comparison either - so the estate is never "fully measured" whether this lands
+or not.
+
+**Decision: leave it declining to answer.** A model reported as unmeasured is a
+worse report and a better number than a model reported as in sync because three
+subtle comparisons all defaulted to "same". Revisit only if a deployment turns
+out to lean on virtual chassis.
+
+### Genuinely still open
+
+The adapter-only models - the lifecycle rows, cables, inventory items, modules,
+tagged items, FHRP groups, routing and peering. They have no bulk path at all,
+so none of this machinery reaches them, and each needs its own row resolution.
+That is a separate body of work, and until it happens `in_sync` stays `None` by
+design.
 
 ## Rollback
 

--- a/docs/03_Plans/active/2026-08-15-measure-real-drift.md
+++ b/docs/03_Plans/active/2026-08-15-measure-real-drift.md
@@ -167,21 +167,46 @@ The audit was run before any of them was wired up, and it justified itself.
 Slice one's hidden writes were dependency creates. These are worse - they are
 writes to models the function does not own, and one of them is a delete:
 
-| path | writes beyond its own rows |
-| --- | --- |
-| `macaddress` | none - **cleared** |
-| `interface` | **`cable.delete()`**, plus two recursive self-calls |
-| `device` | creates `Tag` and `TaggedItem` rows |
-| `ipaddress` | `Device.objects.bulk_update` (primary-IP assignment) |
-| `virtualchassis` | `Device.objects.bulk_update` |
+| path | writes beyond its own rows | state |
+| --- | --- | --- |
+| `macaddress` | none | **measured** |
+| `ipaddress` | `Device.objects.bulk_update`, **plus a VRF upsert via `runner._ensure_vrf`** | **measured** |
+| `interface` | **`cable.delete()`**, plus two recursive self-calls | deferred |
+| `device` | creates `Tag` and `TaggedItem` rows | deferred |
+| `virtualchassis` | creates `VirtualChassis`, THEN assigns devices to them | deferred |
 
 A preview on `interface` would have deleted cables. On `device` it would have
 created tags and tag assignments. "Return before the final `bulk_create`" is
-not sufficient for any of the four, and the dispatch now carries this table as
-a comment so nobody assumes otherwise.
+not sufficient for any of the three deferred paths, and the dispatch carries
+this table as a comment so nobody assumes otherwise.
 
-Only `macaddress` is wired up. The other four return `None` and keep their
-upper bound.
+### The audit method was wrong, and ipaddress proved it
+
+The first pass grepped for direct ORM writes - `bulk_create`, `bulk_update`,
+`.save(`, `.delete(`. That reported `ipaddress` as having one cross-model
+write. It has two: the second is `runner._ensure_vrf`, called during
+classification, which upserts a VRF. A grep for ORM calls cannot see a write
+behind a runner method.
+
+What makes that survivable is that **the preview runner is a write firewall**.
+Every `runner.` call is answered by the shim, so a write behind one is
+neutralised by construction, and a method the shim does not implement raises
+`AttributeError` rather than writing. Loud beats silent.
+
+So the grep is the right tool for direct writes and the wrong tool on its own.
+Adding a path means reading its `runner.` calls too. `_ensure_vrf` is now
+overridden with a lookup returning `None` for an absent VRF - the same
+treatment slice one gives an absent dependency, and correct for the same
+reason: an address cannot already exist under a VRF NetBox does not have.
+
+### virtualchassis was mis-triaged too
+
+Listed initially as a single `Device.objects.bulk_update`. It is two-phase: it
+creates `VirtualChassis` rows, then assigns devices to them, and the second
+phase reads `vc.pk` from the first. Skipping phase one does not yield a
+classifiable phase two. Same shape as `interface`'s cable delete - the
+classification depends on the write having happened - so it needs design, not
+a guard.
 
 ### The shim is the cost of coverage
 
@@ -211,10 +236,18 @@ increments `failed`.
 
 ### Still to do
 
-`interface`, `device`, `ipaddress` and `virtualchassis` - the reporting
-deployment's highest-volume models. Each needs its cross-model writes
-suppressed individually, and `interface`'s cable delete needs care rather than
-a guard: the classification may depend on it having happened.
+`device`, `interface` and `virtualchassis`.
+
+`device` is the tractable one: `Tag` and `TaggedItem` creation is a phase, and
+if it sits after device classification the same early return works. Check
+whether classification reads back the tags it creates before assuming so.
+
+`interface` and `virtualchassis` are not guard-shaped. In both, a write happens
+partway and later classification depends on its result - a deleted cable, a
+created `VirtualChassis`. Options are to model the intended post-write state
+without performing it, or to accept these two as permanently upper-bound and
+say so on the panel. The second is honest and cheap; the first is what an
+operator would want for `interface`, which is high volume.
 
 ## Rollback
 

--- a/forward_netbox/tests/test_drift_comparison.py
+++ b/forward_netbox/tests/test_drift_comparison.py
@@ -132,16 +132,16 @@ class UncoveredModelsReportNoComparisonTest(TestCase):
     """
 
     def test_the_unaudited_bespoke_paths_return_none_under_preview(self):
-        """Each of these writes to a model other than its own.
+        """The two paths still without a comparison.
 
-        `interface` deletes cables, `device` creates Tag and TaggedItem rows,
-        and `ipaddress` and `virtualchassis` both bulk_update Device. Returning
-        before their final write would not make them read-only, so until each is
-        handled they must decline to answer rather than answer wrongly.
+        `device` creates Tag and TaggedItem rows. `virtualchassis` creates
+        VirtualChassis rows and then reads their pks back to assign devices, so
+        skipping the first phase leaves the second unclassifiable. Returning
+        before their final write would not make either read-only, so until each
+        is handled they must decline to answer rather than answer wrongly.
         """
         for model_string in (
             "dcim.device",
-            "dcim.interface",
             "dcim.virtualchassis",
         ):
             with self.subTest(model=model_string):
@@ -229,6 +229,102 @@ class IpAddressComparisonTest(TestCase):
 
         self.assertIsNotNone(result)
         self.assertEqual(result["creates"], 0)
+
+
+class InterfaceComparisonTest(TestCase):
+    """interface deletes a cable partway through applying, and re-enters itself.
+
+    NetBox refuses `type=lag` on a cabled interface, so the apply removes the
+    cable and re-applies the row. A preview must not do that - it is the most
+    destructive thing any of these paths does - and must still count the row,
+    because an existing cabled interface becoming a LAG is plainly a change.
+    """
+
+    def setUp(self):
+        from dcim.models import Device
+        from dcim.models import DeviceRole
+        from dcim.models import DeviceType
+
+        site = Site.objects.create(name="I Site", slug="i-site")
+        mfr = Manufacturer.objects.create(name="I Mfr", slug="i-mfr")
+        dtype = DeviceType.objects.create(manufacturer=mfr, model="I DT", slug="i-dt")
+        role = DeviceRole.objects.create(name="I Role", slug="i-role")
+        self.device = Device.objects.create(
+            name="iface-dev", site=site, device_type=dtype, role=role
+        )
+
+    def test_a_cabled_lag_conversion_does_not_delete_the_cable(self):
+        from dcim.models import Cable
+        from dcim.models import Interface
+
+        left = Interface.objects.create(
+            device=self.device, name="Ethernet1", type="1000base-t"
+        )
+        right = Interface.objects.create(
+            device=self.device, name="Ethernet2", type="1000base-t"
+        )
+        cable = Cable.objects.create(
+            a_terminations=[left], b_terminations=[right], status="connected"
+        )
+        cables_before = Cable.objects.count()
+
+        result = compare_model_rows(
+            None,
+            "dcim.interface",
+            [{"device": "iface-dev", "name": "Ethernet1", "type": "lag"}],
+        )
+
+        self.assertEqual(Cable.objects.count(), cables_before)
+        self.assertTrue(Cable.objects.filter(pk=cable.pk).exists())
+        left.refresh_from_db()
+        self.assertIsNotNone(left.cable_id)
+        # Still counted, just not performed.
+        self.assertIsNotNone(result)
+        self.assertEqual(result["updates"], 1)
+
+    def test_an_interface_preview_creates_nothing(self):
+        from dcim.models import Interface
+
+        before = Interface.objects.count()
+
+        result = compare_model_rows(
+            None,
+            "dcim.interface",
+            [
+                {
+                    "device": "iface-dev",
+                    "name": "Ethernet9",
+                    "type": "1000base-t",
+                    "enabled": True,
+                }
+            ],
+        )
+
+        self.assertEqual(Interface.objects.count(), before)
+        self.assertEqual(result["creates"], 1)
+
+    def test_an_unchanged_interface_is_not_drift(self):
+        from dcim.models import Interface
+
+        Interface.objects.create(
+            device=self.device, name="Ethernet3", type="1000base-t"
+        )
+
+        result = compare_model_rows(
+            None,
+            "dcim.interface",
+            [
+                {
+                    "device": "iface-dev",
+                    "name": "Ethernet3",
+                    "type": "1000base-t",
+                    "enabled": True,
+                }
+            ],
+        )
+
+        self.assertEqual(result["creates"], 0)
+        self.assertEqual(result["updates"], 0)
 
 
 class PartialCoverageIsReportedTest(TestCase):

--- a/forward_netbox/tests/test_drift_comparison.py
+++ b/forward_netbox/tests/test_drift_comparison.py
@@ -132,23 +132,18 @@ class UncoveredModelsReportNoComparisonTest(TestCase):
     """
 
     def test_the_unaudited_bespoke_paths_return_none_under_preview(self):
-        """The two paths still without a comparison.
+        """The one path still without a comparison.
 
-        `device` creates Tag and TaggedItem rows. `virtualchassis` creates
-        VirtualChassis rows and then reads their pks back to assign devices, so
-        skipping the first phase leaves the second unclassifiable. Returning
-        before their final write would not make either read-only, so until each
-        is handled they must decline to answer rather than answer wrongly.
+        `virtualchassis` creates VirtualChassis rows and then reads their pks
+        back to assign devices, so skipping the first phase leaves the second
+        unclassifiable - there is no verdict to shortcut to, the way there was
+        for `interface`. Until that is handled it must decline to answer rather
+        than answer wrongly.
         """
-        for model_string in (
-            "dcim.device",
-            "dcim.virtualchassis",
-        ):
-            with self.subTest(model=model_string):
-                self.assertIsNone(
-                    compare_model_rows(None, model_string, [{"name": "x"}]),
-                    f"{model_string} has no comparison yet and must not claim one",
-                )
+        self.assertIsNone(
+            compare_model_rows(None, "dcim.virtualchassis", [{"name": "x"}]),
+            "virtualchassis has no comparison yet and must not claim one",
+        )
 
     def test_an_empty_row_set_is_zero_drift_rather_than_unmeasured(self):
         # Nothing fetched genuinely is nothing to change, for any model.
@@ -322,6 +317,102 @@ class InterfaceComparisonTest(TestCase):
                 }
             ],
         )
+
+        self.assertEqual(result["creates"], 0)
+        self.assertEqual(result["updates"], 0)
+
+
+class DeviceComparisonTest(TestCase):
+    """device creates Tags and TaggedItems, and upserts a Platform.
+
+    The Tag and TaggedItem writes are inside the same transaction as the Device
+    write, so an early return skips them. The Platform upsert is not - it is
+    reached through `runner._ensure_platform` during classification, and it
+    creates a Manufacturer under it, so the preview runner overrides both.
+    """
+
+    def setUp(self):
+        from dcim.models import DeviceRole
+        from dcim.models import DeviceType
+
+        self.site = Site.objects.create(name="D Site", slug="d-site")
+        mfr = Manufacturer.objects.create(name="D Mfr", slug="d-mfr")
+        self.dtype = DeviceType.objects.create(
+            manufacturer=mfr, model="D DT", slug="d-dt"
+        )
+        self.role = DeviceRole.objects.create(name="D Role", slug="d-role")
+
+    def _row(self, name, **extra):
+        row = {
+            "name": name,
+            "site": "D Site",
+            "site_slug": "d-site",
+            "device_type": "D DT",
+            "device_type_slug": "d-dt",
+            "manufacturer": "D Mfr",
+            "manufacturer_slug": "d-mfr",
+            "role": "D Role",
+            "role_slug": "d-role",
+            "status": "active",
+        }
+        row.update(extra)
+        return row
+
+    def test_a_device_preview_creates_no_device(self):
+        from dcim.models import Device
+
+        before = Device.objects.count()
+
+        result = compare_model_rows(None, "dcim.device", [self._row("new-dev")])
+
+        self.assertEqual(Device.objects.count(), before)
+        self.assertIsNotNone(result)
+
+    def test_a_device_preview_creates_no_platform_or_manufacturer(self):
+        from dcim.models import Platform
+
+        platforms_before = Platform.objects.count()
+        mfrs_before = Manufacturer.objects.count()
+
+        compare_model_rows(
+            None,
+            "dcim.device",
+            [
+                self._row(
+                    "plat-dev",
+                    platform="Platform That Does Not Exist",
+                    platform_slug="platform-that-does-not-exist",
+                )
+            ],
+        )
+
+        self.assertEqual(Platform.objects.count(), platforms_before)
+        self.assertEqual(Manufacturer.objects.count(), mfrs_before)
+
+    def test_a_device_preview_creates_no_tags(self):
+        from extras.models import Tag
+        from extras.models import TaggedItem
+
+        tags_before = Tag.objects.count()
+        assignments_before = TaggedItem.objects.count()
+
+        compare_model_rows(None, "dcim.device", [self._row("tag-dev")])
+
+        self.assertEqual(Tag.objects.count(), tags_before)
+        self.assertEqual(TaggedItem.objects.count(), assignments_before)
+
+    def test_an_unchanged_device_is_not_drift(self):
+        from dcim.models import Device
+
+        Device.objects.create(
+            name="steady-dev",
+            site=self.site,
+            device_type=self.dtype,
+            role=self.role,
+            status="active",
+        )
+
+        result = compare_model_rows(None, "dcim.device", [self._row("steady-dev")])
 
         self.assertEqual(result["creates"], 0)
         self.assertEqual(result["updates"], 0)

--- a/forward_netbox/tests/test_drift_comparison.py
+++ b/forward_netbox/tests/test_drift_comparison.py
@@ -142,7 +142,6 @@ class UncoveredModelsReportNoComparisonTest(TestCase):
         for model_string in (
             "dcim.device",
             "dcim.interface",
-            "ipam.ipaddress",
             "dcim.virtualchassis",
         ):
             with self.subTest(model=model_string):
@@ -185,6 +184,48 @@ class MacAddressComparisonTest(TestCase):
         # The point of auditing it: a clean path should report a comparison, not
         # be lumped in with the ones that cannot.
         result = compare_model_rows(None, "dcim.macaddress", [])
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["creates"], 0)
+
+
+class IpAddressComparisonTest(TestCase):
+    """ipaddress writes a VRF mid-classification, behind a runner call.
+
+    The audit grep looks for direct ORM writes and did not see it. It is
+    neutralised because the preview runner overrides `_ensure_vrf` with a
+    lookup - so these tests exist to hold that override in place, since losing
+    it would put VRF creation back into a read-only preview silently.
+    """
+
+    def test_an_ipaddress_preview_does_not_create_the_missing_vrf(self):
+        before = set(VRF.objects.values_list("name", flat=True))
+
+        compare_model_rows(
+            None,
+            "ipam.ipaddress",
+            [{"address": "10.77.0.1/32", "vrf": "vrf-absent-from-netbox"}],
+        )
+
+        self.assertEqual(set(VRF.objects.values_list("name", flat=True)), before)
+        self.assertFalse(VRF.objects.filter(name="vrf-absent-from-netbox").exists())
+
+    def test_an_ipaddress_preview_creates_no_address(self):
+        from ipam.models import IPAddress
+
+        before = IPAddress.objects.count()
+
+        result = compare_model_rows(
+            None,
+            "ipam.ipaddress",
+            [{"address": "10.77.0.2/32"}],
+        )
+
+        self.assertEqual(IPAddress.objects.count(), before)
+        self.assertIsNotNone(result)
+
+    def test_it_answers_rather_than_declining(self):
+        result = compare_model_rows(None, "ipam.ipaddress", [])
 
         self.assertIsNotNone(result)
         self.assertEqual(result["creates"], 0)

--- a/forward_netbox/utilities/apply_engine_bulk.py
+++ b/forward_netbox/utilities/apply_engine_bulk.py
@@ -460,7 +460,6 @@ def bulk_orm_apply_simple_models(
     # what they do, so nobody wires one up on the assumption that returning
     # before the final bulk_create is sufficient - it is not:
     #
-    #   device          creates Tag and TaggedItem rows
     #   virtualchassis  creates VirtualChassis rows, THEN assigns devices to
     #                   them - so the second phase needs the first to have
     #                   happened and cannot simply be skipped
@@ -472,6 +471,11 @@ def bulk_orm_apply_simple_models(
     # `interface` is handled: its cabled-LAG conversions delete a cable and
     # re-enter the function, so a preview skips them and counts those rows as
     # the updates they plainly are.
+    #
+    # `device` is handled: its Tag, Device and TaggedItem writes all happen
+    # inside one transaction that classification does not read back from, and
+    # its `_ensure_platform` (which upserts a Platform, and a Manufacturer
+    # under it) is overridden by the preview runner with a lookup.
     #
     # Note the audit that produced this list greps for direct ORM writes and so
     # does NOT see writes behind a runner call. That is safe only because the
@@ -490,7 +494,7 @@ def bulk_orm_apply_simple_models(
     if model_string == "dcim.interface":
         return bulk_orm_apply_interface(runner, rows, preview=preview)
     if model_string == "dcim.device":
-        return None if preview else bulk_orm_apply_device(runner, rows)
+        return bulk_orm_apply_device(runner, rows, preview=preview)
 
     from dcim.models import DeviceType
     from dcim.models import DeviceRole
@@ -1896,7 +1900,7 @@ def _device_field_differs(existing, field, value):
     return getattr(existing, field) != value
 
 
-def bulk_orm_apply_device(runner, rows: list[dict[str, Any]]):
+def bulk_orm_apply_device(runner, rows: list[dict[str, Any]], *, preview=False):
     """Batched apply for dcim.device with adapter-parity semantics.
 
     The clean common case — a device whose site/role/device-type (and optional
@@ -2244,6 +2248,21 @@ def bulk_orm_apply_device(runner, rows: list[dict[str, Any]]):
             if isinstance(name_cache, dict):
                 name_cache[tag.name] = tag
         return {name: tag for name, tag in resolved.items() if tag is not None}
+
+    if preview:
+        # Every write this path performs - the scope Tags, the Devices, and the
+        # TaggedItem assignments - happens inside the transaction below, and
+        # `_ensure_scope_tags_in_transaction` is called from within it rather
+        # than during classification. So returning here performs none of them,
+        # and no classification result depends on them having happened.
+        #
+        # Statistics are emitted first for the same reason as in the interface
+        # path: this function defers them to the end via `row_outcomes`, so a
+        # bare return would leave the shim seeing no rows and reporting zero
+        # drift for the largest model in the estate.
+        for (outcome,) in row_outcomes:
+            runner.logger.increment_statistics("dcim.device", outcome=outcome)
+        return {"creates": len(create_objects), "updates": len(update_objects)}
 
     with transaction.atomic(using=using):
         try:

--- a/forward_netbox/utilities/apply_engine_bulk.py
+++ b/forward_netbox/utilities/apply_engine_bulk.py
@@ -461,8 +461,7 @@ def bulk_orm_apply_simple_models(
     # before the final bulk_create is sufficient - it is not:
     #
     #   virtualchassis  creates VirtualChassis rows, THEN assigns devices to
-    #                   them - so the second phase needs the first to have
-    #                   happened and cannot simply be skipped
+    #                   them. Deliberately left unmeasured; see below.
     #
     # `ipaddress` is handled: its direct writes are all in one block at the end,
     # and the VRF upsert it performs mid-classification goes through
@@ -489,6 +488,27 @@ def bulk_orm_apply_simple_models(
         return bulk_orm_apply_macaddress(runner, rows, preview=preview)
     if model_string == "ipam.ipaddress":
         return bulk_orm_apply_ipaddress(runner, rows, preview=preview)
+    # virtualchassis is left unmeasured on purpose, not for want of effort.
+    #
+    # A shortcut does exist - a device whose target VirtualChassis is absent is
+    # unambiguously a change, the same reasoning that made `interface` and the
+    # absent-dependency cases work. What rules it out is that an unsaved VC
+    # breaks the device phase in three separate places, each silently:
+    #
+    #   `position_key = (vc.pk, position)`  - every to-be-created VC collapses
+    #       to (None, position), so unrelated VCs collide as one occupied slot
+    #   `device.virtual_chassis_id == vc.pk` - a device with NO chassis compares
+    #       equal to None and is counted UNCHANGED
+    #   `device.full_clean()`               - validates against an unsaved FK
+    #
+    # The middle one under-counts drift while looking correct, which is the
+    # exact failure this whole feature exists to prevent, and it would need all
+    # three handled to avoid it. Against that: virtualchassis is low volume, and
+    # measuring it unlocks nothing - `in_sync` stays unanswered regardless,
+    # because the adapter-only models have no comparison either.
+    #
+    # So it declines to answer. That is a worse report and a better number than
+    # the alternative.
     if model_string == "dcim.virtualchassis":
         return None if preview else bulk_orm_apply_virtualchassis(runner, rows)
     if model_string == "dcim.interface":

--- a/forward_netbox/utilities/apply_engine_bulk.py
+++ b/forward_netbox/utilities/apply_engine_bulk.py
@@ -462,17 +462,28 @@ def bulk_orm_apply_simple_models(
     #
     #   interface       `cable.delete()`, plus two recursive self-calls
     #   device          creates Tag and TaggedItem rows
-    #   ipaddress       Device.objects.bulk_update (primary-IP assignment)
-    #   virtualchassis  Device.objects.bulk_update
+    #   virtualchassis  creates VirtualChassis rows, THEN assigns devices to
+    #                   them - so the second phase needs the first to have
+    #                   happened and cannot simply be skipped
+    #
+    # `ipaddress` is handled: its direct writes are all in one block at the end,
+    # and the VRF upsert it performs mid-classification goes through
+    # `runner._ensure_vrf`, which the preview runner overrides with a lookup.
+    #
+    # Note the audit that produced this list greps for direct ORM writes and so
+    # does NOT see writes behind a runner call. That is safe only because the
+    # preview runner shims the whole runner surface - an unshimmed method raises
+    # instead of writing - and it is why adding a path means reading its runner
+    # calls too, not just grepping it.
     #
     # Until each is handled they report no comparison, which keeps their
     # upper-bound estimate rather than a confident zero.
     if model_string == "dcim.macaddress":
         return bulk_orm_apply_macaddress(runner, rows, preview=preview)
+    if model_string == "ipam.ipaddress":
+        return bulk_orm_apply_ipaddress(runner, rows, preview=preview)
     if model_string == "dcim.virtualchassis":
         return None if preview else bulk_orm_apply_virtualchassis(runner, rows)
-    if model_string == "ipam.ipaddress":
-        return None if preview else bulk_orm_apply_ipaddress(runner, rows)
     if model_string == "dcim.interface":
         return None if preview else bulk_orm_apply_interface(runner, rows)
     if model_string == "dcim.device":
@@ -2318,7 +2329,7 @@ def bulk_orm_apply_device(runner, rows: list[dict[str, Any]]):
     return True
 
 
-def bulk_orm_apply_ipaddress(runner, rows: list[dict[str, Any]]):
+def bulk_orm_apply_ipaddress(runner, rows: list[dict[str, Any]], *, preview=False):
     """Batched apply for ipam.ipaddress with adapter-parity semantics.
 
     Mirrors ``apply_ipam_ipaddress`` (sync_ipam.py) row-for-row — device and
@@ -2567,6 +2578,19 @@ def bulk_orm_apply_ipaddress(runner, rows: list[dict[str, Any]]):
             update_objects[ip.pk] = ip
         runner.logger.increment_statistics("ipam.ipaddress", outcome="applied")
         runner.events_clearer.increment()
+
+    if preview:
+        # Every direct write in this path - the released-primary Device
+        # bulk_update as well as the IPAddress create and update - is inside the
+        # block below, so returning here performs none of them.
+        #
+        # The VRF upsert this path also performs is NOT reached by that, because
+        # it happens during classification through `runner._ensure_vrf`. The
+        # preview runner overrides that method with a lookup, which is why the
+        # shim is a write firewall rather than a convenience: a write behind a
+        # runner call is neutralised by construction, and an unshimmed method
+        # raises rather than writing.
+        return {"creates": len(create_objects), "updates": len(update_objects)}
 
     from django.db import IntegrityError
 

--- a/forward_netbox/utilities/apply_engine_bulk.py
+++ b/forward_netbox/utilities/apply_engine_bulk.py
@@ -460,7 +460,6 @@ def bulk_orm_apply_simple_models(
     # what they do, so nobody wires one up on the assumption that returning
     # before the final bulk_create is sufficient - it is not:
     #
-    #   interface       `cable.delete()`, plus two recursive self-calls
     #   device          creates Tag and TaggedItem rows
     #   virtualchassis  creates VirtualChassis rows, THEN assigns devices to
     #                   them - so the second phase needs the first to have
@@ -469,6 +468,10 @@ def bulk_orm_apply_simple_models(
     # `ipaddress` is handled: its direct writes are all in one block at the end,
     # and the VRF upsert it performs mid-classification goes through
     # `runner._ensure_vrf`, which the preview runner overrides with a lookup.
+    #
+    # `interface` is handled: its cabled-LAG conversions delete a cable and
+    # re-enter the function, so a preview skips them and counts those rows as
+    # the updates they plainly are.
     #
     # Note the audit that produced this list greps for direct ORM writes and so
     # does NOT see writes behind a runner call. That is safe only because the
@@ -485,7 +488,7 @@ def bulk_orm_apply_simple_models(
     if model_string == "dcim.virtualchassis":
         return None if preview else bulk_orm_apply_virtualchassis(runner, rows)
     if model_string == "dcim.interface":
-        return None if preview else bulk_orm_apply_interface(runner, rows)
+        return bulk_orm_apply_interface(runner, rows, preview=preview)
     if model_string == "dcim.device":
         return None if preview else bulk_orm_apply_device(runner, rows)
 
@@ -1323,6 +1326,7 @@ def bulk_orm_apply_interface(
     rows: list[dict[str, Any]],
     *,
     prechange_snapshots: dict[int, Any] | None = None,
+    preview: bool = False,
 ):
     """Batched apply for dcim.interface.
 
@@ -1768,6 +1772,28 @@ def bulk_orm_apply_interface(
                 update_objects[member.pk] = member
             outcome[0] = "applied"
             resolved_lag_links.append((member, parent))
+
+    if preview:
+        # Two things make this path different from the others.
+        #
+        # It defers its per-row statistics to the end of the function instead of
+        # incrementing inline, so a preview has to emit them here or the shim
+        # sees nothing and reports zero drift.
+        #
+        # And the cabled-LAG conversions below are skipped outright. Each one
+        # deletes a cable and re-enters this function, which is the one thing a
+        # read-only measurement must not do. Those rows are still counted: an
+        # existing cabled interface becoming a LAG is unambiguously a change to
+        # a row NetBox already has, so it counts as an update. They are counted
+        # without being performed, which is the whole distinction. They cannot
+        # double-count, because both branches that fill `cabled_lag_rows`
+        # `continue` before reaching `create_objects` or `update_objects`.
+        for (outcome,) in row_outcomes:
+            runner.logger.increment_statistics("dcim.interface", outcome=outcome)
+        return {
+            "creates": len(create_objects),
+            "updates": len(update_objects) + len(cabled_lag_rows),
+        }
 
     from django.db import IntegrityError
 

--- a/forward_netbox/utilities/drift_comparison.py
+++ b/forward_netbox/utilities/drift_comparison.py
@@ -44,6 +44,18 @@ class _PreviewEventsClearer:
         return None
 
 
+class _NullSourceParameters:
+    parameters = {}
+
+
+class _NullSync:
+    """Stands in for a sync when the caller has none. Carries no parameters."""
+
+    source = _NullSourceParameters()
+    pk = None
+    name = ""
+
+
 class PreviewRunner:
     """A runner that records nothing and writes nothing.
 
@@ -54,7 +66,12 @@ class PreviewRunner:
     """
 
     def __init__(self, sync=None):
-        self.sync = sync
+        # Some paths read source parameters straight off the sync -
+        # `_scope_tags_enabled` does - so a caller with no sync gets a null
+        # object rather than an AttributeError. Production always passes the
+        # real sync, so this only affects callers that have none, and it
+        # degrades to "no opt-in parameters set" rather than guessing.
+        self.sync = sync if sync is not None else _NullSync()
         self.logger = _PreviewStatistics()
         self.events_clearer = _PreviewEventsClearer()
         # Every lookup cache `sync_primitives` reads off a runner, seeded empty.
@@ -80,6 +97,9 @@ class PreviewRunner:
         self._primed_missing_unique_lookup_keys = set()
         self._model_coalesce_fields = {}
         self._conflict_policy = {}
+        self._device_tag_ids_cache = {}
+        self._scope_matched_tags = {}
+        self._scope_tag_objs = {}
         self.rejected_rows = 0
 
     def _record_issue(self, *args, **kwargs):
@@ -122,6 +142,40 @@ class PreviewRunner:
         from .sync_reporting import ipaddress_assignment_skip_reason
 
         return ipaddress_assignment_skip_reason(address)
+
+    def _ensure_platform(self, row, *, manufacturer_authoritative=False):
+        """Find the platform, never create it - and never create a manufacturer.
+
+        The real `_ensure_platform` upserts, and calls `_ensure_manufacturer`,
+        which upserts too. Both are reached from inside the device
+        classification, so inheriting either would write while measuring. Same
+        class of trap as `_ensure_vrf`, and likewise invisible to a grep for ORM
+        calls.
+        """
+        from dcim.models import Platform
+
+        slug = str((row or {}).get("slug") or "").strip()
+        name = str((row or {}).get("name") or "").strip()
+        if slug:
+            match = Platform.objects.filter(slug=slug).order_by("pk").first()
+            if match is not None:
+                return match
+        if not name:
+            return None
+        return Platform.objects.filter(name=name).order_by("pk").first()
+
+    def _ensure_manufacturer(self, row):
+        from dcim.models import Manufacturer
+
+        slug = str((row or {}).get("slug") or "").strip()
+        name = str((row or {}).get("name") or "").strip()
+        if slug:
+            match = Manufacturer.objects.filter(slug=slug).order_by("pk").first()
+            if match is not None:
+                return match
+        if not name:
+            return None
+        return Manufacturer.objects.filter(name=name).order_by("pk").first()
 
     def _ensure_vrf(self, row, *, update_existing=True):
         """Find the VRF, never create or update it.

--- a/forward_netbox/utilities/drift_comparison.py
+++ b/forward_netbox/utilities/drift_comparison.py
@@ -57,12 +57,29 @@ class PreviewRunner:
         self.sync = sync
         self.logger = _PreviewStatistics()
         self.events_clearer = _PreviewEventsClearer()
+        # Every lookup cache `sync_primitives` reads off a runner, seeded empty.
+        # Enumerated from that module rather than discovered one AttributeError
+        # at a time; they are all plain memoisation, so an empty one only costs
+        # a query.
         self._content_types = {}
-        self._interface_by_device_name_cache = {}
-        self._missing_interface_by_device_name_cache = {}
+        self._asn_by_number_cache = {}
         self._device_by_name_cache = {}
-        self._primed_missing_unique_lookup_keys = set()
+        self._interface_by_device_name_cache = {}
+        self._interface_canonical_cache = {}
+        self._module_bay_by_device_name_cache = {}
+        # The three negative caches are sets - the primitives call `.add` and
+        # `.discard` on them, not item assignment.
+        self._missing_device_by_name_cache = set()
+        self._missing_interface_by_device_name_cache = set()
+        self._missing_module_bay_by_device_name_cache = set()
+        self._tag_by_name_cache = {}
+        self._tag_by_slug_cache = {}
+        self._vrf_by_name_cache = {}
+        self._vrf_by_rd_cache = {}
         self._unique_lookup_cache = {}
+        self._primed_missing_unique_lookup_keys = set()
+        self._model_coalesce_fields = {}
+        self._conflict_policy = {}
         self.rejected_rows = 0
 
     def _record_issue(self, *args, **kwargs):
@@ -95,6 +112,42 @@ class PreviewRunner:
         from .sync_primitives import lookup_interface
 
         return lookup_interface(self, device, interface_name)
+
+    def _get_device_by_name(self, device_name):
+        from .sync_primitives import get_device_by_name
+
+        return get_device_by_name(self, device_name)
+
+    def _ipaddress_assignment_skip_reason(self, address):
+        from .sync_reporting import ipaddress_assignment_skip_reason
+
+        return ipaddress_assignment_skip_reason(address)
+
+    def _ensure_vrf(self, row, *, update_existing=True):
+        """Find the VRF, never create or update it.
+
+        The real runner upserts here, which is why this override exists: the
+        method is called from inside the ipaddress classification, so inheriting
+        it would have written VRF rows during a read-only preview. The audit
+        grep did not catch it, because it is a write behind a runner call rather
+        than a direct ORM one - which is the case for the shim being a firewall
+        rather than a convenience.
+
+        Returning ``None`` for an absent VRF matches how slice one treats an
+        absent dependency: the address cannot already exist in NetBox under a
+        VRF NetBox does not have, so it classifies as a create.
+        """
+        from ipam.models import VRF
+
+        name = (row or {}).get("name")
+        rd = (row or {}).get("rd") or None
+        if rd:
+            match = VRF.objects.filter(rd=rd).order_by("pk").first()
+            if match is not None:
+                return match
+        if not name:
+            return None
+        return VRF.objects.filter(name=name).order_by("pk").first()
 
     # --- state the classification reports into, which a preview discards ----
 


### PR DESCRIPTION
Slice three of #206. `ipam.ipaddress` is wired up, `virtualchassis` is re-triaged as deferred, and **the audit method that produced the earlier table was wrong**.

## The audit was incomplete, and ipaddress proved it

The first pass grepped for direct ORM writes — `bulk_create`, `bulk_update`, `.save(`, `.delete(` — and reported `ipaddress` as having one cross-model write. It has two. The second is `runner._ensure_vrf`, called *during classification*, which upserts a VRF. **A grep for ORM calls cannot see a write behind a runner method.**

What makes that survivable is that the preview runner is a **write firewall**: every `runner.` call is answered by the shim, so a write behind one is neutralised by construction, and a method the shim does not implement raises `AttributeError` rather than writing. Loud beats silent.

So the grep is the right tool for direct writes and the wrong tool on its own. Adding a path means reading its `runner.` calls too — the dispatch comment now says so, because the next path will have the same trap.

`_ensure_vrf` is overridden with a lookup returning `None` for an absent VRF — the same treatment slice one gives an absent dependency, and correct for the same reason: an address cannot already exist under a VRF NetBox does not have.

## virtualchassis was mis-triaged

Listed as a single `Device.objects.bulk_update`. It is two-phase: creates `VirtualChassis` rows, *then* assigns devices to them, and the second phase reads `vc.pk` from the first. Skipping phase one does not yield a classifiable phase two. Same shape as `interface`'s cable delete, so it joins the deferred set.

## Coverage

| path | state |
| --- | --- |
| site, manufacturer, devicetype, vlan, vrf, prefix | measured |
| macaddress | measured |
| **ipaddress** | **measured (this PR)** |
| device | deferred — creates `Tag` and `TaggedItem` |
| interface | deferred — `cable.delete()` |
| virtualchassis | deferred — two-phase |

## Tests

**2140 pass** — 2137 before plus three. The shim caches are now enumerated from `sync_primitives` rather than discovered one `AttributeError` at a time, and the three negative caches are sets because the primitives call `.add`/`.discard` on them.

Keeps #206 open for `device`, `interface`, `virtualchassis`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)