### PR TITLE
fix: make the release checks say what they measured

### DIFF
--- a/docs/03_Plans/active/2026-08-15-release-check-defaults.md
+++ b/docs/03_Plans/active/2026-08-15-release-check-defaults.md
@@ -1,0 +1,68 @@
+# Make the release checks say what they measured
+
+## Goal
+
+Stop two release checks from silently reporting on something other than the
+release in flight.
+
+## Why
+
+Both misfired during 2.8.1 and cost real time, in the same shape: the tool
+answered confidently about the wrong subject.
+
+`invoke release-authorization-check` defaulted `version` to `"2.6.0"`, so a bare
+invocation checked a years-old release and refused. Read as a failure of the
+release in flight.
+
+`check_release_lineage.py` defaults `--release-commit` to `origin/main`, which
+is correct after the release PR merges and wrong before it. Its refusal said
+only "lineage has 3 commits and needs at least 4" with no indication of which
+commit it had walked, so a pre-merge run reads identically to a genuinely
+broken release.
+
+## Constraints
+
+- The lineage default is not itself wrong. Running after the merge and before
+  the tag is the documented usage, and removing the default would make the
+  common case worse.
+- Neither check may become more permissive. These are the checks that stop a
+  version number being burned.
+
+## Touched Surfaces
+
+- `tasks.py` - `release_authorization_check`
+- `scripts/check_release_lineage.py` - the refusal message
+
+## Approach
+
+The authorization check drops its default and refuses without a version. A
+release check that quietly measures the wrong release is worse than one that
+declines to guess.
+
+The lineage check keeps its default and names the resolved commit in the
+refusal: `REFUSED for origin/main (ecd3216): ...`. That turns "the release is
+broken" into "you measured the wrong commit", which is the distinction the
+message was missing rather than the default being wrong.
+
+## Validation
+
+Behavioural, both confirmed by hand: a bare `invoke
+release-authorization-check` refuses with the corrected invocation, and a
+lineage refusal names its target.
+
+## Rollback
+
+Revert. The defaults return and so does the ambiguity.
+
+## Decision Log
+
+- **Remove one default, keep the other.** The authorization default had no
+  correct case - no release is meaningfully "2.6.0 by default". The lineage
+  default has a correct case and only needed to say what it used.
+- **Fix the message rather than the default for lineage.** Requiring the flag
+  every time would trade a rare misread for a permanent papercut on the path
+  that runs before every tag.
+
+## Open
+
+- Nothing. Both are small and self-contained.

--- a/scripts/check_release_lineage.py
+++ b/scripts/check_release_lineage.py
@@ -109,7 +109,23 @@ def main(argv: list[str] | None = None) -> int:
     try:
         result = check_release_lineage(args.release_commit, args.version)
     except LineageError as exc:
-        print(f"release lineage would be REFUSED: {exc}", file=sys.stderr)
+        # Name what was measured, not just the verdict. `--release-commit`
+        # defaults to `origin/main`, which is right when this runs after the
+        # release PR merges and wrong before it - and a bare "lineage has 3
+        # commits and needs at least 4" reads as a real refusal either way.
+        # Resolving the ref here costs nothing and turns "the release is
+        # broken" into "you measured the wrong commit".
+        try:
+            resolved = provenance._git_capture(
+                "rev-parse", "--short", args.release_commit
+            ).strip()
+            measured = f"{args.release_commit} ({resolved})"
+        except Exception:  # noqa: BLE001 - the refusal matters more than the ref
+            measured = args.release_commit
+        print(
+            f"release lineage would be REFUSED for {measured}: {exc}",
+            file=sys.stderr,
+        )
         return 1
     print("release lineage looks publishable:")
     for key, value in result.items():

--- a/tasks.py
+++ b/tasks.py
@@ -559,11 +559,29 @@ def release_preflight(context):
     context.run(f"{shlex.quote(sys.executable)} scripts/check_release_preflight.py")
 
 
-@task(name="release-authorization-check")
-def release_authorization_check(context, version="2.6.0"):
+@task(
+    name="release-authorization-check",
+    help={"version": "Release version to check, e.g. 2.8.1. Required."},
+)
+def release_authorization_check(context, version=None):
+    """Check one release's authorization record.
+
+    `version` has no default on purpose. It used to default to "2.6.0", so a
+    bare `invoke release-authorization-check` silently checked a years-old
+    release and reported on it - during 2.8.0 that read as a failure of the
+    release in flight and cost a real detour. A release check that quietly
+    measures the wrong release is worse than one that refuses to guess.
+    """
+    version = str(version or "").strip()
+    if not version:
+        raise Exit(
+            "Pass the release being checked, e.g. "
+            "`invoke release-authorization-check --version 2.8.1`.",
+            code=2,
+        )
     context.run(
         f"{shlex.quote(sys.executable)} scripts/check_release_authorization.py "
-        f"--version {shlex.quote(str(version))}"
+        f"--version {shlex.quote(version)}"
     )
 
 


### PR DESCRIPTION
Two release checks misfired during 2.8.1 in the same shape: each answered confidently about the wrong subject.

**`invoke release-authorization-check` defaulted `version` to `"2.6.0"`.** A bare invocation checked a years-old release and refused, which read as a failure of the release in flight. That default has no correct case, so it is gone — the task now refuses without a version.

**`check_release_lineage.py` refusals did not name their target.** `--release-commit` defaults to `origin/main`, which is right after the release PR merges and wrong before it, and the message was only `lineage has 3 commits and needs at least 4` — identical whether the release is broken or the wrong commit was walked. The default stays, because running post-merge pre-tag is the documented usage and requiring the flag every time would be a permanent papercut. The refusal now reads:

```
release lineage would be REFUSED for origin/main (ecd3216): lineage has 2 commits and needs at least 4 ...
```

Neither check becomes more permissive. Both verified by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)