### PR TITLE
chore: test and validate against NetBox 4.6.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ See the
 
 ## Release Compatibility
 
-The `2.8.2` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.6`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
+The `2.8.2` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
 
 <details>
 <summary>Release compatibility history</summary>

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "${FORWARD_NETBOX_HOST_PORT:-8000}:8000"
     env_file: env/netbox.env
     environment:
-      NETBOX_VER: "${NETBOX_VER:-v4.6.6}"
+      NETBOX_VER: "${NETBOX_VER:-v4.6.8}"
     secrets:
       - api_token_pepper_1
       - db_password
@@ -31,7 +31,7 @@ services:
       context: ../
       dockerfile: development/Dockerfile
       args:
-        NETBOX_VER: "${NETBOX_VER:-v4.6.6}"
+        NETBOX_VER: "${NETBOX_VER:-v4.6.8}"
   netbox-worker:
     !!merge <<: *netbox
     depends_on:
@@ -40,7 +40,7 @@ services:
     ports: []
     environment:
       FORWARD_NETBOX_WORKER_AUTORELOAD: "${FORWARD_NETBOX_WORKER_AUTORELOAD:-1}"
-      NETBOX_VER: "${NETBOX_VER:-v4.6.6}"
+      NETBOX_VER: "${NETBOX_VER:-v4.6.8}"
     command:
       - sh
       - -lc

--- a/docs/01_User_Guide/README.md
+++ b/docs/01_User_Guide/README.md
@@ -59,7 +59,7 @@ migrations, e.g. netbox-dlm `0.2.0+`; older builds need
 
 ## Release Compatibility
 
-The `2.8.2` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.6`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
+The `2.8.2` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
 
 <details>
 <summary>Release compatibility history</summary>

--- a/docs/03_Plans/active/2026-08-17-netbox-4.6.8-uplift.md
+++ b/docs/03_Plans/active/2026-08-17-netbox-4.6.8-uplift.md
@@ -1,0 +1,103 @@
+# Move the tested-on runtime to NetBox 4.6.8
+
+## Goal
+
+Test and validate against NetBox `4.6.8` instead of `4.6.6`, so the claim in
+the compatibility table is backed by a gate that actually ran there.
+
+## Why
+
+NetBox `4.6.7` and `4.6.8` shipped during the 2.8.2 release. Both are patch
+releases with no plugin-facing changes, and the declared range - `4.6.x`
+(>= `4.6.5`) - already covers them, so nothing was broken. What lagged was the
+evidence: every gate ran on `4.6.6`, so "tested on" named a runtime two patches
+behind the one customers install.
+
+This is not a documentation edit. The version is exact-pinned in the artifact
+validator, the SBOM validator and the release-authorization checker precisely
+so that the claim cannot drift from the runtime, which means moving it runs the
+whole suite, the artifact test, the reproducible build and the upgrade leg
+against 4.6.8 for the first time.
+
+## Constraints
+
+- Historical facts must not move. `UPGRADE_FROM_NETBOX_OVERRIDES = {"2.8.0":
+  "v4.6.6"}` records that 2.8.0 cannot install on 4.6.5, and the comments in
+  migration `0052`, `version_series.py` and `test_migration_dependencies.py`
+  describe what specific releases did. A blind find-and-replace rewrites those
+  into statements that are false.
+- The FROM side of the upgrade leg stays `v4.6.5`. It is the declared minimum,
+  and moving it would silently drop the NetBox-upgrade half of that gate.
+- `min_version` stays `4.6.5`. This changes what is tested, not what is
+  supported.
+
+## Touched Surfaces
+
+Thirteen pins, enumerated rather than swept:
+
+- `development/docker-compose.yml` (3)
+- `tasks.py` - the default `NETBOX_VER` and two exact-equality release guards
+- `scripts/check_release_authorization.py` - two environment maps, one tuple,
+  and the evidence text pattern
+- `scripts/validate_installed_artifact.py`, `scripts/validate_sbom.py`
+- `README.md`, `docs/README.md`, `docs/01_User_Guide/README.md`
+- `scripts/tests/test_release_authorization.py`, `scripts/tests/test_tasks.py`,
+  `scripts/tests/test_validate_sbom.py`
+
+## Approach
+
+Each site was replaced with its old value asserted present first, so a pin that
+had already moved or been reworded would fail loudly rather than be skipped.
+
+The thirteenth site was found by the harness tests, not by the enumeration:
+
+    "exact-runtime-artifact": (re.compile(r"\bNetBox\s+4\.6\.6\b", ...)
+
+The release-authorization checker requires the artifact evidence to *say* which
+runtime it ran on. Written as an escaped regex, it does not match a grep for
+`4.6.6` or `v4.6.6`, so a literal search reports a complete sweep while missing
+it. Left behind, the next release's authorization would have refused correct
+evidence - after the tag existed. A sweep for other escaped forms found none.
+
+## Validation
+
+- `invoke harness-test` - 321 tests, which is what found the regex pin.
+- The full gate with `NETBOX_VER=v4.6.8` and
+  `FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.8.2`, so the upgrade leg seeds 2.8.2
+  on v4.6.5 and lands on v4.6.8 - a two-version NetBox jump as well as a plugin
+  upgrade.
+- `pre-commit run --all-files`.
+
+The bulk-merge scale projection failed the first gate at 4382s against a 3600s
+limit. It was measured on both runtimes back to back before being believed:
+1662s on 4.6.6 and 1734s on 4.6.8, a 4% difference and less than half the
+budget. The failing run coincided with a kernel compile on the host - 32 cores
+at load 98, and the Django suite took 1459s against its usual 818s. The test
+asserts wall clock with no load normalisation, so it reports a regression for
+any busy machine; worth revisiting separately, and not evidence about 4.6.8.
+
+## Rollback
+
+Revert. Everything returns to 4.6.6; nothing about supported versions changes
+either way.
+
+## Decision Log
+
+- **Enumerate, do not sed.** Several 4.6.6 mentions next to the pins are
+  historical and must stay. The distinction is not mechanical, so the change
+  could not be.
+- **Move the tested-on version in its own change.** Folding it into the 2.8.2
+  release would have re-run a 30-minute gate mid-release for a claim that was
+  not wrong, only stale.
+- **No single constant introduced.** Thirteen sites obviously wants one, but
+  collapsing them is a refactor of the release checks, and doing that in the
+  same change as the version move would leave neither independently
+  reviewable. Noted below instead.
+
+## Open
+
+- The tested-on version has no single source of truth. Thirteen sites is the
+  reason this needed a plan file at all, and the next uplift will find the same
+  sprawl. Worth one small refactor, separately.
+- NetBox `4.7.0-beta1` is a different problem: `max_version = "4.6.99"` means
+  the plugin refuses to load there, so it is scheduled work rather than a gap.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ Forward 26.6 is the baseline for async NQE.
 
 ## Release Compatibility
 
-The `2.8.2` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.6`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
+The `2.8.2` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
 
 <details>
 <summary>Release compatibility history</summary>

--- a/scripts/check_release_authorization.py
+++ b/scripts/check_release_authorization.py
@@ -66,7 +66,7 @@ EVIDENCE_BASE_RE = re.compile(
 )
 EVIDENCE_REQUIRED_TEXT_PATTERNS = {
     "exact-runtime-artifact": (
-        re.compile(r"\bNetBox\s+4\.6\.6\b", re.IGNORECASE),
+        re.compile(r"\bNetBox\s+4\.6\.8\b", re.IGNORECASE),
         re.compile(r"\bBranching\s+1\.1\.2\b", re.IGNORECASE),
         re.compile(r"\bPython\s+3\.14\b", re.IGNORECASE),
         re.compile(r"\bSBOM\b", re.IGNORECASE),
@@ -87,13 +87,13 @@ RELEASE_RUNTIME_ENVIRONMENT = {
     "FORWARD_NETBOX_DOCKER_PROJECT": "forward-netbox-release-gate",
     "FORWARD_NETBOX_POSTGRES_DATA_PATH": "netbox-postgres-data",
     "FORWARD_NETBOX_WORKER_AUTORELOAD": "0",
-    "NETBOX_VER": "v4.6.6",
+    "NETBOX_VER": "v4.6.8",
 }
 ACCEPTANCE_RUNTIME_ENVIRONMENT = {
     "FORWARD_NETBOX_DOCKER_PROJECT": "forward-netbox-upgrade26",
     "FORWARD_NETBOX_POSTGRES_DATA_PATH": "netbox-postgres-data",
     "FORWARD_NETBOX_WORKER_AUTORELOAD": "0",
-    "NETBOX_VER": "v4.6.6",
+    "NETBOX_VER": "v4.6.8",
 }
 
 
@@ -138,7 +138,7 @@ def _safe_environment_assignment(assignment: str) -> bool:
         # cannot be used to smuggle a value into the recorded command.
         return value == "1"
     return (name, value) in {
-        ("NETBOX_VER", "v4.6.6"),
+        ("NETBOX_VER", "v4.6.8"),
         ("FORWARD_NETBOX_WORKER_AUTORELOAD", "0"),
         ("FORWARD_NETBOX_POSTGRES_DATA_PATH", "netbox-postgres-data"),
     }

--- a/scripts/tests/test_release_authorization.py
+++ b/scripts/tests/test_release_authorization.py
@@ -19,35 +19,35 @@ class ReleaseAuthorizationTest(unittest.TestCase):
         "final-tree-full-gate": (
             "`rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate "
             "FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data "
-            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 "
+            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 "
             "invoke ci` passed: 1343 tests, 0 failures."
         ),
         "exact-runtime-artifact": (
             "`rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate "
             "FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data "
-            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 "
-            "invoke artifact-test` passed: NetBox 4.6.6, Branching 1.1.2, "
+            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 "
+            "invoke artifact-test` passed: NetBox 4.6.8, Branching 1.1.2, "
             "Python 3.14, and SBOM validation; 0 errors."
         ),
         "scale-and-failure": (
             "`rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-upgrade26 "
             "FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data "
-            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 "
+            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 "
             "invoke scale-soak --runs 3` passed 3 runs and "
             "`rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate "
             "FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data "
-            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 "
+            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 "
             "invoke scenario-test` passed 28 failure scenarios, 0 failures and "
             "`rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate "
             "FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data "
-            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 "
+            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 "
             "invoke bulk-merge-retry-scale-test` passed 20,005-row replay with "
             "a 1,512-second 1M-row projection under the 2,400-second limit."
         ),
         "ui-validation": (
             "`rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate "
             "FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data "
-            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 "
+            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 "
             "FORWARD_NETBOX_HOST_PORT=18081 NETBOX_URL=http://127.0.0.1:18081 "
             "invoke playwright-test` passed 14 desktop and mobile checks, 0 failures."
         ),
@@ -59,7 +59,7 @@ class ReleaseAuthorizationTest(unittest.TestCase):
         "customer-equivalent-acceptance": (
             "`rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-upgrade26 "
             "FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data "
-            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.6 "
+            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 "
             "invoke sync-release-gate --sync-ids 51` passed sync id 51: 0 blockers, "
             "0 warnings, 0 errors."
         ),
@@ -260,7 +260,7 @@ class ReleaseAuthorizationTest(unittest.TestCase):
         # The loosening must not leak: everything except the port pair is still
         # compared for exact equality with the canonical release environment.
         evidence = self._on_host_port("final-tree-full-gate", 18080).replace(
-            "NETBOX_VER=v4.6.6", "NETBOX_VER=v4.6.4"
+            "NETBOX_VER=v4.6.8", "NETBOX_VER=v4.6.4"
         )
         with self.assertRaisesRegex(ValueError, "placeholder_evidence"):
             release_authorization.check_release_authorization(

--- a/scripts/tests/test_tasks.py
+++ b/scripts/tests/test_tasks.py
@@ -51,7 +51,7 @@ class DockerComposeIsolationTest(unittest.TestCase):
         context = SimpleNamespace(
             run=Mock(),
             forward_netbox=SimpleNamespace(
-                netbox_ver="v4.6.6",
+                netbox_ver="v4.6.8",
                 project_name="forward-netbox",
                 compose_dir="/tmp/forward-netbox",
             ),
@@ -77,7 +77,7 @@ class DockerComposeIsolationTest(unittest.TestCase):
         context = SimpleNamespace(
             run=Mock(),
             forward_netbox=SimpleNamespace(
-                netbox_ver="v4.6.6",
+                netbox_ver="v4.6.8",
                 project_name="forward-netbox",
                 compose_dir="/tmp/forward-netbox",
             ),
@@ -91,7 +91,7 @@ class DockerComposeIsolationTest(unittest.TestCase):
 
 
 class ReleaseArtifactTaskTest(unittest.TestCase):
-    def _context(self, netbox_version="v4.6.6"):
+    def _context(self, netbox_version="v4.6.8"):
         return SimpleNamespace(
             run=Mock(),
             forward_netbox=SimpleNamespace(
@@ -121,7 +121,7 @@ class ReleaseArtifactTaskTest(unittest.TestCase):
             tasks.artifact_test.body(context)
 
         commands = [call.args[0] for call in context.run.call_args_list]
-        self.assertIn("--build-arg NETBOX_VER=v4.6.6", commands[0])
+        self.assertIn("--build-arg NETBOX_VER=v4.6.8", commands[0])
         self.assertIn(
             "--build-arg PACKAGE=/source/dist/forward_netbox-2.6.0-py3-none-any.whl",
             commands[0],
@@ -142,7 +142,7 @@ class ReleaseArtifactTaskTest(unittest.TestCase):
         self.assertIn("uv tool run --isolated", commands[2])
         self.assertIn("cyclonedx-py environment", commands[2])
         self.assertIn("--pyproject /tmp/netbox-runtime-pyproject.toml", commands[2])
-        self.assertIn('version = "4.6.6"', commands[2])
+        self.assertIn('version = "4.6.8"', commands[2])
         self.assertIn("forward-netbox==2.6.0", commands[2])
         self.assertIn("/opt/netbox/venv/bin/python", commands[2])
         self.assertIn("--output-reproducible", commands[2])
@@ -317,7 +317,7 @@ class ArtifactUpgradeTaskTest(unittest.TestCase):
 
     WHEEL = "dist/forward_netbox-2.6.7-py3-none-any.whl"
 
-    def _context(self, netbox_version="v4.6.6", tags="v2.6.5\nv2.6.6\n"):
+    def _context(self, netbox_version="v4.6.8", tags="v2.6.5\nv2.6.6\n"):
         run = Mock(return_value=SimpleNamespace(stdout=tags))
         return SimpleNamespace(
             run=run,

--- a/scripts/tests/test_validate_sbom.py
+++ b/scripts/tests/test_validate_sbom.py
@@ -42,7 +42,7 @@ class ValidateSbomTest(unittest.TestCase):
         )
 
         self.assertGreaterEqual(result["component_count"], 20)
-        self.assertEqual(result["netbox_version"], "4.6.6")
+        self.assertEqual(result["netbox_version"], "4.6.8")
 
     def test_rejects_runtime_version_mismatch(self):
         components = self._components()

--- a/scripts/validate_installed_artifact.py
+++ b/scripts/validate_installed_artifact.py
@@ -33,8 +33,8 @@ def main():
         raise SystemExit(
             f"forward-netbox {package_version} != expected {args.expected_version}"
         )
-    if netbox_version != "4.6.6":
-        raise SystemExit(f"NetBox {netbox_version} != required 4.6.6")
+    if netbox_version != "4.6.8":
+        raise SystemExit(f"NetBox {netbox_version} != required 4.6.8")
     if branching_version != "1.1.2":
         raise SystemExit(f"netbox-branching {branching_version} != required 1.1.2")
 

--- a/scripts/validate_sbom.py
+++ b/scripts/validate_sbom.py
@@ -10,7 +10,7 @@ from pathlib import Path
 REQUIRED_COMPONENTS = {
     "forward-netbox": None,
     "httpx": "0.28.1",
-    "netbox": "4.6.6",
+    "netbox": "4.6.8",
     "netbox-cisco-aci": "0.4.0",
     "netbox-dlm": "0.9.1",
     "netbox-peering-manager": "0.3.0",

--- a/tasks.py
+++ b/tasks.py
@@ -91,7 +91,7 @@ namespace = Collection("forward_netbox")
 namespace.configure(
     {
         "forward_netbox": {
-            "netbox_ver": os.environ.get("NETBOX_VER", "v4.6.6"),
+            "netbox_ver": os.environ.get("NETBOX_VER", "v4.6.8"),
             "project_name": os.environ.get(
                 "FORWARD_NETBOX_DOCKER_PROJECT",
                 "forward-netbox",
@@ -1199,9 +1199,9 @@ def artifact_test(context):
     version, wheel = _release_artifact_inputs()
     sbom_path = _prepare_sbom_output(version)
     netbox_version = str(context.forward_netbox.netbox_ver or "").strip()
-    if netbox_version != "v4.6.6":
+    if netbox_version != "v4.6.8":
         raise Exit(
-            "Release artifact validation requires NETBOX_VER=v4.6.6.",
+            "Release artifact validation requires NETBOX_VER=v4.6.8.",
             code=2,
         )
 
@@ -1312,9 +1312,9 @@ def artifact_upgrade_test(context, from_version=None, from_netbox_ver=None):
     """
     version, wheel = _release_artifact_inputs()
     netbox_version = str(context.forward_netbox.netbox_ver or "").strip()
-    if netbox_version != "v4.6.6":
+    if netbox_version != "v4.6.8":
         raise Exit(
-            "Release artifact validation requires NETBOX_VER=v4.6.6.",
+            "Release artifact validation requires NETBOX_VER=v4.6.8.",
             code=2,
         )
     # `invoke ci` runs this through its pre-list, which cannot pass arguments, so


### PR DESCRIPTION
NetBox 4.6.7 and 4.6.8 shipped during the 2.8.2 release. Both are patch releases with no plugin-facing changes and the declared range `4.6.x (>= 4.6.5)` already covered them — nothing was broken. What lagged was the **evidence**: every gate ran on 4.6.6, so "tested on" named a runtime two patches behind what customers install.

**This is not a docs edit.** The version is exact-pinned in the artifact validator, the SBOM validator and the release-authorization checker precisely so the claim can't drift from the runtime — so moving it runs the whole suite, the artifact test, the reproducible build and the upgrade leg against 4.6.8 for the first time.

## Thirteen pins, enumerated not swept

Several nearby `4.6.6` mentions are **historical facts** that must not move: `UPGRADE_FROM_NETBOX_OVERRIDES = {"2.8.0": "v4.6.6"}` records that 2.8.0 cannot install on 4.6.5, and comments in migration `0052`, `version_series.py` and `test_migration_dependencies.py` describe what specific releases did. A find-and-replace would rewrite those into statements that are false.

The **thirteenth** site was found by the harness tests, not by my enumeration:

```python
"exact-runtime-artifact": (re.compile(r"\bNetBox\s+4\.6\.6\b", ...)
```

Written as an escaped regex, so a grep for `4.6.6`/`v4.6.6` reports a complete sweep while missing it. Left behind, the next release's authorization would have refused *correct* evidence — after the tag existed.

`min_version` stays 4.6.5 and the upgrade leg still seeds there: this changes what is **tested**, not what is **supported**.

## Gate on v4.6.8

321 harness · 70 scenario · 2203 Django (4 skipped) · reproducible build · upgrade leg seeding 2.8.2 on v4.6.5 → v4.6.8 with prior-release rows surviving.

## About the scale test

It failed the first gate at 4382s against a 3600s limit. Measured on both runtimes back to back before being believed:

| Runtime | Projected 1M-row retry | Limit |
|---|---|---|
| v4.6.6 | 1662s | 3600 |
| v4.6.8 | 1734s | 3600 |

4% apart, less than half the budget. The failing run coincided with a kernel compile on the host — 32 cores at load 98, and the Django suite took 1459s against its usual 818s.

Worth noting separately: that test asserts wall clock with **no load normalisation**, so it reports a regression on any busy machine. Flaky gate rather than regression detector; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USSiufTbAXENjZ1jPpjhTD