### PR TITLE
fix: stop two checks reporting confidently about what they never measured

### DIFF
--- a/docs/03_Plans/active/2026-08-18-release-command-honesty.md
+++ b/docs/03_Plans/active/2026-08-18-release-command-honesty.md
@@ -1,0 +1,94 @@
+# Stop two checks reporting confidently about things they did not measure
+
+## Goal
+
+Make `release.py --finish` report the release it actually performed, and make
+the bulk-merge scale gate refuse to answer instead of answering wrongly.
+
+## Why
+
+Both misreport in the same direction - a confident verdict from something never
+validly measured - and both cost time during 2.8.2.
+
+`--finish` exited 1 after a **completely successful** release: tag created,
+workflow green, identical PyPI and GitHub artifacts published. The failure came
+from `stage_post_release`, which runs `check_harness.py`, which requires the
+provenance anchor to name the release the table calls current. The anchor
+cannot advance until the bridge commit exists; the bridge commit cannot exist
+until the pull request that step is opening has merged. The check is
+**unsatisfiable by construction** at the moment it runs, so it has failed on
+every release since 2.7.13 and been discarded by hand each time. An exit status
+that says "failed" while the artifacts are live teaches people to stop reading
+it - and this is the command where reading it matters most.
+
+`test_bulk_merge_scale` asserts a wall-clock projection with no load
+normalisation. During the 2.8.2 follow-up work a kernel compile on the host - 32
+cores at load 98 - turned a 1662s projection into 4382s and failed the gate.
+The same revision on the same runtime passed minutes later. Measured back to
+back on a quiet host: 1662s on NetBox 4.6.6 and 1734s on 4.6.8, a 4% difference
+against a 3600s budget. The gate reported a regression that did not exist.
+
+## Constraints
+
+- Neither check may become more permissive about what it actually checks. The
+  release still fails for a failed release; the scale budget is unchanged.
+- The post-release follow-up must not become easy to forget. The harness
+  already fails while the anchor is stale, and that stays true.
+- The `.dev0` policy question is NOT settled here. Whether `main` should carry
+  a `.dev0` marker after a release is a product decision with a customer report
+  cited on both sides; this change only stops that question deciding whether a
+  release is reported as successful.
+
+## Touched Surfaces
+
+- `scripts/release.py` - the `stage_post_release` call site
+- `forward_netbox/tests/test_bulk_merge_scale.py` - `MAX_LOAD_PER_CORE`,
+  `_load_per_core`, and the projection assertion
+
+## Approach
+
+The release command wraps post-release staging and reports it as follow-up
+work, printing the manual steps. The release either published or it did not,
+and staging cannot change which.
+
+The scale test reads one-minute load average per core and skips - not passes,
+not fails - above 1.5. Skipping is the correct outcome for an unmeasurable
+performance gate: an operator reading "skipped: host load per core is 3.06" is
+told exactly what to do, where a failure sends them hunting a regression that
+is not there. The threshold allows normal background noise while catching a
+parallel build.
+
+## Validation
+
+- `invoke harness-test`, which covers `scripts/release.py`.
+- The scale test on an idle host, confirming it still measures and still
+  asserts.
+- Full suite.
+
+## Rollback
+
+Revert. The release command misreports again and the scale gate flakes on busy
+hosts again.
+
+## Decision Log
+
+- **Skip, do not normalise.** Dividing the projection by observed load would
+  invent a model of how contention scales and quietly mask real regressions.
+  Refusing to answer is honest and needs no model.
+- **Skip, do not raise the budget.** The budget is a real constraint about a
+  worker timeout. Loosening it to accommodate a busy laptop would weaken the
+  gate permanently to fix a measurement problem.
+- **Wrap the call site, do not delete the step.** Removing `.dev0` staging
+  would decide a policy question that is not mine, and the step is useful on
+  the releases where it can run.
+- **Do not "fix" the unsatisfiable harness call inside the step.** Making it
+  pass would require running it against a tree state that does not exist yet.
+  Reporting it as deferred follow-up is the accurate description.
+
+## Open
+
+- The `.dev0` policy: `stage_open_next`'s docstring cites a customer who could
+  not tell an install from `main` apart from the published release, while the
+  practice since 2.7.13 has been that `main` stays at the released version
+  because customers install from source. Both cannot be right. Worth one
+  decision, recorded once.

--- a/forward_netbox/tests/test_bulk_merge_scale.py
+++ b/forward_netbox/tests/test_bulk_merge_scale.py
@@ -46,6 +46,23 @@ REGION_COUNT = 5
 # Commit staging in chunks so setup does not hold one giant transaction (setup
 # cost is not the measurement target).
 STAGE_CHUNK = 2_000
+# Above this, the host is oversubscribed and a wall-clock projection says more
+# about the other work on the box than about the merge. One is full occupancy;
+# 1.5 allows normal background noise while still catching a parallel build.
+MAX_LOAD_PER_CORE = 1.5
+
+
+def _load_per_core():
+    """One-minute load average per CPU, or None where it cannot be read."""
+    import os
+
+    try:
+        cores = os.cpu_count() or 1
+        return os.getloadavg()[0] / cores
+    except (OSError, AttributeError):  # pragma: no cover - platform dependent
+        return None
+
+
 SUPPORTED_RETRY_TIMEOUT_SECONDS = 7_200
 # Keep half of the configured worker timeout available for queueing and
 # transient variance while allowing the measured retry path to use the
@@ -262,6 +279,27 @@ class BulkMergeScaleTest(TransactionTestCase):
             Site.objects.filter(slug__startswith="scale-site-").count(), SITE_COUNT
         )
         projected_1m_retry_seconds = remerge_secs * 1_000_000 / total_staged
+        # A wall-clock projection is only a statement about this code when the
+        # machine taking it was free to run it. On a contended host it measures
+        # the contention: a kernel compile on a 32-core box turned a 1662s
+        # projection into 4382s and failed this assertion, while the same
+        # revision on the same runtime passed minutes later. That is a
+        # confident regression report from a measurement that was never valid -
+        # the failure mode this codebase keeps finding, in a test.
+        #
+        # So refuse to answer rather than answer wrongly. Skipping is the
+        # correct outcome: an unmeasurable performance gate must not read as
+        # either pass or fail.
+        load_per_core = _load_per_core()
+        if load_per_core is not None and load_per_core > MAX_LOAD_PER_CORE:
+            self.skipTest(
+                "host load per core is "
+                f"{load_per_core:.2f} (limit {MAX_LOAD_PER_CORE}); a wall-clock "
+                "projection taken here measures the contention, not the merge. "
+                f"Projection was {projected_1m_retry_seconds:.0f}s against a "
+                f"{SUPPORTED_RETRY_TIMEOUT_SECONDS * RETRY_TIMEOUT_HEADROOM_RATIO:.0f}s "
+                "budget; re-run on an idle host."
+            )
         self.assertLess(
             projected_1m_retry_seconds,
             SUPPORTED_RETRY_TIMEOUT_SECONDS * RETRY_TIMEOUT_HEADROOM_RATIO,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -810,7 +810,35 @@ def stage_finish(version: str) -> None:
             "tagged release workflow did not publish identical PyPI and GitHub "
             f"artifacts (conclusion={conclusion!r})"
         )
-    stage_post_release(version, tag)
+    # The release is DONE at this point: the tag exists, the workflow
+    # published identical PyPI and GitHub artifacts, and every gate passed.
+    # What follows is convenience staging, and it must not be able to report
+    # the release as failed.
+    #
+    # It could, and did, on every release since 2.7.13. `stage_post_release`
+    # runs `check_harness.py`, which requires the provenance anchor to name the
+    # release the table calls current - and the anchor cannot advance until the
+    # bridge commit exists, which cannot happen until the pull request this
+    # step is trying to open has merged. The check is unsatisfiable by
+    # construction at the moment it runs, so the command exited 1 after a
+    # completely successful release. An exit status that says "failed" when the
+    # artifacts are live teaches people to stop reading it.
+    try:
+        stage_post_release(version, tag)
+    except Exception as exc:  # noqa: BLE001 - the release already succeeded
+        print(
+            f"\n[release] v{version} PUBLISHED SUCCESSFULLY.\n"
+            f"[release] post-release staging did not complete ({exc}).\n"
+            "[release] That is follow-up work, not a failed release. Do it by "
+            "hand:\n"
+            "\n"
+            "    1. open the documentation-only post-release bridge on main\n"
+            "    2. advance PRIOR_RELEASE_TAG and PRIOR_POST_RELEASE_DOC_COMMIT\n"
+            "       to that bridge commit, and promote the release table\n"
+            "\n"
+            "The harness fails until the anchor lands, so this cannot be "
+            "forgotten quietly - only deferred.\n"
+        )
 
 
 def _next_patch_version(version: str) -> str:


### PR DESCRIPTION
Both misreport in the same direction — a confident verdict from something never validly measured — and both cost time during 2.8.2. Landing them **before** cutting 2.8.3, since both are false negatives in the tooling we're about to run in anger.

## 1. `release.py --finish` exited 1 after a successful release

Tag created, workflow green, identical PyPI and GitHub artifacts published — and the command reported failure.

The mechanism, not just the symptom: `stage_post_release` runs `check_harness.py`, which requires the provenance anchor to name the release the table calls current. **The anchor cannot advance until the bridge commit exists; the bridge commit cannot exist until the PR that step is opening has merged.** Unsatisfiable by construction at the moment it runs — same shape as the 2.6.9 gate that could never have passed for any input. It has failed on *every* release since 2.7.13 and been discarded by hand each time.

An exit status that says "failed" while the artifacts are live teaches people to stop reading it, and this is the command where reading it matters most.

Post-release staging is now reported as the follow-up work it is, with the manual steps printed.

**The `.dev0` policy question is untouched.** `stage_open_next` cites a customer who couldn't tell an install from `main` apart from the published release; the practice since 2.7.13 is that `main` stays at the released version because customers install from source. Both can't be right — but that question shouldn't decide whether a successful release is reported as failed.

## 2. The scale gate reported a regression that did not exist

`test_bulk_merge_scale` asserted a wall-clock projection with no load normalisation. A kernel compile on the host (32 cores, load 98) turned a 1662s projection into **4382s** and failed the gate; the same revision on the same runtime passed minutes later.

| Runtime | Projection | Limit |
|---|---|---|
| v4.6.6 (quiet) | 1662s | 3600 |
| v4.6.8 (quiet) | 1734s | 3600 |
| v4.6.8 (during compile) | 4382s | 3600 |

It now reads load-average-per-core and **skips** above 1.5:

> *skipped: host load per core is 3.06 (limit 1.5); a wall-clock projection taken here measures the contention, not the merge. Projection was 4382s against a 3600s budget; re-run on an idle host.*

Skipping is the correct outcome for an unmeasurable performance gate — neither pass nor fail. Normalising by observed load would invent a contention model and mask real regressions; raising the budget would weaken a real worker-timeout constraint to fix a measurement problem.

**Neither check became more permissive about what it actually checks.**

## Validation

Verified on an idle host that the scale gate still measures and still asserts — **1666s, passed rather than skipped**. A guard that silently skipped forever would be worse than the flake it replaces.

321 harness tests, full suite **2208 OK** (4 skipped), lint and harness clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USSiufTbAXENjZ1jPpjhTD