### PR TITLE
fix: stop the recovery documentation from repeating the leak

### DIFF
--- a/docs/03_Plans/active/2026-08-18-advance-history-baseline.md
+++ b/docs/03_Plans/active/2026-08-18-advance-history-baseline.md
@@ -11,8 +11,8 @@ without rewriting public history.
 The v2.8.3 publish workflow refused the tag. Its sensitive-content step runs
 the release-only superset feed and reported a redacted PATH,
 `path:sha256:e478676137834484`, which is
-`docs/03_Plans/active/2026-08-17-blake-2.8.2-followups.md` - a filename this
-repository created. Nothing was published: build and publish were skipped.
+a plan filename this repository created, which carried a customer contact's
+given name. Nothing was published: build and publish were skipped.
 
 `#228` renamed the file, which fixes the working-tree scan. It does not fix the
 history scan: `scan_commit_history` calls `scan_name(path, kind="path")` for

--- a/docs/03_Plans/active/2026-08-18-release-2.8.3.md
+++ b/docs/03_Plans/active/2026-08-18-release-2.8.3.md
@@ -97,9 +97,9 @@ exists so the recovery is not mistaken for a clean first attempt.
 The sensitive-content gate applies the release-only superset pattern feed,
 which no developer checkout has. It reported two findings against
 `path:sha256:e478676137834484` - a redacted PATH rather than file content. The
-hash resolves to `docs/03_Plans/active/2026-08-17-blake-2.8.2-followups.md`, a
-filename this repository created, identified by hashing all 1009 tracked paths
-and matching the digest without ever seeing the feed.
+hash resolves to a plan filename this repository created, which carried a
+customer contact's given name. It was identified by hashing all 1009 tracked
+paths and matching the digest, without ever seeing the feed.
 
 Nothing was published. `Validate tagged release` failed and the build, PyPI and
 GitHub-release jobs were all skipped, so no 2.8.3 artifact ever existed.


### PR DESCRIPTION
The second v2.8.3 tag was refused for the same reason as the first, by my own hand: **the plans written to document the leak quoted the offending filename verbatim** — `#229` at line 14, the release plan's recovery section at line 100. I documented a customer's name by reproducing it.

Nothing was published on either attempt; validation failed and build/publish were skipped both times.

## The durable fix

`.sensitive-patterns.local.txt` — which the scanner has recommended in its failure message all along, and which nobody had ever created. It's **gitignored**, so it can hold the identifiers the release-only superset feed carries.

With it present, a developer checkout now fails **exactly** the way CI does:

```
path:docs/03_Plans/active/2026-08-18-advance-history-baseline.md:14: local literal pattern line 4
path:docs/03_Plans/active/2026-08-18-release-2.8.3.md:100: local literal pattern line 4
```

Same lines, same rule, before a tag exists rather than after.

## A third surface

That file immediately surfaced something neither refusal reached: the scanner also checks **ref names**, and a stale local remote-tracking ref still carried the old branch name. Local only — CI does a fresh checkout — and pruned. But it makes the point: **contents, paths, refs and tag names are four surfaces**, and reviewing one is not reviewing the others. My original review covered exactly one.

## Wording

Both plans now say "a plan filename this repository created, which carried a customer contact's given name" — everything the record needs, without being the thing it warns about.

History still carries the quoted name at `40677cf` and `48c14fd`, so the reviewed baseline advances again in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USSiufTbAXENjZ1jPpjhTD