### PR TITLE
release: re-authorize 2.8.3 after the second refusal

### DIFF
--- a/docs/03_Plans/active/2026-08-18-release-2.8.3.md
+++ b/docs/03_Plans/active/2026-08-18-release-2.8.3.md
@@ -126,44 +126,110 @@ Recovery, in order:
   bypass actors; the ruleset was captured to JSON first, restored immediately
   afterwards, and confirmed `active` before the new tag was created.
 
+### Second refusal
+
+The recreated tag was refused again, by the same gate, for content this
+recovery introduced. Two of the recovery documents quoted the offending
+filename verbatim while explaining that the filename was the problem.
+Documenting a leak by reproducing it puts the value back on a scanned surface,
+and the scanner does not grade intent. Nothing was published on that attempt
+either.
+
+Recovery, continued:
+
+- `#231` reworded both documents to describe the filename without repeating it.
+- `#232` is not recovery. A deployment's 2.8.2 drift report arrived during it
+  and produced a confirmed defect, described below.
+- `#233` advanced the reviewed history baseline again, past the commits that
+  carried the quotes, and synchronised the repository variable.
+- `.sensitive-patterns.local.txt` was created. This is the change that ends the
+  loop: it reproduces the refusal locally, before a tag exists. It also
+  immediately surfaced a scanned surface neither refusal had reached, a stale
+  remote-tracking ref carrying the old branch name.
+
+### One more fix, from a fresh field report
+
+`#232` was added after the second refusal, because the deployment's 2.8.2 drift
+report showed `Models compared 2 / 32` with one of the two - a
+`netbox_dlm.softwareversion` row carrying 45 Forward rows - marked `In sync:
+Yes`.
+
+That model is adapter-only. It appears nowhere in `apply_engine_bulk.py`, so the
+comparison dispatcher has no entry for it and returns "no comparison"; the
+report should have shown it unmeasured. The badge came from a shortcut in
+`drift_comparison.py` that returned a zero for any empty row list, before the
+dispatcher was consulted. Emptiness cannot distinguish "nothing incoming" from
+"the rows never arrived", and only the first justifies a zero.
+
+Of 32 models the page made two affirmative claims, and at least one was
+produced by the single branch that never read NetBox. Reverting the fix makes
+three of the six new tests fail with the reported symptom.
+
+It rides in this release rather than the next because the release had to be
+re-gated and re-authorized regardless, so the marginal cost was one commit.
+
 ## Open
 
-- Whether a deployment's fresh preview measured nothing is still undiagnosed.
-  This release makes the report self-identifying, and the device fix may
-  resolve it by a different route - a failed row alone produces the symptom.
+- Eight models with working preview paths - `dcim.site`, `dcim.devicetype`,
+  `dcim.manufacturer`, `dcim.interface`, `dcim.macaddress`, `ipam.vlan`,
+  `ipam.vrf`, `ipam.prefix` - reported unmeasured on that deployment, each with
+  change candidates exactly equal to its Forward row count, which is the
+  upper-bound fallback. They should have been measured, and `#232` does not
+  address it. No hypothesis has been tested; the discriminating evidence is the
+  `comparison_coverage` object in the preview payload.
+- The earlier theory that a failed row was blocking baseline promotion there is
+  now disproved: the deployment's own evidence panel reports zero failed rows.
+- The release preflight prints `passed` for the evidence-base check while
+  skipping it whenever the version is already tagged. A skipped check should
+  report skipped.
 - The `.dev0` policy contradiction is recorded in `#226` and not resolved.
 
 ## Release Authorization
 
-- Evidence base commit: `40677cf13011b0962937b77fe4c7019845bfaf1d`
+- Evidence base commit: `f5b6d38cdd90d27b29e1bbef435820a60355bbad`
 
-- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.8.2 invoke ci` passed on the final 2.8.3 tree with exit status 0: 321 harness tests OK, 70 scenario tests OK, 2208 Django tests OK with 4 skipped, and 1 UI test OK. The upgrade leg seeded under 2.8.2 on NetBox v4.6.5 and upgraded 2.8.2 -> 2.8.3 on NetBox v4.6.8, with the rows seeded under the previous release surviving. This is the RE-GATED tree, run again after the publish refusal below; the earlier evidence attested to a tree that no longer exists.
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.8.2 invoke ci` passed on the final 2.8.3 tree: 321 harness tests OK, 70 scenario tests OK, 2214 Django tests OK with 4 skipped, and 1 UI test OK. The upgrade leg seeded under 2.8.2 on NetBox v4.6.5 and upgraded 2.8.2 -> 2.8.3 on NetBox v4.6.8, with the rows seeded under the previous release surviving. The Django total is 6 higher than the previous run because this tree adds the drift-comparison tests described below.
+
+  This is the THIRD gate for this version, run after the second publish refusal
+  and after three further merges. Reusing either earlier record would have
+  attested to a tree that no longer exists.
 
   The gated tree is the release tree apart from this authorization record, which
   is Markdown in a single plan file and is appended after the gate by
   construction.
 
-  First release gated on NetBox 4.6.8, and gated from a cold host: the machine
-  rebooted mid-run and the gate was restarted from a fresh Docker daemon, so
-  none of this rests on warm caches.
+  The process exit status was not recorded on this run. Every stage printed its
+  own terminal success line, the log contains no `Encountered a bad command exit
+  code` and no traceback, and `invoke` aborts the chain on the first non-zero
+  subprocess - so the run is complete and green, but the status itself was
+  observed indirectly rather than captured. The runner script now records it;
+  the artifact evidence below has it directly.
 
-  The crash-resume scale projection MEASURED rather than skipping - 1655s
-  against a 3600s budget, at a load per core well under the new guard's
-  threshold. That is the fourth consistent reading (1655, 1662, 1666, 1734
-  across two runtimes), which is what makes the 4382s reading taken during a
-  kernel compile identifiable as contention rather than regression.
+  The crash-resume scale projection MEASURED rather than skipping - 1701.83s
+  against a 3600s budget. That is the fifth consistent reading (1655, 1662,
+  1666, 1701, 1734 across two runtimes), which is what identifies the 4382s
+  reading taken during a kernel compile as host contention.
 
   `FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1` records that the release-time
   sensitive-pattern feed is not present on this host, so the preflight
   acknowledged the gap rather than scanning against it. The superset feed still
-  runs fail-closed in the publish workflow. As for 2.8.2, the gap was reviewed
-  rather than assumed: every string literal added since `v2.8.2` was enumerated
-  - 99, of which 84 are not schema identifiers - and each is a payload key,
-  version string, CSS class, message string this repository authors, or a
-  synthetic test fixture. Documentation prose added since the tag was scanned
-  for person tags, hostname-shaped tokens, long digit runs and addresses, with
-  no hits, and `check_sensitive_content.py --git-files` passes over all tracked
-  content.
+  runs fail-closed in the publish workflow.
+
+  Unlike the two earlier attempts, the gap is now partly closed rather than only
+  reviewed. `.sensitive-patterns.local.txt` - gitignored, and named in every
+  message this scanner emits - was created, and it reproduces the second refusal
+  locally in under a second. `check_sensitive_content.py --git-files
+  --protected-history` passes over tracked content AND protected history, which
+  is the check that should have preceded the first tag. The local feed remains a
+  subset of the release feed, so this is necessary and not sufficient; what makes
+  it stronger than prose review is that both refusals reported every finding
+  they had, so the rest of this tree and history are already known clean against
+  the superset.
+
+  One preflight line is worth recording as a defect rather than a pass:
+  `evidence base commit skipped (v2.8.3 is already tagged)` is printed under a
+  `passed` prefix for a check that did not run. `check_release_authorization.py`
+  was run separately for that reason.
 
 - [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke artifact-test` passed with exit status 0 against the installed `forward_netbox-2.8.3-py3-none-any.whl` on NetBox 4.6.8, Branching 1.1.2, Python 3.14, with 7 authenticated menu routes returning 200, all plugin migrations applying cleanly with no drift, and a validated SBOM of 156 components.
 


### PR DESCRIPTION
Third gate for this version, bound to evidence base commit `f5b6d38`.

The tree moved three times since the last authorization — #231 (wording fix), #232 (drift-comparison fix from a fresh field report), #233 (second baseline advance) — so both earlier evidence records attest to trees that no longer exist.

## Gate

`invoke ci` on NetBox 4.6.8: 321 harness, 70 scenario, 2214 Django (4 skipped), 1 UI. Upgrade leg 2.8.2 on v4.6.5 → 2.8.3 on v4.6.8, seeded rows survived. Django total is +6 for the new drift tests. Scale projection **measured** at 1701.83s against 3600s — the fifth consistent reading.

`invoke artifact-test` exit status 0: installed wheel on NetBox 4.6.8 / Branching 1.1.2 / Python 3.14, 7 menu routes 200, migrations clean, SBOM 156 components.

## Recorded as defects, not passes

- **The gate's exit status was not captured on that run.** Every stage printed its terminal success line and there is no `Encountered a bad command exit code` or traceback, and `invoke` aborts on the first non-zero subprocess — so the run is green, but the status was observed indirectly. The runner script now records it; the artifact evidence has it directly.
- **The preflight prints `passed` for a check it skips**: `evidence base commit skipped (v2.8.3 is already tagged)`. `check_release_authorization.py` was run separately for that reason. A skipped check should report skipped.

## Sensitive-content posture

Genuinely different from the two earlier attempts rather than a restated intention. `.sensitive-patterns.local.txt` now exists and reproduces the second refusal locally in under a second, and `--git-files --protected-history` passes — the check that should have preceded the first tag. The local feed is still a subset of the release feed, so this is necessary, not sufficient; what makes it more than prose review is that both refusals reported every finding they had, so the rest of this tree and history are already known clean against the superset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAh92WhePWYnbCjx6sJZEb