### PR TITLE
fix: take the .dev0 marker back off main

### DIFF
--- a/docs/03_Plans/active/2026-08-18-no-dev0-on-main.md
+++ b/docs/03_Plans/active/2026-08-18-no-dev0-on-main.md
@@ -1,0 +1,71 @@
+# Take the .dev0 marker back off main
+
+## Goal
+
+Return every version surface on `main` to `2.8.3`, the version that shipped.
+
+## Why
+
+`stage_post_release` ran far enough to write a `2.8.4.dev0` bump across the
+four version surfaces before it failed on an unrelated step, and the edits were
+left in the working tree. They were then swept into the post-release bridge
+commit by a `git add -A` that nobody had checked `git status` before running.
+
+`main` must carry the released version between releases. Customers install this
+plugin from source, so a `main` that says `2.8.4.dev0` is a version that was
+never gated, never tagged and never published, presented to anyone who clones.
+
+This is a standing contradiction in the tooling rather than a one-off slip:
+`scripts/release.py` has a `--open-next` stage whose entire purpose is to put
+`.dev0` on `main`, and the operating rule is that it must not be there. The
+contradiction is recorded and unresolved; this change follows the rule and does
+not resolve the contradiction.
+
+## Constraints
+
+- All four surfaces move together. `forward_netbox/utilities/fast_baseline.py`
+  carries a runtime pin that is easy to miss and reverts the first baseline
+  from about six minutes to about fifteen hours when it disagrees.
+- Documentation that describes historical `.dev0` behaviour is not touched.
+  Those sentences are accurate statements about what earlier releases did.
+
+## Touched Surfaces
+
+- `pyproject.toml`
+- `forward_netbox/__init__.py`
+- `forward_netbox/utilities/fast_baseline.py`
+- `forward_netbox/tests/test_runtime_dependency_check.py`
+
+## Approach
+
+Replace the literal in each of the four, then confirm no tracked source or
+packaging file mentions `dev0` any more.
+
+## Validation
+
+`check_harness.py`, `pre-commit run --all-files`, and the runtime dependency
+test, which asserts the declared version directly.
+
+## Rollback
+
+Revert. `main` returns to advertising a version that does not exist.
+
+## Decision Log
+
+- **Follow the recorded rule, not the script.** The script's `--open-next`
+  stage and the no-`.dev0` rule cannot both be right. The rule has a stated
+  reason that names a real consequence for people who install from source; the
+  stage has automation convenience. Resolving the contradiction properly is
+  separate work.
+- **Its own commit.** It is a correction to a mistake in the previous commit
+  and should be reviewable as exactly that, not folded into the promotion.
+
+## Open
+
+- The `.dev0` contradiction itself. Either `--open-next` goes, or the rule
+  does, and neither should be decided as a side effect of a release.
+- The bridge commit that carried these edits is no longer documentation-only,
+  which makes it unusable as `PRIOR_POST_RELEASE_DOC_COMMIT`. Reverting the
+  content here does not fix that: the verifier diffs the release tag against
+  the bridge commit itself, and that diff is immutable. Handled separately in
+  the anchor change.

--- a/forward_netbox/__init__.py
+++ b/forward_netbox/__init__.py
@@ -5,7 +5,7 @@ class NetboxForwardConfig(PluginConfig):
     name = "forward_netbox"
     verbose_name = "Forward"
     description = "Sync Forward data into NetBox using built-in NQE queries."
-    version = "2.8.4.dev0"
+    version = "2.8.3"
     base_url = "forward"
     min_version = "4.6.5"
     max_version = "4.6.99"

--- a/forward_netbox/tests/test_runtime_dependency_check.py
+++ b/forward_netbox/tests/test_runtime_dependency_check.py
@@ -23,7 +23,7 @@ class RuntimeDependencyCheckTest(SimpleTestCase):
         self.assertIsNotNone(_resolved_branching_version())
 
     def test_plugin_config_version_matches_package_release(self):
-        self.assertEqual(NetboxForwardConfig.version, "2.8.4.dev0")
+        self.assertEqual(NetboxForwardConfig.version, "2.8.3")
 
     def test_exact_runtime_passes(self):
         _check_runtime_dependencies()

--- a/forward_netbox/utilities/fast_baseline.py
+++ b/forward_netbox/utilities/fast_baseline.py
@@ -200,7 +200,7 @@ def _runtime_decision():
     expected = {
         "netbox_series": "4.6",
         "branching_series": "1.1",
-        "forward_netbox": "2.8.4.dev0",
+        "forward_netbox": "2.8.3",
         # Each optional distribution lists every version validated against this
         # engine, not a single pin. An exact pin meant a customer upgrading one
         # optional plugin silently lost the fast baseline — no error, just a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "forward-netbox"
-version = "2.8.4.dev0"
+version = "2.8.3"
 description = "NetBox plugin to sync Forward data into NetBox via built-in NQE queries"
 authors = ["Craig Johnson <craigjohnson@forwardnetworks.com>"]
 license = "MIT"


### PR DESCRIPTION
`stage_post_release` ran far enough to write a `2.8.4.dev0` bump across the four version surfaces before failing on a later step, and left the edits in the working tree. They were swept into the post-release bridge commit (#235) by a `git add -A` run without checking `git status` first. My mistake, not the script's.

`main` must carry the released version between releases — customers install from source, so a `main` reading `2.8.4.dev0` offers a version that was never gated, tagged or published.

All four surfaces move together, including the `fast_baseline.py` runtime pin, which silently reverts the first baseline from ~6 minutes to ~15 hours when it disagrees with the declared version.

## Not fixed by this

The bridge commit is no longer documentation-only, so it cannot serve as `PRIOR_POST_RELEASE_DOC_COMMIT`. Reverting the content here does not repair that — the verifier diffs the release tag against the bridge commit itself, and that diff is immutable. It is handled in the anchor change, and it is why this PR is separate.

## Standing contradiction, not resolved here

`scripts/release.py --open-next` exists to put `.dev0` on `main`; the operating rule says it must never be there. Both cannot be right. This follows the rule and leaves the contradiction recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAh92WhePWYnbCjx6sJZEb