### PR TITLE
release: authorize 2.8.4

### DIFF
--- a/docs/03_Plans/active/2026-08-18-release-2.8.4.md
+++ b/docs/03_Plans/active/2026-08-18-release-2.8.4.md
@@ -134,3 +134,40 @@ reverts with `#238` and affects only what the preview reports.
   publishes a 4.7-compatible release.
 - Whether `main` should carry a `.dev0` once the first change after a release
   lands. Narrowed in `#240`, not decided.
+
+## Release Authorization
+
+- Evidence base commit: `05c30a60e991e0b40f1b1852bfd08496789774f8`
+
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.8.3 invoke ci` passed on the final 2.8.4 tree with exit status 0: 334 harness tests OK, 70 scenario tests OK, 2224 Django tests OK with 4 skipped, and 1 UI test OK. The upgrade leg seeded under 2.8.3 on NetBox v4.6.5 and upgraded 2.8.3 -> 2.8.4 on NetBox v4.6.8, with the rows seeded under the previous release surviving.
+
+  The gated tree is the release tree apart from this authorization record, which
+  is Markdown in a single plan file and is appended after the gate by
+  construction.
+
+  The exit status is recorded because it was CAPTURED this time. The 2.8.3 gate
+  had to be attested as observed indirectly - every stage printed success and
+  no failure marker appeared, but the status itself was never read - so the
+  runner script now echoes it. This one read `GATE_EXIT_STATUS=0`.
+
+  The crash-resume scale projection MEASURED rather than skipping - 1778.99s
+  against a 3600s budget. Sixth consistent reading (1655, 1662, 1666, 1701,
+  1734, 1779 across two runtimes), which continues to identify the single
+  4382s reading taken during a kernel compile as host contention.
+
+  `FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1` records that the release-time
+  sensitive-pattern feed is not present on this host. The preflight now prints
+  that line as `unverified` rather than `passed`, which is a change this
+  release ships: the gap has refused two tags and was being reported as a pass.
+
+  `.sensitive-patterns.local.txt` exists on this host and
+  `check_sensitive_content.py --git-files --protected-history` passes over
+  tracked content and protected history. That is necessary and not sufficient -
+  the local feed remains a subset of the release feed - but it is the check
+  whose absence cost the two v2.8.3 refusals.
+
+- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke artifact-test` passed with exit status 0 against the installed `forward_netbox-2.8.4-py3-none-any.whl` on NetBox 4.6.8, Branching 1.1.2, Python 3.14, with 7 authenticated menu routes returning 200, all plugin migrations applying cleanly with no drift, and a validated SBOM of 156 components.
+
+The optional evidence ids are not recorded. The release owner's 2026-07-27
+proportionality decision applies; see
+`docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md`.


### PR DESCRIPTION
Evidence bound to production commit `05c30a6`.

## Gate

`invoke ci` on NetBox 4.6.8, **exit status 0**: 334 harness, 70 scenario, 2224 Django (4 skipped), 1 UI. Upgrade leg 2.8.3 on v4.6.5 → 2.8.4 on v4.6.8, seeded rows survived.

`invoke artifact-test` **exit status 0**: installed wheel on NetBox 4.6.8 / Branching 1.1.2 / Python 3.14, 7 menu routes 200, migrations clean, SBOM 156 components.

Scale projection **measured** at 1778.99s against 3600s — sixth consistent reading (1655, 1662, 1666, 1701, 1734, 1779), which continues to mark the single 4382s reading as the kernel-compile contention it was.

## The exit status is recorded because it was captured

The 2.8.3 authorization had to attest its gate as *observed indirectly* — every stage printed success and no failure marker appeared, but the status itself was never read. The runner script now echoes it, and this one read `GATE_EXIT_STATUS=0`. Small thing; it is the difference between evidence and inference.

## Pattern parity

Recorded as **unverified**, not passed — which is itself one of the changes this release ships. The gap has refused two tags while being printed as a pass.

`.sensitive-patterns.local.txt` exists on this host and `--git-files --protected-history` passes over tracked content and protected history. Necessary, not sufficient: the local feed is still a subset of the release feed. But it is precisely the check whose absence cost both v2.8.3 refusals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAh92WhePWYnbCjx6sJZEb