### PR TITLE
release: authorize 2.8.5

### DIFF
--- a/docs/03_Plans/active/2026-08-19-release-2.8.5.md
+++ b/docs/03_Plans/active/2026-08-19-release-2.8.5.md
@@ -110,3 +110,42 @@ about what a sync does.
   not be where it originates.
 - The comparison cost at a large deployment's scale is now observable and still
   unobserved.
+
+## Release Authorization
+
+- Evidence base commit: `5bca52b93e6aaf8451c061ea11818b2b36aad895`
+
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.8.4 invoke ci` passed on the final 2.8.5 tree with exit status 0: 334 harness tests OK, 70 scenario tests OK, 2248 Django tests OK with 4 skipped, and 1 UI test OK. The upgrade leg seeded under 2.8.4 on NetBox v4.6.5 and upgraded 2.8.4 -> 2.8.5 on NetBox v4.6.8, with the rows seeded under the previous release surviving.
+
+  The gated tree is the release tree apart from this authorization record, which
+  is Markdown in a single plan file and is appended after the gate by
+  construction.
+
+  The crash-resume scale projection MEASURED rather than skipping - 1694.53s
+  against a 3600s budget. Seventh consistent reading (1655, 1662, 1666, 1694,
+  1701, 1734, 1779 across two runtimes).
+
+  The Django total of 2248 is worth one note. Two earlier runs of that suite on
+  this host reported 203 errors and then 17, and neither was real: PostgreSQL
+  crashed mid-run and `--keepdb` then reused the damaged database, producing
+  failures indistinguishable from domain regressions -
+  `would_delete_count: 1 != 0` and `'other' != 'whitespace'` - with nothing
+  anywhere naming the database as the cause. The affected modules passed in
+  isolation and a run against a rebuilt database left one genuine failure, a
+  test asserting the previous wording of a log row. This gate builds its own
+  runtime, so it did not inherit that state, and its 2248 matches the rebuilt
+  run exactly.
+
+  `FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1` records that the release-time
+  sensitive-pattern feed is not on this host. The preflight now prints that line
+  as `unverified` rather than `passed` - a change 2.8.4 shipped, and the reason
+  it is legible here. `.sensitive-patterns.local.txt` exists and
+  `check_sensitive_content.py --git-files --protected-history` passes over
+  tracked content and protected history. Necessary, not sufficient: the local
+  feed remains a subset of the release feed.
+
+- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke artifact-test` passed with exit status 0 against the installed `forward_netbox-2.8.5-py3-none-any.whl` on NetBox 4.6.8, Branching 1.1.2, Python 3.14, with 7 authenticated menu routes returning 200, all plugin migrations applying cleanly with no drift, and a validated SBOM of 156 components.
+
+The optional evidence ids are not recorded. The release owner's 2026-07-27
+proportionality decision applies; see
+`docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md`.


### PR DESCRIPTION
Evidence bound to production commit `5bca52b`.

**Gate** — `invoke ci` on NetBox 4.6.8, **exit status 0**: 334 harness, 70 scenario, 2248 Django (4 skipped), 1 UI. Upgrade leg 2.8.4 on v4.6.5 → 2.8.5 on v4.6.8, seeded rows survived.

**Artifact** — `invoke artifact-test` **exit status 0**: installed `forward_netbox-2.8.5-py3-none-any.whl` on NetBox 4.6.8 / Branching 1.1.2 / Python 3.14, 7 menu routes 200, migrations clean, SBOM 156 components.

Scale projection **measured** at 1694.53s against 3600s — seventh consistent reading.

## Why the Django total is trustworthy

Two earlier runs of that suite on this host reported 203 errors, then 17. Neither was real: PostgreSQL crashed mid-run, and `--keepdb` then reused the damaged database — producing failures indistinguishable from domain regressions (`would_delete_count: 1 != 0`, `'other' != 'whitespace'`) with nothing naming the database as the cause.

The affected modules passed in isolation, and a run against a rebuilt database left exactly one genuine failure: a test asserting the previous wording of a log row, which #248 deliberately changed and which is updated there.

This gate builds its own runtime, so it never inherited that state — and its 2248 matches the rebuilt-database run exactly.

## Pattern parity

Recorded as **unverified**, not passed. That distinction is itself something 2.8.4 shipped, and it is why the gap is legible in this record rather than hidden among five "passed" lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAh92WhePWYnbCjx6sJZEb