### PR TITLE
release: authorize 2.8.5

### DIFF
--- a/docs/03_Plans/active/2026-08-19-release-2.8.5.md
+++ b/docs/03_Plans/active/2026-08-19-release-2.8.5.md
@@ -133,3 +133,45 @@ and every clone of it rather than the whole forge.
   not be where it originates.
 - The comparison cost at a large deployment's scale is now observable and still
   unobserved.
+
+## Release Authorization
+
+- Evidence base commit: `f841a892e088279fe5b42bac01e9994c844db198`
+
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.8.4 invoke ci` passed on the final 2.8.5 tree with exit status 0: 334 harness tests OK, 70 scenario tests OK, 2248 Django tests OK with 4 skipped, and 1 UI test OK. The upgrade leg seeded under 2.8.4 on NetBox v4.6.5 and upgraded 2.8.4 -> 2.8.5 on NetBox v4.6.8, with the rows seeded under the previous release surviving.
+
+  The gated tree is the release tree apart from this authorization record, which
+  is Markdown in a single plan file and is appended after the gate by
+  construction.
+
+  This is the SECOND gate for this version. The first attested to a tree that no
+  longer exists: `main` was reset to remove a device hostname that had reached
+  the repository as a test fixture, and the 2.8.5 commits were discarded with
+  it. Reusing that evidence would have bound this release to a lineage it was
+  never measured on.
+
+  The crash-resume scale projection MEASURED rather than skipping - 1587.55s
+  against a 3600s budget, the lowest of eight readings (1587, 1655, 1662, 1666,
+  1694, 1701, 1734, 1779 across two runtimes).
+
+  The Django total of 2248 matches the pre-rewrite gate exactly, which is the
+  evidence that re-landing restored the content rather than approximating it.
+
+  Two earlier runs of that suite on this host reported 203 errors and then 17,
+  and neither was real: PostgreSQL crashed mid-run and `--keepdb` reused the
+  damaged database, producing failures indistinguishable from domain
+  regressions. This gate builds its own runtime and did not inherit that state.
+
+  `FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1` records that the release-time
+  feed is not on this host; the preflight prints it as `unverified` rather than
+  `passed`, which is a change 2.8.4 shipped.
+  `check_sensitive_content.py --git-files --protected-history` passes over
+  tracked content and protected history, and the local feed was widened during
+  this release with the device-name patterns from that estate - which is how the
+  fixture was caught, though only after it had merged.
+
+- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke artifact-test` passed with exit status 0 against the installed `forward_netbox-2.8.5-py3-none-any.whl` on NetBox 4.6.8, Branching 1.1.2, Python 3.14, with 7 authenticated menu routes returning 200, all plugin migrations applying cleanly with no drift, and a validated SBOM of 156 components.
+
+The optional evidence ids are not recorded. The release owner's 2026-07-27
+proportionality decision applies; see
+`docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md`.


### PR DESCRIPTION
Evidence bound to production commit `f841a89` on the rebuilt lineage.

**Gate** — `invoke ci` on NetBox 4.6.8, **exit status 0**: 334 harness, 70 scenario, 2248 Django (4 skipped), 1 UI. Upgrade leg 2.8.4 on v4.6.5 → 2.8.5 on v4.6.8, seeded rows survived.

**Artifact** — `invoke artifact-test` **exit status 0**: `forward_netbox-2.8.5-py3-none-any.whl` on NetBox 4.6.8 / Branching 1.1.2 / Python 3.14, 7 routes 200, migrations clean, SBOM 156 components.

Scale projection **measured** at 1587.55s against 3600s — lowest of eight readings.

## Second gate, and why the first could not be reused

`main` was reset to remove a device hostname that had reached the repository as a test fixture, and the 2.8.5 commits were discarded with it. The earlier evidence attested to a tree that no longer exists; reusing it would have bound this release to a lineage it was never measured on.

**The Django total of 2248 matches the pre-rewrite gate exactly** — that is the evidence that re-landing restored the content rather than approximating it.

## Sensitive-content posture

The local pattern feed was widened during this release with the device-name patterns from that estate. That is how the fixture was caught — though only after it had merged, which is the honest limit: the local feed is still a subset of the release feed, and it only gained those patterns because a screenshot had already shown them to me.

`--git-files --protected-history` passes over tracked content and protected history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAh92WhePWYnbCjx6sJZEb