### PR TITLE
fix: the traceback is readable without a shell

### DIFF
--- a/docs/03_Plans/active/2026-08-19-a-failure-records-where-it-happened.md
+++ b/docs/03_Plans/active/2026-08-19-a-failure-records-where-it-happened.md
@@ -99,6 +99,32 @@ the next one needs the RQ registry again.
 - **Both recorders together.** The merge recorder was the one left behind the
   last time this file gained a diagnostic.
 
+## The operator must never need a shell
+
+The release owner's instruction, and the reason this change has a third part.
+
+Finding where a customer's sync failed required reading RQ's failed-job
+registry out of Redis over `manage.py shell`. That is not a support workflow,
+and on the run that prompted it the registry returned nothing newer than two
+months old - so the cost was paid and the answer was not there.
+
+The traceback now goes to `job.data["traceback"]`. NetBox renders job data on
+the job page, reachable from the ingestion, so it is readable without a shell.
+`sanitize_job_diagnostics` already replaces that key wholesale, so the support
+bundle carries `<redacted diagnostic>` exactly as before - verified in
+`_job_export_payload` rather than inferred from a bundle.
+
+It is deliberately NOT in the issue's `raw_data`, which is exported verbatim; a
+traceback there would leave the deployment.
+
+Three tiers, no shell in any of them:
+
+| surface | carries | leaves the deployment |
+| --- | --- | --- |
+| ingestion issue row | `file:line:function` | yes |
+| job page | full traceback | no |
+| support bundle | frames only | yes |
+
 ## Open
 
 - The defect itself is still unidentified. This makes it findable; the frames

--- a/forward_netbox/jobs.py
+++ b/forward_netbox/jobs.py
@@ -91,10 +91,31 @@ def _build_job_log_entries(log_data):
     return entries
 
 
-def safe_save_job_data(job, obj_with_logger):
+def safe_save_job_data(job, obj_with_logger, *, exc=None):
+    """Persist the run's log data, and on failure the traceback with it.
+
+    The traceback goes into `job.data["traceback"]`, which is the one place it
+    can be both visible and contained. An operator opens the job in NetBox and
+    reads it; `sanitize_job_diagnostics` replaces that key wholesale on export,
+    so the support bundle they send carries `<redacted diagnostic>` exactly as
+    it does today.
+
+    Until now it was nowhere. The job error is redacted at write time and the
+    ingestion issue records schema identifiers only, so answering "where did it
+    fail" meant reading RQ's failed-job registry out of Redis over a shell -
+    which a deployment should never be asked to do, and which on the run that
+    prompted this returned nothing newer than two months old.
+    """
     try:
         obj_with_logger.logger.flush()
         log_data = json_safe_value(obj_with_logger.logger.log_data)
+        if exc is not None:
+            import traceback as _traceback
+
+            log_data = dict(log_data or {})
+            log_data["traceback"] = "".join(
+                _traceback.format_exception(type(exc), exc, exc.__traceback__)
+            )
         job.data = log_data
         job.log_entries = _build_job_log_entries(log_data)
         job.save(update_fields=["data", "log_entries"])
@@ -624,7 +645,7 @@ def sync_forwardsync(job, *args, **kwargs):
                 sync.pk,
                 exception_type(exc),
             )
-        safe_save_job_data(job, sync)
+        safe_save_job_data(job, sync, exc=exc)
         terminate_job_once(
             job,
             status=JobStatusChoices.STATUS_ERRORED,

--- a/forward_netbox/tests/test_raise_site_is_recorded.py
+++ b/forward_netbox/tests/test_raise_site_is_recorded.py
@@ -206,3 +206,48 @@ class TheServerLogHoldsTheTracebackTest(SimpleTestCase):
         self.assertIn("raw_data=diagnosis", source)
         self.assertNotIn("raw_data=exc", source)
         self.assertNotIn("message=str(exc)", source)
+
+
+class TheTracebackIsVisibleWithoutAShellTest(SimpleTestCase):
+    """An operator must never be asked to read Redis to find out where it failed.
+
+    The traceback is written to `job.data["traceback"]`, which NetBox renders on
+    the job page, and which `sanitize_job_diagnostics` replaces wholesale on
+    export - so it is readable on the deployment and redacted in the support
+    bundle they send back.
+    """
+
+    def test_the_traceback_is_redacted_on_export(self):
+        from forward_netbox.utilities.diagnostics import REDACTED_DIAGNOSTIC
+        from forward_netbox.utilities.diagnostics import sanitize_job_diagnostics
+
+        try:
+            _raise_key_error_with_a_customer_shaped_key()
+        except KeyError as exc:
+            import traceback
+
+            rendered = "".join(
+                traceback.format_exception(type(exc), exc, exc.__traceback__)
+            )
+
+        data = {"logs": [], "traceback": rendered}
+        exported = sanitize_job_diagnostics(data)
+        self.assertEqual(exported["traceback"], REDACTED_DIAGNOSTIC)
+        self.assertNotIn("switch-alpha.invalid", repr(exported))
+
+    def test_the_saver_accepts_an_exception_and_records_it(self):
+        import inspect
+
+        from forward_netbox import jobs
+
+        source = inspect.getsource(jobs.safe_save_job_data)
+        self.assertIn("exc=None", source)
+        self.assertIn('log_data["traceback"]', source)
+
+    def test_the_sync_failure_path_passes_the_exception(self):
+        import inspect
+
+        from forward_netbox import jobs
+
+        source = inspect.getsource(jobs.sync_forwardsync)
+        self.assertIn("safe_save_job_data(job, sync, exc=exc)", source)


### PR DESCRIPTION
Finding where a customer's sync failed required reading RQ's failed-job registry out of Redis over `manage.py shell`. That is not a support workflow — and on the run that prompted it, the registry returned **nothing newer than two months old**. The cost was paid and the answer was not there.

## The change

The traceback goes to `job.data["traceback"]`, which is the one place it can be both visible and contained:

| surface | carries | leaves the deployment |
|---|---|---|
| ingestion issue row | `file:line:function` (#256) | yes |
| **job page** | **full traceback** | **no** |
| support bundle | frames only | yes |

NetBox renders job data on the job page, reachable from the ingestion, so it is readable in the UI. `sanitize_job_diagnostics` already lists `"traceback"` in `_SENSITIVE_DIAGNOSTIC_KEYS` and replaces it wholesale, so the bundle still carries `<redacted diagnostic>`.

I verified that in `_job_export_payload` — which runs `safe_job_error_summary()` over `job.error` and `sanitize_job_diagnostics()` over `job.data` — rather than inferring it from a bundle that happened to look redacted.

## Deliberately not in `raw_data`

The ingestion issue's `raw_data` is exported verbatim. A traceback there would leave the deployment. The asymmetry is the point: detail stays local, only code identifiers travel.

## Validation

Full Django suite **2263 tests OK, 0 failures**. Tests assert the traceback is redacted on export and that a customer-shaped value in it does not survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAh92WhePWYnbCjx6sJZEb