### PR TITLE
release: authorize 2.8.6

### DIFF
--- a/docs/03_Plans/active/2026-08-19-release-2.8.6.md
+++ b/docs/03_Plans/active/2026-08-19-release-2.8.6.md
@@ -94,3 +94,41 @@ about what a sync does.
   `ForwardSyncError`, `SyncError` and `JobTimeoutException`, so a `KeyError`
   should re-raise and register. Unexplained, and a second reason the server log
   matters more than the registry.
+
+## Release Authorization
+
+- Evidence base commit: `0edd10f462bb46cf111dd185ab22519505b29e69`
+
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.8.5 invoke ci` passed on the final 2.8.6 tree with exit status 0: 334 harness tests OK, 70 scenario tests OK, 2265 Django tests OK with 4 skipped, and 1 UI test OK. The upgrade leg seeded under 2.8.5 on NetBox v4.6.5 and upgraded 2.8.5 -> 2.8.6 on NetBox v4.6.8, with the rows seeded under the previous release surviving.
+
+  The gated tree is the release tree apart from this authorization record, which
+  is Markdown in a single plan file and is appended after the gate by
+  construction.
+
+  The evidence base is the crash-fix commit, which landed AFTER the version-bump
+  commit. Precedent: the 2.8.3 recovery bound its evidence to a baseline-advance
+  commit the same way; the binding rule is HEAD^, not the prepare commit.
+
+  A first gate for this version was started before the crash was root-caused and
+  was killed: its scope no longer matched the release, and its mounted tree had
+  been edited mid-run, which invalidates a gate regardless. Nothing from that
+  run is attested here.
+
+  The 2265 Django total includes the two mixed-model ChangeDiff tests that
+  reproduce the customer's crash; their negative control - both erroring on the
+  unfixed code, `KeyError('vrf')` in one direction and duplicate same-identity
+  diffs in the other - was run in an isolated runtime before the fix landed.
+
+  The crash-resume scale projection MEASURED - 1664.44s against a 3600s budget,
+  the ninth consistent reading (1587-1779 across two runtimes).
+
+  `FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1` records that the release-time
+  feed is not on this host; the preflight prints that line as `unverified`.
+  `check_sensitive_content.py --git-files --protected-history` passes over
+  tracked content and protected history against the widened local feed.
+
+- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke artifact-test` passed with exit status 0 against the installed `forward_netbox-2.8.6-py3-none-any.whl` on NetBox 4.6.8, Branching 1.1.2, Python 3.14, with 7 authenticated menu routes returning 200, all plugin migrations applying cleanly with no drift, and a validated SBOM of 156 components.
+
+The optional evidence ids are not recorded. The release owner's 2026-07-27
+proportionality decision applies; see
+`docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md`.


### PR DESCRIPTION
Evidence bound to `0edd10f` — the crash-fix commit, per the 2.8.3 precedent that the binding rule is `HEAD^`, not the prepare commit.

**Gate** — exit status 0 on NetBox 4.6.8: 334 harness, 70 scenario, **2265 Django** (4 skipped) — including the two tests that reproduce the customer's crash — 1 UI. Upgrade leg 2.8.5 on v4.6.5 → 2.8.6 on v4.6.8, seeded rows survived.

**Artifact** — exit status 0: `forward_netbox-2.8.6-py3-none-any.whl` on NetBox 4.6.8 / Branching 1.1.2 / Python 3.14, 7 routes 200, migrations clean, SBOM 156 components.

Scale projection measured 1664.44s against 3600s — ninth consistent reading.

**Attested honestly:** a first gate for this version was killed — its scope predated the crash fix, and its mounted tree was edited mid-run, which invalidates a gate regardless. Nothing from that run is attested here. The negative control for the crash tests (both erroring on unfixed code) ran in an isolated runtime before the fix landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAh92WhePWYnbCjx6sJZEb