### PR TITLE
release: prepare 2.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Generated from the README compatibility table by `scripts/gen_changelog.py`. Do not edit by hand.
 
+## v2.8.7
+
+Release candidate; Drift preview compares converged rows in bulk instead of per row; drift rows identify their workload.
+
 ## v2.8.6
 
 Fix: a failed sync records where it happened, readable in NetBox without a shell.

--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ See the
 
 ## Release Compatibility
 
-The `2.8.6` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
+The `2.8.7` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
+| `v2.8.7` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Drift preview compares converged rows in bulk instead of per row; drift rows identify their workload. |
 | `v2.8.6` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Fix: a failed sync records where it happened, readable in NetBox without a shell. |
 | `v2.8.5` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.6`; Fix: a failed sync names what failed, and a redacted warning is no longer reported as a failure. |
 | `v2.8.4` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.5`; Fix: the drift report measures a converged estate instead of reporting it as maximally uncertain. |

--- a/docs/01_User_Guide/README.md
+++ b/docs/01_User_Guide/README.md
@@ -70,13 +70,14 @@ migrations, e.g. netbox-dlm `0.2.0+`; older builds need
 
 ## Release Compatibility
 
-The `2.8.6` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
+The `2.8.7` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
+| `v2.8.7` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Drift preview compares converged rows in bulk instead of per row; drift rows identify their workload. |
 | `v2.8.6` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Fix: a failed sync records where it happened, readable in NetBox without a shell. |
 | `v2.8.5` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.6`; Fix: a failed sync names what failed, and a redacted warning is no longer reported as a failure. |
 | `v2.8.4` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.5`; Fix: the drift report measures a converged estate instead of reporting it as maximally uncertain. |

--- a/docs/03_Plans/active/2026-08-20-release-2.8.7.md
+++ b/docs/03_Plans/active/2026-08-20-release-2.8.7.md
@@ -1,0 +1,126 @@
+# Release 2.8.7
+
+## Goal
+
+Ship the fix for a preview that cost twenty-four minutes to measure an estate
+with 440 rows of drift, and make the page it feeds say which workload each row
+belongs to.
+
+## Why
+
+A deployment's drift report priced its own comparison for the first time. The
+instrumentation that made that possible shipped in 2.8.4 precisely because the
+cost "has never been observed" at scale, and the first reading was:
+
+    Comparison cost   1452552 ms for 558380 rows
+                      Slowest: dcim.interface at 842445 ms
+
+Twenty-four minutes, 58% of it in one model. That model read 357,864 rows and
+found 387 rows of drift, so almost every row it looked at was unchanged - the
+expensive case was the one that had nothing to report.
+
+The cause is a single missing call. `apply_model_rows` primes the dependency
+lookup caches before handing rows to the classification, so the real apply reads
+parent devices, interfaces, tags and VLANs in bulk. `compare_model_rows` calls
+`bulk_orm_apply_simple_models` directly - deliberately, so the comparison cannot
+diverge from the apply - and that route skipped the priming. The identical code
+then resolved each parent one row at a time against caches that started empty
+and only ever filled from their own misses.
+
+The same report carried a second defect. There is one row per WORKLOAD and each
+was labelled by its MODEL, so an estate with three `dcim.inventoryitem` maps saw
+three rows all reading `dcim.inventoryitem` - one with 0 Forward rows and 56
+pending removals, another with 48 and 0 - and "Not compared" printed the name
+three times in a row. The rows were right and only the label was ambiguous, but
+a page that prints one identifier three times beside different numbers reads as
+a rendering fault, and this page's whole job is to be believed.
+
+The third item belongs to the release machine rather than to any deployment.
+`verify_release_provenance._github_json` used `urllib.request`, which forces
+`Connection: close` and cannot be overridden, and this host stalls close-mode
+responses. It cost four release cycles across 2.8.5 and 2.8.6 and was worked
+around by a `sitecustomize` shim outside the repository - so every tagged tree
+still carried the path that does not work here.
+
+## Constraints
+
+- A patch. No migration, and nothing changes what a sync writes to NetBox.
+- The comparison must keep routing through the real apply path. A cheaper
+  comparison that answers differently is worse than a slow one, because the
+  drift figure is the product and an operator acts on it.
+- Priming must stay read-only. A preview that wrote anything into an operator's
+  NetBox as a side effect of being looked at is the failure `drift_comparison`
+  already guards against.
+- No rendered label may carry an execution value; shard keys are device data.
+- `max_version` stays `4.6.99`, unchanged and for the same measured reason:
+  `netbox_branching` 1.1.2 does not import on 4.7.0-beta1.
+
+## Touched Surfaces
+
+Landed as `#263`. This commit adds the version surfaces, the compatibility
+tables, and this plan.
+
+- `forward_netbox/utilities/drift_comparison.py`
+- `forward_netbox/utilities/drift_report.py`
+- `forward_netbox/templates/forward_netbox/forwardsync_drift_report.html`
+- `scripts/verify_release_provenance.py`
+
+## Approach
+
+`compare_model_rows` calls `prime_dependency_lookup_caches` before classifying,
+exactly as `apply_model_rows` does. Rows that match an existing object now cost
+a constant number of queries rather than a number proportional to the rows: 3 at
+both 6 rows and 24, where before it was 15 and 51.
+
+`drift_report` gives each row a label qualified by the query behind it, but only
+where a model has more than one workload, falling back to position where the
+query name is absent or shared between siblings.
+
+`_github_json` speaks HTTP/1.1 through `http.client` and sends no `Connection`
+header, retrying bounded transport faults only - an HTTP status is an answer
+about the release, so a 403 or a 404 is raised on the first response.
+
+## Validation
+
+Recorded in the Release Authorization section below, bound to the evidence base
+commit: the full isolated gate and the exact-runtime artifact test, both on the
+final tree, both on NetBox 4.6.8.
+
+## Rollback
+
+No migration, so a downgrade is an install of the prior wheel. The priming
+change is a cost change only - the counts are pinned identical primed and cold,
+which is what makes it safe to revert under time pressure. Reverting the labels
+restores the ambiguous names. Reverting the transport restores a verifier that
+cannot complete on this host.
+
+## Decision Log
+
+- **Prime rather than shortcut.** Detecting unchanged rows without instantiating
+  them would be faster still and would let the comparison disagree with the
+  apply. Rejected on the reasoning that put the comparison on the apply path.
+- **The create path is documented, not optimised.** A row with no counterpart is
+  instantiated and NetBox charges two queries per instance for content type and
+  custom field defaults. Avoiding that means leaving the apply path. The cost is
+  pinned as per-row so it is not mistaken for one already fixed.
+- **Qualify only ambiguous rows.** Labelling every row `model (query)` would put
+  a redundant suffix on the twenty-odd models with one workload to fix the two
+  without.
+- **Position, not execution value, as the last resort.** Two workloads for one
+  model can share a query name; the value that always separates them is shard
+  data.
+- **`http.client` rather than a retry loop over `urllib`.** Retrying would work
+  eventually, at 30 seconds per stalled attempt against a host that fails
+  roughly five close-mode requests in six. Removing the header the host reacts
+  to is the fix.
+- **Patch, not minor.** Nothing gains an operator control.
+
+## Open
+
+- The after-number for the 24 minutes comes from that deployment's next
+  preview. Expect the interface model to collapse and the models dominated by
+  creates not to move - on that report those are also the ones with no
+  comparison at all.
+- This host still stalls close-mode HTTP for every other caller. The verifier
+  was made immune, which is not the same as the machine being fixed, and it
+  needs attention outside a release window. See the 2.8.6 plan's Open section.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,13 +8,14 @@ Forward 26.6 is the baseline for async NQE.
 
 ## Release Compatibility
 
-The `2.8.6` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
+The `2.8.7` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
+| `v2.8.7` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Drift preview compares converged rows in bulk instead of per row; drift rows identify their workload. |
 | `v2.8.6` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Fix: a failed sync records where it happened, readable in NetBox without a shell. |
 | `v2.8.5` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.6`; Fix: a failed sync names what failed, and a redacted warning is no longer reported as a failure. |
 | `v2.8.4` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.5`; Fix: the drift report measures a converged estate instead of reporting it as maximally uncertain. |

--- a/forward_netbox/__init__.py
+++ b/forward_netbox/__init__.py
@@ -5,7 +5,7 @@ class NetboxForwardConfig(PluginConfig):
     name = "forward_netbox"
     verbose_name = "Forward"
     description = "Sync Forward data into NetBox using built-in NQE queries."
-    version = "2.8.6"
+    version = "2.8.7"
     base_url = "forward"
     min_version = "4.6.5"
     max_version = "4.6.99"

--- a/forward_netbox/tests/test_runtime_dependency_check.py
+++ b/forward_netbox/tests/test_runtime_dependency_check.py
@@ -23,7 +23,7 @@ class RuntimeDependencyCheckTest(SimpleTestCase):
         self.assertIsNotNone(_resolved_branching_version())
 
     def test_plugin_config_version_matches_package_release(self):
-        self.assertEqual(NetboxForwardConfig.version, "2.8.6")
+        self.assertEqual(NetboxForwardConfig.version, "2.8.7")
 
     def test_exact_runtime_passes(self):
         _check_runtime_dependencies()

--- a/forward_netbox/utilities/fast_baseline.py
+++ b/forward_netbox/utilities/fast_baseline.py
@@ -200,7 +200,7 @@ def _runtime_decision():
     expected = {
         "netbox_series": "4.6",
         "branching_series": "1.1",
-        "forward_netbox": "2.8.6",
+        "forward_netbox": "2.8.7",
         # Each optional distribution lists every version validated against this
         # engine, not a single pin. An exact pin meant a customer upgrading one
         # optional plugin silently lost the fast baseline — no error, just a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "forward-netbox"
-version = "2.8.6"
+version = "2.8.7"
 description = "NetBox plugin to sync Forward data into NetBox via built-in NQE queries"
 authors = ["Craig Johnson <craigjohnson@forwardnetworks.com>"]
 license = "MIT"


### PR DESCRIPTION
Version surfaces, compatibility tables, and the release plan for 2.8.7. The production change landed in #263.

The README/docs tables carry 2.8.7 as a **release candidate**; promotion to current release happens in the post-release anchor commit, as it did for 2.8.6 (#262).

## Gate results, on this exact tree

Both recorded in the plan's `## Release Authorization` section on the evidence branch.

**Full isolated gate** — exit status 0:
- 334 harness tests OK
- 70 scenario tests OK
- 2276 Django tests OK (4 skipped)
- 1 UI test OK
- Upgrade leg: 2.8.6 on NetBox v4.6.5 → 2.8.7 on NetBox v4.6.8, migrated, rows seeded under the previous release survived

**Exact-runtime artifact test** — passed against the installed `forward_netbox-2.8.7-py3-none-any.whl` on NetBox 4.6.8, Branching 1.1.2, Python 3.14: 7 authenticated menu routes returning 200, all plugin migrations applying cleanly, validated SBOM of 156 components.

`FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1` records that the release-time pattern feed is not on this host; the preflight prints that line as `unverified`, and the gate applies the superset feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkHV4nyhyrmRH3kmTSBf26