### PR TITLE
release: authorize 2.8.7

### DIFF
--- a/docs/03_Plans/active/2026-08-20-release-2.8.7.md
+++ b/docs/03_Plans/active/2026-08-20-release-2.8.7.md
@@ -124,3 +124,39 @@ cannot complete on this host.
 - This host still stalls close-mode HTTP for every other caller. The verifier
   was made immune, which is not the same as the machine being fixed, and it
   needs attention outside a release window. See the 2.8.6 plan's Open section.
+
+## Release Authorization
+
+- Evidence base commit: `9e30a023a5aff1f5920a4fb9d14ce980a08c0f2d`
+
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.8.6 invoke ci` passed on the final 2.8.7 tree with exit status 0: 334 harness tests OK, 70 scenario tests OK, 2276 Django tests OK with 4 skipped, and 1 UI test OK. The upgrade leg seeded under 2.8.6 on NetBox v4.6.5 and upgraded 2.8.6 -> 2.8.7 on NetBox v4.6.8, with the rows seeded under the previous release surviving.
+
+  The gated tree is the release tree apart from this authorization record, which
+  is Markdown in a single plan file and is appended after the gate by
+  construction.
+
+  The evidence base is the prepare commit. The production change landed BEFORE
+  it, in `#263`, rather than between prepare and authorize as in 2.8.6; the
+  binding rule is HEAD^, which this satisfies either way.
+
+  The 2276 Django total is 2265 plus the eleven tests added by `#263`: four in
+  `test_preview_primes_its_lookup_caches` and seven in
+  `test_drift_rows_are_distinguishable`.
+
+  A FIRST invocation of this gate died 236 tests into the harness suite with no
+  exit status, no error output and no OOM, having already torn down its own
+  containers - and its wrapper reported "completed, exit code 0". Nothing from
+  that run is attested here. The run recorded above was launched detached and
+  wrote `GATE_EXIT=0` itself; that self-written status, not a wrapper's, is what
+  this entry attests.
+
+  `FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1` records that the release-time
+  feed is not on this host; the preflight prints that line as `unverified`.
+  `check_sensitive_content.py --git-files --protected-history` passes over
+  tracked content and protected history against the widened local feed.
+
+- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke artifact-test` passed against the installed `forward_netbox-2.8.7-py3-none-any.whl` on NetBox 4.6.8, Branching 1.1.2, Python 3.14, with 7 authenticated menu routes returning 200, all plugin migrations applying cleanly with no drift, and a validated SBOM of 156 components.
+
+The optional evidence ids are not recorded. The release owner's 2026-07-27
+proportionality decision applies; see
+`docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md`.


### PR DESCRIPTION
Records the two gate results on the final tree, bound to the prepare commit `9e30a023a5aff1f5920a4fb9d14ce980a08c0f2d` as the evidence base. Changes only the release plan.

`check_release_authorization.py --version 2.8.7` passes:

```json
{"authorized_evidence_ids": ["exact-runtime-artifact", "final-tree-full-gate"],
 "evidence_base_commit": "9e30a023a5aff1f5920a4fb9d14ce980a08c0f2d",
 "plan": "docs/03_Plans/active/2026-08-20-release-2.8.7.md"}
```

**Full isolated gate**, exit status 0: 334 harness, 70 scenario, 2276 Django (4 skipped), 1 UI. Upgrade leg 2.8.6 on NetBox v4.6.5 → 2.8.7 on v4.6.8 with seeded rows surviving.

**Exact-runtime artifact test**: `forward_netbox-2.8.7-py3-none-any.whl` on NetBox 4.6.8 / Branching 1.1.2 / Python 3.14, 7 authenticated menu routes at 200, migrations clean, SBOM of 156 components validated.

The authorization also records that a first invocation of the gate died mid-run and that its wrapper falsely reported success. Nothing from that run is attested; the attested run wrote its own exit status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkHV4nyhyrmRH3kmTSBf26