### PR TITLE
release: authorize 2.8.8

### DIFF
--- a/docs/03_Plans/active/2026-08-20-release-2.8.8.md
+++ b/docs/03_Plans/active/2026-08-20-release-2.8.8.md
@@ -89,3 +89,34 @@ half is observational and changes nothing about what runs.
   have made this a single "Not measured" cell instead of an outage.
 - The 2.8.7 comparison-cost after-number is still unobserved, because this
   defect is what stopped the preview from running.
+
+## Release Authorization
+
+- Evidence base commit: `bfac8b3ab3c232665c0d5ba9f185b3677ecdea0a`
+
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.8.7 invoke ci` passed on the final 2.8.8 tree with exit status 0: 334 harness tests OK, 70 scenario tests OK, 2280 Django tests OK with 4 skipped, and 1 UI test OK. The upgrade leg seeded under 2.8.7 on NetBox v4.6.5 and upgraded 2.8.7 -> 2.8.8 on NetBox v4.6.8, with the rows seeded under the previous release surviving.
+
+  The upgrade leg is bound to 2.8.7 deliberately: that is the version this
+  release fixes, so it is the upgrade every affected deployment will perform.
+
+  The gated tree is the release tree apart from this authorization record, which
+  is Markdown in a single plan file and is appended after the gate by
+  construction.
+
+  The 2280 Django total is 2276 plus the four tests added by `#268`.
+
+  The exit status is the one the gate command wrote itself
+  (`echo "GATE_EXIT=$?"`), not a wrapper's. During this release a background
+  wrapper again reported "completed, exit code 0" for a starter process that had
+  merely launched the gate; only the self-written status is attested here.
+
+  `FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1` records that the release-time
+  feed is not on this host; the preflight prints that line as `unverified`.
+  `check_sensitive_content.py --git-files --protected-history` passes over
+  tracked content and protected history against the widened local feed.
+
+- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke artifact-test` passed with exit status 0 against the installed `forward_netbox-2.8.8-py3-none-any.whl` on NetBox 4.6.8, Branching 1.1.2, Python 3.14, with 7 authenticated menu routes returning 200, all plugin migrations applying cleanly with no drift, and a validated SBOM of 156 components.
+
+The optional evidence ids are not recorded. The release owner's 2026-07-27
+proportionality decision applies; see
+`docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md`.


### PR DESCRIPTION
Records the two gate results on the final tree, bound to the prepare commit `bfac8b3ab3c232665c0d5ba9f185b3677ecdea0a` as the evidence base. Changes only the release plan.

`check_release_authorization.py --version 2.8.8` passes with both evidence ids authorized.

**Full isolated gate**, exit status 0: 334 harness, 70 scenario, 2280 Django (4 skipped), 1 UI. Upgrade leg 2.8.7 → 2.8.8 on NetBox v4.6.5 → v4.6.8, bound to 2.8.7 deliberately because that is the version this release fixes.

**Exact-runtime artifact test**: `forward_netbox-2.8.8-py3-none-any.whl` on NetBox 4.6.8 / Branching 1.1.2 / Python 3.14, 7 authenticated menu routes at 200, migrations clean, SBOM of 156 components validated.

The authorization records that the attested exit status is the one the gate wrote itself, not a wrapper's — a background wrapper again reported success for a starter process that had only launched the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkHV4nyhyrmRH3kmTSBf26