### PR TITLE
chore: advance the release provenance anchor to 2.8.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git fetch --no-tags origin main:refs/remotes/origin/main
-          git fetch --force origin refs/tags/v2.8.7:refs/tags/v2.8.7
+          git fetch --force origin refs/tags/v2.8.8:refs/tags/v2.8.8
           set -o pipefail
           for attempt in $(seq 1 120); do
             provenance_log="$(mktemp)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Generated from the README compatibility table by `scripts/gen_changelog.py`. Do 
 
 ## v2.8.8
 
-Release candidate; Fix: the dependency preview runs again on deployments with optional plugins installed.
+Fix: the dependency preview runs again on deployments with optional plugins installed.
 
 ## v2.8.7
 

--- a/README.md
+++ b/README.md
@@ -64,15 +64,15 @@ See the
 
 ## Release Compatibility
 
-The `2.8.8` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
+The `2.8.8` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.8.8` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Fix: the dependency preview runs again on deployments with optional plugins installed. |
-| `v2.8.7` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Drift preview compares converged rows in bulk instead of per row; drift rows identify their workload. |
+| `v2.8.8` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Fix: the dependency preview runs again on deployments with optional plugins installed. |
+| `v2.8.7` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.8`; Drift preview compares converged rows in bulk instead of per row; drift rows identify their workload. |
 | `v2.8.6` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.7`; Fix: a failed sync records where it happened, readable in NetBox without a shell. |
 | `v2.8.5` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.6`; Fix: a failed sync names what failed, and a redacted warning is no longer reported as a failure. |
 | `v2.8.4` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.5`; Fix: the drift report measures a converged estate instead of reporting it as maximally uncertain. |

--- a/docs/01_User_Guide/README.md
+++ b/docs/01_User_Guide/README.md
@@ -70,15 +70,15 @@ migrations, e.g. netbox-dlm `0.2.0+`; older builds need
 
 ## Release Compatibility
 
-The `2.8.8` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
+The `2.8.8` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.8.8` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Fix: the dependency preview runs again on deployments with optional plugins installed. |
-| `v2.8.7` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Drift preview compares converged rows in bulk instead of per row; drift rows identify their workload. |
+| `v2.8.8` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Fix: the dependency preview runs again on deployments with optional plugins installed. |
+| `v2.8.7` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.8`; Drift preview compares converged rows in bulk instead of per row; drift rows identify their workload. |
 | `v2.8.6` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.7`; Fix: a failed sync records where it happened, readable in NetBox without a shell. |
 | `v2.8.5` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.6`; Fix: a failed sync names what failed, and a redacted warning is no longer reported as a failure. |
 | `v2.8.4` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.5`; Fix: the drift report measures a converged estate instead of reporting it as maximally uncertain. |

--- a/docs/03_Plans/active/2026-08-20-anchor-2.8.8.md
+++ b/docs/03_Plans/active/2026-08-20-anchor-2.8.8.md
@@ -1,0 +1,75 @@
+# Advance the release provenance anchor to 2.8.8
+
+## Goal
+
+Move the provenance anchor onto the shipped 2.8.8 release and promote it to
+current in the compatibility tables.
+
+## Why
+
+The anchor names the previous release and the documentation-only bridge commit
+that must directly follow its tag. Until it advances, `check_harness.py` fails
+by construction, because the tables would name a current release the anchor does
+not. That failure is the check working, and it is why this cannot be forgotten
+quietly - only deferred.
+
+v2.8.8 published: the tag peels to `7c25dd23a988358daa7126562c950e9811891f53`,
+all four release workflow jobs succeeded, and PyPI and GitHub carry
+byte-identical artifacts - wheel
+`488fb094c2eddcabf4b8d857fb989d75e1b952d2156f87fc5e131bbb8cf2f58b` and sdist
+`3b1322a8663a3deaf4e4871560a7b1e14e9e4667d67a448f3adab8df25816523` - each
+verified by downloading the GitHub asset and hashing it rather than by reading
+the workflow's own report.
+
+## Constraints
+
+- The bridge must be the first commit after the tag on main's first-parent
+  lineage and documentation-only. `82f04d6` is one file, 46 lines, no code.
+- The table promotion belongs here rather than on the release branch, where it
+  would flip the tables to "current release" before a tag exists and make the
+  harness unsatisfiable.
+
+## Touched Surfaces
+
+- `scripts/verify_release_provenance.py` - `PRIOR_RELEASE_TAG`,
+  `PRIOR_POST_RELEASE_DOC_COMMIT`
+- `scripts/check_harness.py`, `scripts/tests/test_tasks.py`,
+  `.github/workflows/release.yml` - the tag the release workflow is pinned to
+- `README.md`, `docs/README.md`, `docs/01_User_Guide/README.md`, `CHANGELOG.md`
+
+## Approach
+
+Anchor to `v2.8.8` and to bridge commit
+`82f04d6c4a932dc5eb484bfa8ef7010791a4d12a`, promote 2.8.8 to current release,
+demote 2.8.7 to superseded.
+
+## Validation
+
+`check_harness.py` passes with the anchor advanced, `scripts/tests` passes, and
+`verify_release_provenance.py --controls-only` passes against live GitHub.
+
+## Rollback
+
+Revert this commit. The anchor returns to v2.8.7 and the harness fails again,
+which is the safe direction: it blocks the next release rather than permitting
+an unverified one.
+
+## Decision Log
+
+- **Promotion folded into the anchor commit**, so the anchor and the tables can
+  never disagree in a pushed state.
+- **`stage_publish` called directly rather than through `--publish`**, which
+  avoided the premature `release: promote` commit that had to be unwound during
+  2.8.7. Nothing needed unwinding this time.
+- **No `.dev0` opened.** `main` carries the RELEASED version.
+
+## Open
+
+- 2.8.8 fixes a regression 2.8.7 shipped. The gate that passed 2.8.7 was not
+  weak - 2,276 tests, a full upgrade leg, an artifact test - but nothing in it
+  ran a dependency PREVIEW over a routing model, so the new code path was
+  unexercised. The structural contract test added in `#268` closes that class;
+  whether other single-job-over-all-models paths have the same blast radius is
+  not yet answered.
+- The 2.8.7 comparison-cost after-number remains unobserved, because the
+  regression is what prevented the preview from producing it.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,15 +8,15 @@ Forward 26.6 is the baseline for async NQE.
 
 ## Release Compatibility
 
-The `2.8.8` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
+The `2.8.8` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.8.8` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Fix: the dependency preview runs again on deployments with optional plugins installed. |
-| `v2.8.7` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Drift preview compares converged rows in bulk instead of per row; drift rows identify their workload. |
+| `v2.8.8` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Fix: the dependency preview runs again on deployments with optional plugins installed. |
+| `v2.8.7` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.8`; Drift preview compares converged rows in bulk instead of per row; drift rows identify their workload. |
 | `v2.8.6` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.7`; Fix: a failed sync records where it happened, readable in NetBox without a shell. |
 | `v2.8.5` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.6`; Fix: a failed sync names what failed, and a redacted warning is no longer reported as a failure. |
 | `v2.8.4` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.5`; Fix: the drift report measures a converged estate instead of reporting it as maximally uncertain. |

--- a/scripts/check_harness.py
+++ b/scripts/check_harness.py
@@ -197,7 +197,7 @@ REQUIRED_TEXT = {
     ],
     ".github/workflows/release.yml": [
         "fetch-depth: 0",
-        "refs/tags/v2.8.7",
+        "refs/tags/v2.8.8",
         "verify_release_provenance.py",
         "--git-files",
         "--protected-history",

--- a/scripts/tests/test_tasks.py
+++ b/scripts/tests/test_tasks.py
@@ -175,7 +175,7 @@ class ReleaseArtifactTaskTest(unittest.TestCase):
 
         self.assertIn("--require-hashes", workflow)
         self.assertIn("requirements-release.txt", workflow)
-        self.assertIn("refs/tags/v2.8.7", workflow)
+        self.assertIn("refs/tags/v2.8.8", workflow)
         self.assertIn("scripts/build_reproducible_distribution.py", workflow)
         self.assertIn("python -m invoke artifact-test", workflow)
         self.assertIn("sbom/", workflow)

--- a/scripts/verify_release_provenance.py
+++ b/scripts/verify_release_provenance.py
@@ -29,8 +29,8 @@ GITHUB_API_URL = "https://api.github.com"
 #         from two commits, so their provenance could not be verified.
 UNPUBLISHED_RELEASE_TAGS = ("v2.7.3", "v2.7.7", "v2.7.8", "v2.7.10")
 
-PRIOR_RELEASE_TAG = "v2.8.7"
-PRIOR_POST_RELEASE_DOC_COMMIT = "2811eba4286d34b195b5f820de47b6612276f2af"
+PRIOR_RELEASE_TAG = "v2.8.8"
+PRIOR_POST_RELEASE_DOC_COMMIT = "82f04d6c4a932dc5eb484bfa8ef7010791a4d12a"
 
 # Content a specific bridge commit is excused for carrying, keyed by commit hash.
 #


### PR DESCRIPTION
Anchors provenance to `v2.8.8` and to the documentation-only bridge commit `82f04d6c4a932dc5eb484bfa8ef7010791a4d12a`, and promotes 2.8.8 to current release in the compatibility tables.

The harness fails by construction until this lands — the tables would name a current release the anchor does not.

## v2.8.8 published

- Tag peels to `7c25dd23a988358daa7126562c950e9811891f53`
- All four release workflow jobs succeeded
- PyPI and GitHub artifacts verified byte-identical by downloading the GitHub assets and hashing them:
  - wheel `488fb094c2eddcabf4b8d857fb989d75e1b952d2156f87fc5e131bbb8cf2f58b`
  - sdist `3b1322a8663a3deaf4e4871560a7b1e14e9e4667d67a448f3adab8df25816523`

## Verified here

- `check_harness.py --base origin/main`: passed
- `scripts/tests`: 334 OK
- `pre-commit run --all-files`: passed
- `verify_release_provenance.py --controls-only`: passed against live GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkHV4nyhyrmRH3kmTSBf26