### PR TITLE
fix: the unattended device sweep requires the same evidence as the prune

### DIFF
--- a/docs/03_Plans/active/2026-08-21-ownership-sweep-quarantine.md
+++ b/docs/03_Plans/active/2026-08-21-ownership-sweep-quarantine.md
@@ -1,0 +1,106 @@
+# The unattended device sweep gets the same evidence bar as the operator path
+
+## Goal
+
+A sync may delete a device on its own only on the same evidence Prune orphans
+requires from an operator: a quarantined absence, and a sane aggregate.
+
+## Why
+
+The same act - delete a device because it is absent from Forward's result -
+existed at two different standards. The operator path (Prune orphans) requires
+an absence QUARANTINE (>=3 consecutive confirmed absent runs AND >=72 hours,
+operator-tunable per source, fail-closed for a device with no absence record), a
+25% shrink refusal, a confirm dialog, and an absence classification. The
+unattended ownership sweep in `apply_durable_workload_deltas` deleted on the
+FIRST absence, gated only by ownership claims - and the scope claim is released
+by the same first observation of absence, so the gate evaporated exactly one run
+before the delete fired.
+
+The quarantine model's own docstring states the principle the sweep violated: a
+device disabled in Forward is indistinguishable from one that was deleted, so
+deleting on the first absence destroys devices that are merely in a maintenance
+window. The sequence - disabled in Forward -> claim released on run 1 -> deleted
+on run 2 - is the long-standing "disabled in Forward deletes from NetBox"
+mechanism. A deployment's ten devices survived it only because
+`netbox_routing.bgppeer` rows held PROTECT references; a device with no
+protecting child was removed silently, since a successful delete files no
+ingestion issue.
+
+## Constraints
+
+- The sweep itself is intended behaviour and stays: a device this sync created
+  and Forward genuinely dropped must eventually go without an operator visit.
+  Option A (remove the sweep) was rejected for stranding those devices forever;
+  option C (demote to tagging) for making the sweep redundant with the tag job.
+- Fail closed everywhere: no absence record means zero confirmed absences.
+- Zeroed thresholds remain an explicit operator "no quarantine" and are
+  honoured, exactly as on the prune path - one knob, not two.
+- The hold-backs must be observable, not silent.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/workload_state.py` - `_owned_device_rows` also
+  returns the name->pk map; the sweep filters through
+  `partition_quarantined_orphans` and the shrink ceiling; two new summary
+  fields.
+- `forward_netbox/tests/test_workload_state.py` - the first-absence test now
+  asserts the new policy; two new tests pin the negative space.
+
+## Approach
+
+The sweep's absent identities are joined to their Device pks and filtered
+through `partition_quarantined_orphans` - the same machinery, thresholds and
+source parameters as the prune. On top, the prune's aggregate refusal: past
+`SCOPE_SHRINK_REFUSAL_FLOOR` devices and `SCOPE_SHRINK_REFUSAL_RATIO` of
+previously-managed, the sweep deletes NOTHING, because a query fault absents a
+fleet just as convincingly as a decommission absents one device and only the
+aggregate can tell them apart. Unattended, there is no operator to ask, so the
+answer is to delete nothing while the streaks keep advancing.
+
+Held rows are reported as `ownership_quarantine_held_rows` and
+`ownership_shrink_held_rows` in the durable-state summary.
+
+The absence streaks are maintained for every sync by the post-sync scope-tags
+job and lag this fetch by one run - the conservative direction.
+
+## Validation
+
+- `test_owned_device_absent_past_quarantine_is_deleted` - the intended
+  behaviour, now with evidence.
+- `test_owned_device_first_absence_is_held_by_the_quarantine` - the policy
+  change itself: one absence deletes nothing, fail-closed.
+- `test_a_mass_absence_is_a_fault_and_deletes_nothing` - every device past
+  quarantine individually, held in aggregate.
+- `test_current_scope_claim_protects_owned_device_from_delete` - updated to
+  clear the quarantine so the claim guard is what it exercises.
+- Full Django suite green (recorded in the release authorization when cut).
+
+## Rollback
+
+Revert. The sweep returns to first-absence deletion. Reverting cannot delete
+anything by itself - this change only ever removes rows from a delete set.
+
+## Decision Log
+
+- **Option B over A and C.** Keeps the intended behaviour at the operator
+  path's evidence bar; A strands devices, C duplicates the tag job.
+- **Reuse `partition_quarantined_orphans` verbatim** rather than a parallel
+  implementation: same thresholds, same source parameters, same fail-closed
+  semantics, one place to tune.
+- **Hold, don't raise, on the shrink ceiling.** The prune raises because an
+  operator is present to read the refusal. Unattended, an exception fails the
+  run; holding the deletes lets the rest of the sync proceed and the streaks
+  keep advancing, and the summary says what was held.
+- **Guard order: quarantine, then claims, then references.** Cheapest and most
+  conservative first. The claim test is pinned past the quarantine so it still
+  exercises the claim guard.
+
+## Open
+
+- The `netbox_dlm.softwareversion` catalogue sweep still enumerates the entire
+  table, including operator-created rows the sync never touched. Quarantine is
+  device-shaped and does not apply; the refused-delete guard (#273) makes its
+  failures honest. Scoping it to plugin-provenanced rows is its own question.
+- `DEPENDENCY_SKIP_ISSUE_DETAIL_LIMIT = 10` cap and the mislabelled
+  dependency-skip summary wording remain from the previous plan's Open list.

--- a/forward_netbox/tests/test_workload_state.py
+++ b/forward_netbox/tests/test_workload_state.py
@@ -733,7 +733,24 @@ class DurableWorkloadStateTest(TestCase):
         )
         self.assertEqual(by_summary["netbox_dlm.cve"]["protected_delete_rows"], 1)
 
-    def test_owned_device_absent_from_first_authoritative_state_is_deleted(self):
+    def _quarantine_cleared(self, device):
+        """An absence streak past both default thresholds (3 runs, 72 hours)."""
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from forward_netbox.models import ForwardDeviceAbsence
+
+        now = timezone.now()
+        ForwardDeviceAbsence.objects.create(
+            sync=self.sync,
+            device=device,
+            consecutive_absent_runs=3,
+            first_absent_at=now - timedelta(hours=73),
+            last_absent_at=now,
+        )
+
+    def test_owned_device_absent_past_quarantine_is_deleted(self):
         from dcim.models import Device
         from dcim.models import DeviceRole
         from dcim.models import DeviceType
@@ -766,6 +783,11 @@ class DurableWorkloadStateTest(TestCase):
             source_device_key=device.name,
             device=device,
         )
+        # The absence must have been CONFIRMED, repeatedly and over time, before
+        # the sweep may act on it - the same quarantine Prune orphans requires.
+        # This used to assert deletion on the first absence with no evidence at
+        # all, which is the policy the quarantine exists to forbid.
+        self._quarantine_cleared(device)
 
         workloads, _, summaries = apply_durable_workload_deltas(
             self.sync,
@@ -783,6 +805,130 @@ class DurableWorkloadStateTest(TestCase):
             [{"name": "stale-device", "site": "Owned Device Site"}],
         )
         self.assertEqual(summaries[0]["ownership_delete_rows"], 1)
+        self.assertEqual(summaries[0]["ownership_quarantine_held_rows"], 0)
+
+    def test_owned_device_first_absence_is_held_by_the_quarantine(self):
+        """The policy change itself: one absence is not evidence.
+
+        No absence row exists for this device, so the quarantine holds it
+        fail-closed - by its reckoning the absence has been confirmed zero
+        times. The device survives, no delete workload is produced, and the
+        summary says why.
+        """
+        from dcim.models import Device
+        from dcim.models import DeviceRole
+        from dcim.models import DeviceType
+        from dcim.models import Manufacturer
+        from dcim.models import Site
+
+        site = Site.objects.create(name="Fresh Absence Site", slug="fresh-absence")
+        manufacturer = Manufacturer.objects.create(
+            name="Fresh Absence Vendor", slug="fresh-absence-vendor"
+        )
+        device_type = DeviceType.objects.create(
+            manufacturer=manufacturer,
+            model="Fresh Absence Type",
+            slug="fresh-absence-type",
+        )
+        role = DeviceRole.objects.create(
+            name="Fresh Absence Role", slug="fresh-absence-role"
+        )
+        device = Device.objects.create(
+            name="fresh-absent-device",
+            site=site,
+            device_type=device_type,
+            role=role,
+            status="active",
+        )
+        ingestion = self._ingestion("snapshot-0")
+        ForwardDeviceIdentity.objects.create(
+            sync=self.sync,
+            ingestion=ingestion,
+            source_device_key=device.name,
+            device=device,
+        )
+
+        workloads, _, summaries = apply_durable_workload_deltas(
+            self.sync,
+            [
+                _workload(
+                    [],
+                    model_string="dcim.device",
+                    coalesce_fields=[["name", "site"]],
+                )
+            ],
+        )
+
+        self.assertEqual(workloads, [])
+        self.assertEqual(summaries[0]["ownership_delete_rows"], 0)
+        self.assertEqual(summaries[0]["ownership_quarantine_held_rows"], 1)
+        self.assertTrue(Device.objects.filter(pk=device.pk).exists())
+
+    def test_a_mass_absence_is_a_fault_and_deletes_nothing(self):
+        """Past the floor and the ratio, absence stops being attrition.
+
+        Every device here has individually cleared the quarantine - that is the
+        point. A query fault absents the whole fleet for three days just as
+        convincingly as a decommission absents one device, so the per-device
+        test cannot tell them apart and the aggregate one must.
+        """
+        from dcim.models import Device
+        from dcim.models import DeviceRole
+        from dcim.models import DeviceType
+        from dcim.models import Manufacturer
+        from dcim.models import Site
+
+        from forward_netbox.utilities.scope_reconciliation import (
+            SCOPE_SHRINK_REFUSAL_FLOOR,
+        )
+
+        site = Site.objects.create(name="Mass Absence Site", slug="mass-absence")
+        manufacturer = Manufacturer.objects.create(
+            name="Mass Absence Vendor", slug="mass-absence-vendor"
+        )
+        device_type = DeviceType.objects.create(
+            manufacturer=manufacturer,
+            model="Mass Absence Type",
+            slug="mass-absence-type",
+        )
+        role = DeviceRole.objects.create(
+            name="Mass Absence Role", slug="mass-absence-role"
+        )
+        ingestion = self._ingestion("snapshot-0")
+        count = SCOPE_SHRINK_REFUSAL_FLOOR + 1
+        for index in range(count):
+            device = Device.objects.create(
+                name=f"mass-absent-{index}",
+                site=site,
+                device_type=device_type,
+                role=role,
+                status="active",
+            )
+            ForwardDeviceIdentity.objects.create(
+                sync=self.sync,
+                ingestion=ingestion,
+                source_device_key=device.name,
+                device=device,
+            )
+            self._quarantine_cleared(device)
+
+        workloads, _, summaries = apply_durable_workload_deltas(
+            self.sync,
+            [
+                _workload(
+                    [],
+                    model_string="dcim.device",
+                    coalesce_fields=[["name", "site"]],
+                )
+            ],
+        )
+
+        self.assertEqual(workloads, [])
+        self.assertEqual(summaries[0]["ownership_delete_rows"], 0)
+        self.assertEqual(summaries[0]["ownership_shrink_held_rows"], count)
+        self.assertEqual(
+            Device.objects.filter(name__startswith="mass-absent-").count(), count
+        )
 
     def test_current_scope_claim_protects_owned_device_from_delete(self):
         from dcim.models import Device
@@ -827,6 +973,10 @@ class DurableWorkloadStateTest(TestCase):
             tag=Tag.objects.create(name="Managed", slug="managed"),
             claim_type=ForwardDeviceTagClaim.ClaimType.SCOPE,
         )
+        # Past the quarantine deliberately, so the CLAIM is what saves the
+        # device - which is what this test exists to pin. Without this the
+        # quarantine holds it first and the claim guard is never consulted.
+        self._quarantine_cleared(device)
 
         workloads, _, summaries = apply_durable_workload_deltas(
             self.sync,

--- a/forward_netbox/utilities/workload_state.py
+++ b/forward_netbox/utilities/workload_state.py
@@ -688,14 +688,21 @@ def _claimed_device_delete_identities(delete_entries):
 
 
 def _owned_device_rows(sync, coalesce_fields):
+    """Rows for every device identity this sync owns, plus name -> device pk.
+
+    The pk map exists for the quarantine join: absence streaks are recorded
+    against the Device row, while the sweep reasons in coalesce identities.
+    """
     from ..models import ForwardDeviceIdentity
 
     rows = []
+    device_id_by_name = {}
     identities = (
         ForwardDeviceIdentity.objects.filter(sync=sync)
         .order_by("source_device_key")
         .values(
             "source_device_key",
+            "device_id",
             "device__site__name",
             "device__site__slug",
         )
@@ -706,12 +713,13 @@ def _owned_device_rows(sync, coalesce_fields):
             "site": identity["device__site__name"],
             "site_slug": identity["device__site__slug"],
         }
+        device_id_by_name[identity["source_device_key"]] = identity["device_id"]
         for field_set in coalesce_fields:
             row = {field: values.get(field) for field in field_set}
             if all(value not in (None, "") for value in row.values()):
                 rows.append(row)
                 break
-    return rows
+    return rows, device_id_by_name
 
 
 def _software_version_catalog_rows():
@@ -850,21 +858,74 @@ def apply_durable_workload_deltas(sync, workloads):
         bootstrap_delete_identities = set()
         ownership_delete_identities = set()
         catalog_delete_identities = set()
+        ownership_quarantine_held = 0
+        ownership_shrink_held = 0
         if model_string == "dcim.device" and (current_state is None or compatible):
+            owned_rows, device_id_by_name = _owned_device_rows(sync, coalesce_fields)
             ownership_entries = build_state_entries(
                 model_string,
-                _owned_device_rows(sync, coalesce_fields),
+                owned_rows,
                 coalesce_fields,
             )
-            ownership_deletes = [
-                value["row"]
+            absent_entries = {
+                identity: value
                 for identity, value in ownership_entries.items()
                 if identity not in target_entries
+            }
+            # Absence from one result is not evidence. Deleting a device is the
+            # one act in this function an operator cannot undo, and the operator
+            # path - Prune orphans - already refuses to do it on a single
+            # observation: it requires the absence QUARANTINE (consecutive
+            # absent runs AND elapsed hours, both operator-tunable, fail-closed
+            # for a device with no absence record), because a device disabled in
+            # Forward is indistinguishable from one that was deleted. This sweep
+            # deleted on the first absence, gated only by ownership claims - and
+            # the scope claim is released by the same first observation, so the
+            # gate evaporated exactly one run before the delete fired.
+            #
+            # Same act, same evidence bar: the sweep now deletes only identities
+            # whose absence streak has cleared the same quarantine the prune
+            # uses. The streaks are maintained for every sync by the post-sync
+            # scope-tags job, and they lag this fetch by one run, which errs in
+            # the only acceptable direction - later, never sooner.
+            absent_ids = {
+                device_id_by_name.get(str(value["row"].get("name") or "").strip())
+                for value in absent_entries.values()
+            } - {None}
+            from .scope_reconciliation import partition_quarantined_orphans
+
+            partition = partition_quarantined_orphans(sync, sorted(absent_ids))
+            eligible_ids = set(partition["eligible_pks"])
+            ownership_quarantine_held = len(absent_ids) - len(eligible_ids)
+            # And the prune's other refusal, for the same reason it has one: a
+            # query that returns most of the fleet passes every per-device test,
+            # and every device missing from it then looks individually
+            # deletable. A shrink past the ratio is treated as a scope or query
+            # fault, not as attrition - unattended, there is no operator to ask,
+            # so the answer is to delete nothing and let the streaks keep
+            # advancing until someone looks.
+            from .scope_reconciliation import SCOPE_SHRINK_REFUSAL_FLOOR
+            from .scope_reconciliation import SCOPE_SHRINK_REFUSAL_RATIO
+
+            previously_managed = len(ownership_entries)
+            if (
+                previously_managed
+                and len(eligible_ids) > SCOPE_SHRINK_REFUSAL_FLOOR
+                and len(eligible_ids) / previously_managed > SCOPE_SHRINK_REFUSAL_RATIO
+            ):
+                ownership_shrink_held = len(eligible_ids)
+                eligible_ids = set()
+            ownership_deletes = [
+                value["row"]
+                for identity, value in absent_entries.items()
+                if device_id_by_name.get(str(value["row"].get("name") or "").strip())
+                in eligible_ids
             ]
             ownership_delete_identities = {
                 identity
-                for identity in ownership_entries
-                if identity not in target_entries
+                for identity, value in absent_entries.items()
+                if device_id_by_name.get(str(value["row"].get("name") or "").strip())
+                in eligible_ids
             }
             explicit_deletes = _deduplicate_rows(
                 model_string,
@@ -1058,6 +1119,8 @@ def apply_durable_workload_deltas(sync, workloads):
                     for identity in catalog_delete_identities
                 ),
                 "protected_delete_rows": protected_delete_count,
+                "ownership_quarantine_held_rows": ownership_quarantine_held,
+                "ownership_shrink_held_rows": ownership_shrink_held,
                 "unrepresented_peer": unrepresented_peer,
                 "tombstone_rows": sum(
                     value["action"] == "delete" for value in state_entries.values()


### PR DESCRIPTION
Companion to #273, closing the deeper hole it left open.

## The asymmetry

The same act — delete a device because it is absent from Forward's result — existed at two standards:

| | Prune orphans (operator) | Ownership sweep (unattended) |
|---|---|---|
| Absence quarantine (≥3 runs AND ≥72h, fail-closed) | ✅ | ❌ deleted on **first** absence |
| 25% shrink refusal | ✅ | ❌ |
| Confirm dialog | ✅ | n/a |
| Gate | quarantine | ownership claims — **released by the same first observation of absence** |

The quarantine model's own docstring states the principle the sweep violated: *disabled in Forward is indistinguishable from deleted, so deleting on first absence destroys devices that are merely in a maintenance window.* The sequence — disabled → claim released on run 1 → deleted on run 2 — is the long-standing "disabled in Forward deletes from NetBox" mechanism. A deployment's ten devices survived it only because `bgppeer` PROTECT references held them; a device with no protecting child was removed **silently**, since a successful delete files no ingestion issue.

## The fix

The sweep filters its absent identities through `partition_quarantined_orphans` — same machinery, same thresholds, same source parameters as the prune, fail-closed for a device with no absence record — and applies the prune's aggregate refusal on top: past `SCOPE_SHRINK_REFUSAL_FLOOR` and `SCOPE_SHRINK_REFUSAL_RATIO`, it deletes **nothing**, because a query fault absents a fleet just as convincingly as a decommission absents one device and only the aggregate can tell them apart. Unattended, there is no operator to ask, so the answer is hold and let the streaks keep advancing.

Held rows are reported (`ownership_quarantine_held_rows`, `ownership_shrink_held_rows`) so "did nothing" and "was held" are distinguishable — the property whose absence kept this invisible.

A device absent from Forward now has to earn deletion through four independent guards: quarantine (maintenance windows), shrink ceiling (tag edits / collection faults), ownership claims (multi-sync), and #273's collector check (everything the schema knows). The streaks are maintained for every sync by the post-sync scope-tags job and lag the fetch by one run — the conservative direction.

## Deliberate behaviour change

`test_owned_device_absent_from_first_authoritative_state_is_deleted` asserted deletion on first absence with zero evidence — exactly what the quarantine forbids. It is now `test_owned_device_absent_past_quarantine_is_deleted`. Two new tests pin the negative space (one absence deletes nothing; a mass absence past quarantine deletes nothing), and the claim test is pinned past the quarantine so it still exercises the guard it names.

Options considered: removing the sweep (strands devices a narrowed scope legitimately dropped) and demoting it to tagging (duplicates the tag job). Rejected in the plan's Decision Log.

## Evidence

- Full Django suite: **2288 tests OK** (4 skipped)
- `test_workload_state`: 35 OK · `scripts/tests`: 334 OK · `check_harness` passed · `pre-commit --all-files` passed

Plan: `docs/03_Plans/active/2026-08-21-ownership-sweep-quarantine.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkHV4nyhyrmRH3kmTSBf26