### PR TITLE
release: prepare 2.8.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Generated from the README compatibility table by `scripts/gen_changelog.py`. Do not edit by hand.
 
+## v2.8.9
+
+Release candidate; Fix: a sync deletes a device only on the same quarantined evidence the operator prune requires, and never stages a delete the database will refuse.
+
 ## v2.8.8
 
 Fix: the dependency preview runs again on deployments with optional plugins installed.

--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ See the
 
 ## Release Compatibility
 
-The `2.8.8` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
+The `2.8.9` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
+| `v2.8.9` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Fix: a sync deletes a device only on the same quarantined evidence the operator prune requires, and never stages a delete the database will refuse. |
 | `v2.8.8` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Fix: the dependency preview runs again on deployments with optional plugins installed. |
 | `v2.8.7` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.8`; Drift preview compares converged rows in bulk instead of per row; drift rows identify their workload. |
 | `v2.8.6` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.7`; Fix: a failed sync records where it happened, readable in NetBox without a shell. |

--- a/docs/01_User_Guide/README.md
+++ b/docs/01_User_Guide/README.md
@@ -70,13 +70,14 @@ migrations, e.g. netbox-dlm `0.2.0+`; older builds need
 
 ## Release Compatibility
 
-The `2.8.8` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
+The `2.8.9` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
+| `v2.8.9` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Fix: a sync deletes a device only on the same quarantined evidence the operator prune requires, and never stages a delete the database will refuse. |
 | `v2.8.8` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Fix: the dependency preview runs again on deployments with optional plugins installed. |
 | `v2.8.7` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.8`; Drift preview compares converged rows in bulk instead of per row; drift rows identify their workload. |
 | `v2.8.6` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.7`; Fix: a failed sync records where it happened, readable in NetBox without a shell. |

--- a/docs/03_Plans/active/2026-08-21-release-2.8.9.md
+++ b/docs/03_Plans/active/2026-08-21-release-2.8.9.md
@@ -1,0 +1,91 @@
+# Release 2.8.9
+
+## Goal
+
+Ship the two delete-path fixes: a sync deletes a device only on the same
+quarantined evidence the operator prune requires, and never stages a delete the
+database will refuse.
+
+## Why
+
+A deployment's 2.8.8 sync reported sixteen protected-delete skips - ten
+`dcim.device` held by `netbox_routing.bgppeer`, six `netbox_dlm.softwareversion`
+held by `netbox_dlm.inventoryitemsoftware`. Nothing was lost, and tracing why
+they existed at all uncovered two defects older than the report.
+
+Staged-but-impossible deletes were recorded as done: the durable state
+tombstones a staged delete, so the row stays in NetBox, the plugin believes it
+is gone, nothing retries, and the report goes quiet while the two systems
+disagree (`#273`).
+
+And the unattended ownership sweep deleted devices on the FIRST absence from a
+Forward result, gated only by ownership claims - which are released by the same
+first observation of absence. That is the "disabled in Forward deletes from
+NetBox" mechanism, and the deployment's ten devices survived it only because
+PROTECT references held them; an unprotected device was removed silently
+(`#274`).
+
+## Constraints
+
+- A patch. No migration, and nothing gains an operator control - the quarantine
+  thresholds are the prune's existing source parameters.
+- Both changes only ever REMOVE rows from a delete set; neither can delete
+  anything the previous release would not have.
+- `max_version` stays `4.6.99`, unchanged and for the same measured reason.
+
+## Touched Surfaces
+
+Landed across two pull requests:
+
+- `#273` never stage a delete the database will refuse
+- `#274` the unattended device sweep requires the same evidence as the prune
+
+This commit adds the version surfaces, the compatibility tables, and this plan.
+
+## Approach
+
+`#273`: the delete guards ask Django's `Collector.collect` - the code
+`.delete()` itself runs - rather than hand-written relation lists, ignoring only
+references the delete path itself clears; unreadable verdicts fail closed.
+The relation-list alternative was measured wrong: `protecting_relations(Device)`
+does not name `BGPPeer`, because the link is generic and the protection appears
+only down the cascade.
+
+`#274`: the ownership sweep filters its absent identities through
+`partition_quarantined_orphans` - the prune's own machinery, thresholds and
+source parameters, fail-closed - and applies the prune's aggregate shrink
+refusal on top, holding everything when the absence looks like a query fault
+rather than attrition. Held rows are reported in the durable-state summary.
+
+## Validation
+
+Recorded in the Release Authorization section below, bound to the evidence base
+commit: the full isolated gate and the exact-runtime artifact test, both on the
+final tree, both on NetBox 4.6.8.
+
+## Rollback
+
+No migration, so a downgrade is an install of the prior wheel. Reverting
+restores first-absence deletion and falsely-tombstoned refused deletes - the
+defects, not a safety - so the safe direction is forward.
+
+## Decision Log
+
+- **Two PRs, one release.** The refused-delete guard stands alone; the
+  quarantine gate is the policy decision. Landed separately so each carries its
+  own reasoning, shipped together because they close one hole.
+- **Option B for the sweep** (quarantine, not removal or tagging) - the
+  alternatives strand devices or duplicate the tag job; full reasoning in the
+  two change plans.
+- **Patch, not minor.** Nothing gains an operator control.
+
+## Open
+
+- The `netbox_dlm.softwareversion` catalogue sweep still enumerates the entire
+  table, operator-created rows included. Its refused deletes are now honest;
+  scoping it to plugin-provenanced rows is its own question.
+- `DEPENDENCY_SKIP_ISSUE_DETAIL_LIMIT = 10` means a report of exactly ten skips
+  may be the cap; the dependency-skip summary wording describes the opposite of
+  a protected-delete skip. Both minor, both recorded.
+- The deployment that surfaced this should see its 16 skips drop to zero once
+  its absent devices either return to Forward or age through the quarantine.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,13 +8,14 @@ Forward 26.6 is the baseline for async NQE.
 
 ## Release Compatibility
 
-The `2.8.8` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
+The `2.8.9` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
+| `v2.8.9` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Fix: a sync deletes a device only on the same quarantined evidence the operator prune requires, and never stages a delete the database will refuse. |
 | `v2.8.8` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Fix: the dependency preview runs again on deployments with optional plugins installed. |
 | `v2.8.7` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.8`; Drift preview compares converged rows in bulk instead of per row; drift rows identify their workload. |
 | `v2.8.6` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.7`; Fix: a failed sync records where it happened, readable in NetBox without a shell. |

--- a/forward_netbox/__init__.py
+++ b/forward_netbox/__init__.py
@@ -5,7 +5,7 @@ class NetboxForwardConfig(PluginConfig):
     name = "forward_netbox"
     verbose_name = "Forward"
     description = "Sync Forward data into NetBox using built-in NQE queries."
-    version = "2.8.8"
+    version = "2.8.9"
     base_url = "forward"
     min_version = "4.6.5"
     max_version = "4.6.99"

--- a/forward_netbox/tests/test_runtime_dependency_check.py
+++ b/forward_netbox/tests/test_runtime_dependency_check.py
@@ -23,7 +23,7 @@ class RuntimeDependencyCheckTest(SimpleTestCase):
         self.assertIsNotNone(_resolved_branching_version())
 
     def test_plugin_config_version_matches_package_release(self):
-        self.assertEqual(NetboxForwardConfig.version, "2.8.8")
+        self.assertEqual(NetboxForwardConfig.version, "2.8.9")
 
     def test_exact_runtime_passes(self):
         _check_runtime_dependencies()

--- a/forward_netbox/utilities/fast_baseline.py
+++ b/forward_netbox/utilities/fast_baseline.py
@@ -200,7 +200,7 @@ def _runtime_decision():
     expected = {
         "netbox_series": "4.6",
         "branching_series": "1.1",
-        "forward_netbox": "2.8.8",
+        "forward_netbox": "2.8.9",
         # Each optional distribution lists every version validated against this
         # engine, not a single pin. An exact pin meant a customer upgrading one
         # optional plugin silently lost the fast baseline — no error, just a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "forward-netbox"
-version = "2.8.8"
+version = "2.8.9"
 description = "NetBox plugin to sync Forward data into NetBox via built-in NQE queries"
 authors = ["Craig Johnson <craigjohnson@forwardnetworks.com>"]
 license = "MIT"


### PR DESCRIPTION
Version surfaces, compatibility tables, and the release plan for 2.8.9. Production changes landed in #273 and #274 — the two delete-path fixes: never stage a delete the database will refuse, and the unattended device sweep requires the operator prune's quarantined evidence.

Tables carry 2.8.9 as a **release candidate**; promotion happens in the post-release anchor commit.

## Gate results, on this exact tree

**Full isolated gate** — `GATE_EXIT=0`, self-written:
- 334 harness tests OK · 70 scenario tests OK · **2288 Django tests OK** (4 skipped) · 1 UI test OK
- Upgrade leg: 2.8.8 on NetBox v4.6.5 → 2.8.9 on NetBox v4.6.8, migrated, seeded rows survived

**Exact-runtime artifact test** — `ART_EXIT=0` against the installed `forward_netbox-2.8.9-py3-none-any.whl` on NetBox 4.6.8 / Branching 1.1.2 / Python 3.14: 7 authenticated menu routes at 200, migrations clean, validated SBOM of 156 components.

`FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1` recorded; the gate applies the superset feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkHV4nyhyrmRH3kmTSBf26