### PR TITLE
release: authorize 2.8.9

### DIFF
--- a/docs/03_Plans/active/2026-08-21-release-2.8.9.md
+++ b/docs/03_Plans/active/2026-08-21-release-2.8.9.md
@@ -89,3 +89,33 @@ defects, not a safety - so the safe direction is forward.
   a protected-delete skip. Both minor, both recorded.
 - The deployment that surfaced this should see its 16 skips drop to zero once
   its absent devices either return to Forward or age through the quarantine.
+
+## Release Authorization
+
+- Evidence base commit: `7bc81bb796dd7cfda7fac97e4b87ab84e3c34b8b`
+
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.8.8 invoke ci` passed on the final 2.8.9 tree with exit status 0: 334 harness tests OK, 70 scenario tests OK, 2288 Django tests OK with 4 skipped, and 1 UI test OK. The upgrade leg seeded under 2.8.8 on NetBox v4.6.5 and upgraded 2.8.8 -> 2.8.9 on NetBox v4.6.8, with the rows seeded under the previous release surviving.
+
+  The gated tree is the release tree apart from this authorization record, which
+  is Markdown in a single plan file and is appended after the gate by
+  construction.
+
+  The 2288 Django total is 2286 plus the two policy tests added by `#274`
+  (net of the one renamed first-absence test whose assertion deliberately
+  changed).
+
+  The exit status is the one the gate command wrote itself. A FIRST invocation
+  of this gate was killed alongside its tool wrapper minutes in; nothing from
+  it is attested. The attested run was launched under `setsid` in its own
+  session and wrote `GATE_EXIT=0`.
+
+  `FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1` records that the release-time
+  feed is not on this host; the preflight prints that line as `unverified`.
+  `check_sensitive_content.py --git-files --protected-history` passes over
+  tracked content and protected history against the widened local feed.
+
+- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke artifact-test` passed with exit status 0 against the installed `forward_netbox-2.8.9-py3-none-any.whl` on NetBox 4.6.8, Branching 1.1.2, Python 3.14, with 7 authenticated menu routes returning 200, all plugin migrations applying cleanly with no drift, and a validated SBOM of 156 components.
+
+The optional evidence ids are not recorded. The release owner's 2026-07-27
+proportionality decision applies; see
+`docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md`.


### PR DESCRIPTION
Records the two gate results on the final tree, bound to prepare commit `7bc81bb` as the evidence base. Changes only the release plan. `check_release_authorization.py --version 2.8.9` passes with both evidence ids.

Full gate: 334/70/2288(4 skipped)/1, upgrade 2.8.8→2.8.9 on v4.6.5→v4.6.8. Artifact: wheel on 4.6.8/1.1.2/py3.14, 7 routes 200, SBOM 156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkHV4nyhyrmRH3kmTSBf26