### PR TITLE
chore: advance the release provenance anchor to 2.8.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git fetch --no-tags origin main:refs/remotes/origin/main
-          git fetch --force origin refs/tags/v2.8.8:refs/tags/v2.8.8
+          git fetch --force origin refs/tags/v2.8.9:refs/tags/v2.8.9
           set -o pipefail
           for attempt in $(seq 1 120); do
             provenance_log="$(mktemp)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Generated from the README compatibility table by `scripts/gen_changelog.py`. Do 
 
 ## v2.8.9
 
-Release candidate; Fix: a sync deletes a device only on the same quarantined evidence the operator prune requires, and never stages a delete the database will refuse.
+Fix: a sync deletes a device only on the same quarantined evidence the operator prune requires, and never stages a delete the database will refuse.
 
 ## v2.8.8
 

--- a/README.md
+++ b/README.md
@@ -64,15 +64,15 @@ See the
 
 ## Release Compatibility
 
-The `2.8.9` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
+The `2.8.9` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.8.9` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Fix: a sync deletes a device only on the same quarantined evidence the operator prune requires, and never stages a delete the database will refuse. |
-| `v2.8.8` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Fix: the dependency preview runs again on deployments with optional plugins installed. |
+| `v2.8.9` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Fix: a sync deletes a device only on the same quarantined evidence the operator prune requires, and never stages a delete the database will refuse. |
+| `v2.8.8` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.9`; Fix: the dependency preview runs again on deployments with optional plugins installed. |
 | `v2.8.7` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.8`; Drift preview compares converged rows in bulk instead of per row; drift rows identify their workload. |
 | `v2.8.6` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.7`; Fix: a failed sync records where it happened, readable in NetBox without a shell. |
 | `v2.8.5` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.6`; Fix: a failed sync names what failed, and a redacted warning is no longer reported as a failure. |

--- a/docs/01_User_Guide/README.md
+++ b/docs/01_User_Guide/README.md
@@ -70,15 +70,15 @@ migrations, e.g. netbox-dlm `0.2.0+`; older builds need
 
 ## Release Compatibility
 
-The `2.8.9` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
+The `2.8.9` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.8.9` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Fix: a sync deletes a device only on the same quarantined evidence the operator prune requires, and never stages a delete the database will refuse. |
-| `v2.8.8` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Fix: the dependency preview runs again on deployments with optional plugins installed. |
+| `v2.8.9` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Fix: a sync deletes a device only on the same quarantined evidence the operator prune requires, and never stages a delete the database will refuse. |
+| `v2.8.8` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.9`; Fix: the dependency preview runs again on deployments with optional plugins installed. |
 | `v2.8.7` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.8`; Drift preview compares converged rows in bulk instead of per row; drift rows identify their workload. |
 | `v2.8.6` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.7`; Fix: a failed sync records where it happened, readable in NetBox without a shell. |
 | `v2.8.5` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.6`; Fix: a failed sync names what failed, and a redacted warning is no longer reported as a failure. |

--- a/docs/03_Plans/active/2026-08-21-anchor-2.8.9.md
+++ b/docs/03_Plans/active/2026-08-21-anchor-2.8.9.md
@@ -1,0 +1,54 @@
+# Advance the release provenance anchor to 2.8.9
+
+## Goal
+
+Move the provenance anchor onto the shipped 2.8.9 release and promote it to
+current in the compatibility tables.
+
+## Why
+
+The anchor names the previous release and the documentation-only bridge commit
+that must directly follow its tag; until it advances, `check_harness.py` fails
+by construction, which is the check working.
+
+v2.8.9 published: the tag peels to `58242a030250c0cde10365f3bbb1b32cf9258cd1`,
+the release workflow succeeded, and PyPI and GitHub carry byte-identical
+artifacts (wheel `6464ae9e0fcf225f…`, sdist `0970f992f4e34ffe…`), verified by
+downloading the GitHub assets and hashing them.
+
+## Constraints
+
+- The bridge must be the first commit after the tag on the first-parent lineage
+  and documentation-only. `1f69b97` is one file, no code.
+- The table promotion belongs here, not on the release branch.
+
+## Touched Surfaces
+
+- `scripts/verify_release_provenance.py`, `scripts/check_harness.py`,
+  `scripts/tests/test_tasks.py`, `.github/workflows/release.yml`
+- `README.md`, `docs/README.md`, `docs/01_User_Guide/README.md`, `CHANGELOG.md`
+
+## Approach
+
+Anchor to `v2.8.9` / bridge `1f69b97903e5423e0f70ebbbcdd11127f106ba86`; promote
+2.8.9 to current, demote 2.8.8 to superseded.
+
+## Validation
+
+`check_harness.py` passes with the anchor advanced; `scripts/tests` passes;
+`verify_release_provenance.py --controls-only` passes against live GitHub.
+
+## Rollback
+
+Revert; the harness fails again, which blocks the next release rather than
+permitting an unverified one — the safe direction.
+
+## Decision Log
+
+- Promotion folded into the anchor commit, as for 2.8.6-2.8.8.
+
+## Open
+
+- The deployment that surfaced the delete-path defects should see its 16
+  recurring skips fall to zero on 2.8.9: held rows are now reported as
+  `ownership_quarantine_held_rows` rather than staged and refused.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,15 +8,15 @@ Forward 26.6 is the baseline for async NQE.
 
 ## Release Compatibility
 
-The `2.8.9` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
+The `2.8.9` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
-| `v2.8.9` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Fix: a sync deletes a device only on the same quarantined evidence the operator prune requires, and never stages a delete the database will refuse. |
-| `v2.8.8` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Fix: the dependency preview runs again on deployments with optional plugins installed. |
+| `v2.8.9` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Fix: a sync deletes a device only on the same quarantined evidence the operator prune requires, and never stages a delete the database will refuse. |
+| `v2.8.8` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.9`; Fix: the dependency preview runs again on deployments with optional plugins installed. |
 | `v2.8.7` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.8`; Drift preview compares converged rows in bulk instead of per row; drift rows identify their workload. |
 | `v2.8.6` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.7`; Fix: a failed sync records where it happened, readable in NetBox without a shell. |
 | `v2.8.5` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.6`; Fix: a failed sync names what failed, and a redacted warning is no longer reported as a failure. |

--- a/scripts/check_harness.py
+++ b/scripts/check_harness.py
@@ -197,7 +197,7 @@ REQUIRED_TEXT = {
     ],
     ".github/workflows/release.yml": [
         "fetch-depth: 0",
-        "refs/tags/v2.8.8",
+        "refs/tags/v2.8.9",
         "verify_release_provenance.py",
         "--git-files",
         "--protected-history",

--- a/scripts/tests/test_tasks.py
+++ b/scripts/tests/test_tasks.py
@@ -175,7 +175,7 @@ class ReleaseArtifactTaskTest(unittest.TestCase):
 
         self.assertIn("--require-hashes", workflow)
         self.assertIn("requirements-release.txt", workflow)
-        self.assertIn("refs/tags/v2.8.8", workflow)
+        self.assertIn("refs/tags/v2.8.9", workflow)
         self.assertIn("scripts/build_reproducible_distribution.py", workflow)
         self.assertIn("python -m invoke artifact-test", workflow)
         self.assertIn("sbom/", workflow)

--- a/scripts/verify_release_provenance.py
+++ b/scripts/verify_release_provenance.py
@@ -29,8 +29,8 @@ GITHUB_API_URL = "https://api.github.com"
 #         from two commits, so their provenance could not be verified.
 UNPUBLISHED_RELEASE_TAGS = ("v2.7.3", "v2.7.7", "v2.7.8", "v2.7.10")
 
-PRIOR_RELEASE_TAG = "v2.8.8"
-PRIOR_POST_RELEASE_DOC_COMMIT = "82f04d6c4a932dc5eb484bfa8ef7010791a4d12a"
+PRIOR_RELEASE_TAG = "v2.8.9"
+PRIOR_POST_RELEASE_DOC_COMMIT = "1f69b97903e5423e0f70ebbbcdd11127f106ba86"
 
 # Content a specific bridge commit is excused for carrying, keyed by commit hash.
 #


### PR DESCRIPTION
Anchors provenance to v2.8.9 / bridge `1f69b97`, promotes 2.8.9 to current release. Tag peels to `58242a0`; PyPI and GitHub artifacts verified byte-identical by download+hash. Verified here: check_harness passed, scripts/tests 334 OK, pre-commit passed, provenance --controls-only passed against live GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkHV4nyhyrmRH3kmTSBf26