### PR TITLE
fix: write each config-backup blob as produced, not accumulated

### DIFF
--- a/docs/03_Plans/active/2026-08-21-config-backup-to-git.md
+++ b/docs/03_Plans/active/2026-08-21-config-backup-to-git.md
@@ -165,6 +165,8 @@ repository is the operator's and is untouched by a rollback.
   (An earlier draft of this plan estimated that population at ~900 by
   subtracting a figure from one deployment from a count taken on another; the
   number was not measured and has been removed rather than repeated.)
-- The 20 MB outlier config is one NQE row; page size 100 keeps worst-case page
-  memory ~2 GB only if 100 such outliers cluster, which the probe says they do
-  not (one device >20 MB). A per-page byte budget is noted as hardening.
+- The 20 MB outlier config is one NQE row; page size bounds fetch memory only,
+  not retention. **Measured and fixed in
+  `2026-08-22-config-backup-scale-test.md`**: at 3,400 devices / 1.9 GB, peak
+  RSS grew 4.2 GB because every changed blob was held in a list instead of
+  written as produced; fixed to a 2.4 GB delta on the identical run.

--- a/docs/03_Plans/active/2026-08-22-config-backup-scale-test.md
+++ b/docs/03_Plans/active/2026-08-22-config-backup-scale-test.md
@@ -1,0 +1,98 @@
+# Config backup: scale-tested, and a real memory finding fixed
+
+## Goal
+
+Measure config backup against the fleet size it was designed for - 3,400
+devices, 2.4 GB - rather than the one-device fixtures every prior test used,
+and fix what that measurement found.
+
+## Why
+
+The original plan reasoned about memory from the NQE page size alone: "page
+size 100 keeps worst-case page memory ~2 GB only if 100 such outliers
+cluster, which the probe says they do not." That reasoning addresses FETCH
+memory. It says nothing about what happens to a row after it is fetched.
+
+Measured directly: 3,400 synthetic devices, ~1.9 GB of configs (sized to the
+probed distribution, one 20 MB outlier), pushed through the real code path to
+a real git server. Peak RSS grew by **4.2 GB** for a 1.9 GB payload - roughly
+2.2x, not the near-zero the page-size reasoning implied.
+
+The cause was `new_blobs`: every changed row's `Blob` was appended to a list
+and held for the entire fetch loop, then written to the object store in one
+pass afterward. On a first backup - or any run touching most of the fleet -
+that list holds the whole corpus at once, each entry costing the raw text
+plus dulwich's `Blob` wrapper and its zlib buffer. The page size bounds how
+much is IN FLIGHT from Forward at any moment; it does not bound how much is
+RETAINED after arrival, and retention is what dominated.
+
+## Constraints
+
+- No behaviour change to what gets written or what the result reports. This
+  is a memory-shape fix only.
+- The fix must not require holding fetched rows anywhere new; it removes a
+  retention, it does not relocate one.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/config_backup.py` - write each changed blob to
+  the object store as it is produced, inside the fetch loop, instead of
+  collecting a list and writing it afterward.
+- `forward_netbox/tests/test_config_backup.py` - a real page-boundary test
+  asserting write/fetch ORDER, not merely a count.
+
+## Approach
+
+`repo.object_store.add_object(blob)` moves from a post-loop batch to
+immediately after each blob is constructed. `DiskObjectStore.add_object`
+writes a loose object to disk per call; there was never a reason to defer it,
+only a reason (habit) not to.
+
+## Validation
+
+Re-ran the identical 3,400-device / 1.9 GB scenario after the fix: peak RSS
+delta fell from 4.2 GB to 2.4 GB (a 42% reduction), elapsed time unchanged at
+~53s, correctness identical (3,400 written, 0 unmapped, 0 warnings, push
+succeeded). The residual 2.4 GB is the `config_entries` tree map plus the test
+harness's own fake client holding all synthetic rows in memory at once - a
+worse-than-production artifact of the test, not of the code, since the real
+Forward client streams pages rather than pre-generating an entire fleet.
+
+The new unit test crosses a real page boundary (`CONFIG_BACKUP_PAGE_SIZE + 5`
+rows) and records fetches and writes on one shared timeline, asserting at
+least one write lands before the second fetch. A first version of this test
+asserted only the total count of `add_object` calls, which cannot distinguish
+"batched afterward" from "written as produced" - both call it once per row,
+merely at different times. Run as its own negative control against the
+reverted code: the count-only version passed against the bug it was meant to
+catch; the order-sensitive version correctly failed it (`timeline=['fetch',
+'fetch', 'write' * 105]`), then passed once the fix was restored.
+
+Full `test_config_backup` module: 13 tests OK.
+
+## Rollback
+
+Revert. The prior behaviour was correct, only more memory-hungry; nothing
+here is a data-safety fix.
+
+## Decision Log
+
+- **Write inline, not in two passes.** The two-pass shape (accumulate, then
+  flush) is a natural way to write this kind of loop and was never load-bearing
+  - nothing downstream needs the blobs as a list, only the tree needs their
+  SHAs, which `config_entries` already carries independently.
+- **Fixed the test rather than accepting a passing-but-blind one.** A test
+  that cannot fail against the defect it names is worse than no test: it
+  reads as coverage that is not there. The negative control that exposed this
+  is the same discipline as everywhere else in this codebase's test suite.
+
+## Open
+
+- The residual 2.4 GB includes the test harness's own row-holding, not
+  production behaviour; a genuinely production-shaped memory measurement
+  would need the real Forward client's streaming behaviour, which this
+  environment cannot exercise without a live network of that scale.
+- `config_entries` itself (all paths + SHAs for the whole tree) is retained
+  for the full run because a `Tree` must be built in one pass; this is a
+  much smaller structure than the blobs were (fixed-size dict entries versus
+  full config text) and was not identified as a concern by the measurement.

--- a/forward_netbox/tests/test_config_backup.py
+++ b/forward_netbox/tests/test_config_backup.py
@@ -332,6 +332,93 @@ class ConfigBackupTest(TestCase):
         with self.assertRaises(ForwardSyncError):
             self._run([{"name": "fwd-router-1", "config": "x\n"}])
 
+    def test_changed_blobs_are_written_as_produced_not_accumulated(self):
+        """Peak memory on a large fleet depends on this, not on page size.
+
+        Measured on 3,400 synthetic devices (~1.9 GB of configs): holding
+        every changed `Blob` in a list until the fetch loop finished cost 4.2
+        GB of peak RSS - the whole fleet's blobs plus dulwich's own overhead,
+        resident at once. Writing each blob to the object store as soon as
+        it is produced cut that to 2.4 GB on the identical run. The NQE page
+        size bounds fetch memory; it says nothing about this accumulation,
+        which dominates on any run touching most of the fleet - a first
+        backup being exactly that case.
+
+        A count of `add_object` calls cannot tell "batched afterward" from
+        "written as produced" - both call it once per row, just at different
+        times. This crosses a real page boundary and records fetches and
+        writes on one shared timeline: fixed, page one's writes land before
+        the second fetch; accumulated, every write lands after the last
+        fetch. An earlier version of this test asserted only the count and
+        passed against the accumulating code it exists to catch - the
+        negative control that should have failed it, did not.
+        """
+        from unittest.mock import patch
+
+        from dulwich.object_store import DiskObjectStore
+
+        # More devices than one page, mapped through this test's own sync so
+        # the boundary is guaranteed to fall mid-fleet.
+        site = Site.objects.create(name="Order Site", slug="order-site")
+        mfr = Manufacturer.objects.create(name="Order Mfr", slug="order-mfr")
+        dtype = DeviceType.objects.create(
+            manufacturer=mfr, model="Order DT", slug="order-dt"
+        )
+        role = DeviceRole.objects.create(name="Order Role", slug="order-role")
+        ingestion = ForwardIngestion.objects.create(
+            sync=self.sync, snapshot_id="snap-order"
+        )
+        count = CONFIG_BACKUP_PAGE_SIZE + 5
+        rows = []
+        for i in range(count):
+            device = Device.objects.create(
+                name=f"order-{i:03d}", site=site, device_type=dtype, role=role
+            )
+            ForwardDeviceIdentity.objects.create(
+                sync=self.sync,
+                ingestion=ingestion,
+                source_device_key=f"fwd-order-{i:03d}",
+                device=device,
+            )
+            rows.append(
+                {"name": f"fwd-order-{i:03d}", "config": f"hostname order-{i}\n"}
+            )
+
+        timeline = []
+        original_add_object = DiskObjectStore.add_object
+
+        def recording_add_object(self, obj):
+            if type(obj).__name__ == "Blob":
+                timeline.append("write")
+            return original_add_object(self, obj)
+
+        client = _FakeClient(rows)
+        original_fetch = client.run_nqe_query
+
+        def recording_fetch(**kwargs):
+            timeline.append("fetch")
+            return original_fetch(**kwargs)
+
+        client.run_nqe_query = recording_fetch
+        with patch.object(
+            ForwardSource, "get_client", return_value=client
+        ), patch.object(DiskObjectStore, "add_object", recording_add_object):
+            run_config_backup(self.sync, snapshot_id="snap-order")
+
+        self.assertEqual(
+            timeline.count("fetch"), 2, f"expected two pages, got {timeline}"
+        )
+        self.assertEqual(timeline.count("write"), count, "one write per changed row")
+        second_fetch_index = [i for i, e in enumerate(timeline) if e == "fetch"][1]
+        writes_before_second_fetch = timeline[:second_fetch_index].count("write")
+        self.assertGreater(
+            writes_before_second_fetch,
+            0,
+            "no write happened before the second page was fetched - every "
+            "blob was accumulated and written in one batch afterward, which "
+            f"is the regression this test exists to catch: timeline={timeline}",
+        )
+
 
 class ValidityReadsWhatWeWriteTest(TestCase):
     """The chain, end to end, through the consumer that motivated the feature.

--- a/forward_netbox/utilities/config_backup.py
+++ b/forward_netbox/utilities/config_backup.py
@@ -285,7 +285,6 @@ def run_config_backup(sync, *, snapshot_id, logger=None):
             else:
                 config_entries = {}
 
-            new_blobs = []
             offset = 0
             # Scope the FETCH, not just the write. The identity table is this
             # sync's device scope - the same tag scope every other query is
@@ -319,7 +318,18 @@ def run_config_backup(sync, *, snapshot_id, logger=None):
                     if existing is not None and existing[1] == blob.id:
                         result.unchanged += 1
                         continue
-                    new_blobs.append(blob)
+                    # Written immediately rather than accumulated. A held list
+                    # of every changed Blob for the run is fine at fixture
+                    # scale and is not fine at fleet scale: measured on 3,400
+                    # synthetic devices (~1.9 GB of configs), holding them all
+                    # until the fetch loop finished cost 4.2 GB of peak RSS -
+                    # roughly 2.2x the payload, because each Blob object and
+                    # its zlib buffer live alongside the raw text. The comment
+                    # that sized the NQE page at 100 rows reasoned about fetch
+                    # memory; it did not reason about this accumulation, which
+                    # dominates peak memory on any run that touches most of
+                    # the fleet - a first backup being exactly that case.
+                    repo.object_store.add_object(blob)
                     config_entries[entry_name] = (0o100644, blob.id)
                     result.written += 1
                 if len(rows) < CONFIG_BACKUP_PAGE_SIZE:
@@ -338,8 +348,6 @@ def run_config_backup(sync, *, snapshot_id, logger=None):
                 result.skipped_reason = "no configuration changed"
                 return result
 
-            for blob in new_blobs:
-                repo.object_store.add_object(blob)
             config_tree = Tree()
             for entry_name in sorted(config_entries):
                 mode, sha = config_entries[entry_name]


### PR DESCRIPTION
Found by the scale test that PR #279 deferred: 3,400 synthetic devices, ~1.9 GB of configs, through the real push path to a real git server.

## What the measurement found

The plan reasoned about memory from the NQE page size alone — paging bounds what's *in flight* from Forward. It says nothing about what happens to a row after it arrives.

**Peak RSS grew by 4.2 GB for a 1.9 GB payload** — roughly 2.2x. The cause: every changed row's `Blob` was appended to a list (`new_blobs`) and held for the *entire* fetch loop, written to the object store in one batch afterward. On a first backup — or any run touching most of the fleet — that's the whole corpus resident at once.

## The fix

Write each blob to the object store immediately after it's produced, inside the fetch loop, instead of batching. Re-measured on the identical scenario: **4.2 GB → 2.4 GB (42% reduction)**, correctness and elapsed time unchanged (~53s, 3,400 written, 0 unmapped, push succeeded). The residual 2.4 GB is the test harness's own fake client holding every synthetic row at once — worse than production, since the real Forward client streams pages.

## The regression test caught its own first draft being wrong

A version that counted `add_object` calls can't tell "batched afterward" from "written as produced" — both call it once per row, just at different times. Run as its own negative control against the reintroduced bug, **it passed**. Rewrote it to cross a real page boundary and record fetch/write order on a shared timeline: `timeline=['fetch', 'fetch', 'write' * 105]` against the bug, at least one write before the second fetch against the fix.

## Evidence

- **Full Django suite: 2311 tests OK** (4 skipped), clean exit
- `check_harness` passed · `pre-commit --all-files` passed
- Scale re-measurement described above, against a live local Forgejo server

Plan: `docs/03_Plans/active/2026-08-22-config-backup-scale-test.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkHV4nyhyrmRH3kmTSBf26