### PR TITLE
release: authorize 2.9.0

### DIFF
--- a/docs/03_Plans/active/2026-08-22-release-2.9.0.md
+++ b/docs/03_Plans/active/2026-08-22-release-2.9.0.md
@@ -155,3 +155,28 @@ effect.
 - This host's close-mode HTTP fault, worked around for the release verifier
   since 2.8.7, still affects every other caller and needs attention outside a
   release window.
+
+## Release Authorization
+
+- Evidence base commit: `428cf5b9b0ac6c9defcca8f6d37f8130ebe8ec22`
+
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 invoke ci` passed on the final 2.9.0 tree with exit status 0: 334 harness tests OK, 70 scenario tests OK, 2311 Django tests OK with 4 skipped, 1 bulk-merge-retry-scale test OK, and 1 UI test OK. The upgrade leg seeded under 2.8.9 on NetBox v4.6.5 and upgraded 2.8.9 -> 2.9.0 on NetBox v4.6.8, with the rows seeded under the previous release surviving.
+
+  The gated tree is the release tree apart from this authorization record, which
+  is Markdown in a single plan file and is appended after the gate by
+  construction.
+
+  This gate found and required five fixes before it passed clean on this exact
+  tree, all recorded above under Touched Surfaces: the paramiko
+  `PYSEC-2026-2858` advisory waiver, three `JobTimeoutException` re-raise
+  guards in `config_backup.py`, `netbox-validity` added to the Dockerfile's
+  optional-plugin install and to `validate_sbom.py`, and one yamllint fix.
+
+  `FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1` records that the release-time
+  feed is not on this host; the preflight prints that line as `unverified`.
+
+- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke artifact-test` passed with exit status 0 against the installed `forward_netbox-2.9.0-py3-none-any.whl` on NetBox 4.6.8, Branching 1.1.2, Python 3.14, with 7 authenticated menu routes returning 200, all plugin migrations applying cleanly with no drift, and a validated SBOM of 178 components.
+
+The optional evidence ids are not recorded. The release owner's 2026-07-27
+proportionality decision applies; see
+`docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md`.


### PR DESCRIPTION
## Summary

Records the two required gate results on the final 2.9.0 tree, bound to the
prepare commit `428cf5b9b0ac6c9defcca8f6d37f8130ebe8ec22` as the evidence base.

- `final-tree-full-gate`: `invoke ci` passed with exit status 0 - 334 harness
  tests OK, 70 scenario tests OK, 2311 Django tests OK with 4 skipped, 1
  bulk-merge-retry-scale test OK, 1 UI test OK, upgrade leg 2.8.9 -> 2.9.0
  passed.
- `exact-runtime-artifact`: `invoke artifact-test` passed with exit status 0
  against the built wheel on NetBox 4.6.8, Branching 1.1.2, Python 3.14 - 7
  authenticated menu routes returning 200, clean migrations, SBOM of 178
  components.

Both ran under the exact `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate ...`
environment this checker requires.

## Test plan

- [x] `python3 scripts/check_release_authorization.py --version 2.9.0` passes locally

Claude-Session: https://claude.ai/code/session_012Qfd3hTSxZtmFHuzRJnZre