### PR TITLE
fix: gate releases on open Dependabot alerts, not just constraints.txt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ permissions:
   actions: read
   contents: read
   pull-requests: read
+  security-events: read
   statuses: read
 jobs:
   validate:
@@ -103,6 +104,28 @@ jobs:
           from check_release_preflight import PreflightError
           try:
               print(check_dependency_advisories())
+          except PreflightError as exc:
+              print(f'::error::{exc}')
+              sys.exit(1)
+          "
+      - name: Check for open Dependabot alerts
+        # Same reasoning as the pip-audit step above: calls the preflight's own
+        # check so ACCEPTED_DEPENDABOT_ALERTS lives in exactly one place.
+        # `constraints.txt` is a small, hand-curated pin set - pip-audit
+        # auditing it never sees a transitive dependency's advisory (sqlparse,
+        # pulled in by Django with only a floor pin); Dependabot already scans
+        # the full dependency graph, so this asks it instead of re-deriving
+        # the closure.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python -c "
+          import sys
+          sys.path.insert(0, 'scripts')
+          from check_release_preflight import check_dependabot_alerts
+          from check_release_preflight import PreflightError
+          try:
+              print(check_dependabot_alerts())
           except PreflightError as exc:
               print(f'::error::{exc}')
               sys.exit(1)

--- a/scripts/check_release_preflight.py
+++ b/scripts/check_release_preflight.py
@@ -26,6 +26,8 @@ import sys
 import tomllib
 from pathlib import Path
 
+import verify_release_provenance as provenance
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 PYPROJECT = REPO_ROOT / "pyproject.toml"
@@ -204,6 +206,98 @@ def check_dependency_advisories() -> str:
     return "no known advisories in constraints.txt"
 
 
+# Dependabot alert ids (GHSA, not PYSEC - a different vocabulary from
+# `ACCEPTED_DEPENDENCY_ADVISORIES`, and the two lists do not overlap: paramiko
+# PYSEC-2026-2858 does not appear in this repo's Dependabot alerts at all, and
+# nothing here has yet needed a waiver) that are accepted rather than fixed.
+# Same rule as above: name why, here.
+ACCEPTED_DEPENDABOT_ALERTS: set[str] = set()
+
+_DEPENDABOT_BLOCKING_SEVERITIES = frozenset({"high", "critical"})
+
+
+def _dependabot_token() -> str:
+    token = os.environ.get("GH_TOKEN", "").strip()
+    if token:
+        return token
+    completed = subprocess.run(
+        ["gh", "auth", "token"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    token = completed.stdout.strip()
+    if completed.returncode != 0 or not token:
+        raise PreflightError(
+            "no GitHub token available (GH_TOKEN is unset and `gh auth token` "
+            "failed), so open Dependabot alerts cannot be checked before the "
+            "gate. Dependabot already scans the full dependency graph pip-audit "
+            "cannot see through constraints.txt alone - see the sqlparse "
+            "alerts caught after v2.9.0 shipped, which pip-audit never saw "
+            "because constraints.txt does not pin it."
+        )
+    return token
+
+
+def check_dependabot_alerts() -> str:
+    """No open high-or-critical Dependabot alert may be unaccepted.
+
+    `check_dependency_advisories` only audits `constraints.txt` - a small,
+    hand-curated pin set for packages this project pins deliberately
+    (cryptography, httpx, the optional NetBox plugins). It was never the full
+    dependency closure, so a transitive dependency's advisory (sqlparse,
+    pulled in by Django with only a floor pin) passed every local and CI
+    `pip-audit` run while GitHub's own Dependabot scan - which reads the whole
+    `poetry.lock` - already had it open. Nothing in the release process looked
+    at Dependabot before this. This closes that gap the same way the pip-audit
+    check closes its own: fail closed, before the forty-minute gate, not after
+    the tag.
+    """
+    try:
+        token = _dependabot_token()
+        # `dependabot/alerts` paginates by cursor (`Link` header), not the
+        # `page=N` query parameter every other endpoint `_github_pages` calls
+        # uses - it rejects `page` outright. A single 100-alert page is a
+        # deliberate, named limit rather than real pagination: this is a
+        # single plugin repository, nowhere near 100 open alerts, and cursor
+        # pagination would mean exposing response headers through
+        # `_github_json`, which nothing else needs.
+        alerts = provenance._github_json(
+            "dependabot/alerts?state=open&per_page=100", token
+        )
+        if not isinstance(alerts, list):
+            raise PreflightError("GitHub returned invalid Dependabot alert data")
+        if len(alerts) >= 100:
+            raise PreflightError(
+                "100+ open Dependabot alerts - this check only reads the first "
+                "page; extend it to follow the Link header before trusting it"
+            )
+    except provenance.ProvenanceError as exc:
+        raise PreflightError(f"could not read Dependabot alerts: {exc}")
+    unaccepted = [
+        alert
+        for alert in alerts
+        if alert.get("security_advisory", {}).get("severity")
+        in _DEPENDABOT_BLOCKING_SEVERITIES
+        and alert.get("security_advisory", {}).get("ghsa_id")
+        not in ACCEPTED_DEPENDABOT_ALERTS
+    ]
+    if unaccepted:
+        detail = "; ".join(
+            f"{alert.get('dependency', {}).get('package', {}).get('name')} "
+            f"({alert.get('security_advisory', {}).get('severity')}, "
+            f"{alert.get('security_advisory', {}).get('ghsa_id')})"
+            for alert in unaccepted
+        )
+        raise PreflightError(f"open Dependabot alerts are not accepted: {detail}")
+    if ACCEPTED_DEPENDABOT_ALERTS:
+        return (
+            "no unaccepted high/critical Dependabot alerts (ignoring: "
+            f"{', '.join(sorted(ACCEPTED_DEPENDABOT_ALERTS))})"
+        )
+    return "no open high/critical Dependabot alerts"
+
+
 def _git(*arguments: str) -> str:
     import subprocess
 
@@ -364,11 +458,14 @@ def _outcome(detail: str) -> str:
     return "skipped" if "skipped" in detail else "passed"
 
 
-def _report_lines(version, dependencies, advisories, evidence_base, pattern_parity):
+def _report_lines(
+    version, dependencies, advisories, dependabot_alerts, evidence_base, pattern_parity
+):
     checks = (
         (f"version {version} consistent across surfaces", "passed"),
         (f"UI harness dependencies present ({dependencies})", "passed"),
         (advisories, _outcome(advisories)),
+        (dependabot_alerts, _outcome(dependabot_alerts)),
         (f"evidence base commit {evidence_base}", _outcome(evidence_base)),
         (f"sensitive pattern parity {pattern_parity}", _outcome(pattern_parity)),
     )
@@ -391,6 +488,7 @@ def main() -> int:
         version = check_version_surfaces()
         dependencies = check_ui_harness_dependencies()
         advisories = check_dependency_advisories()
+        dependabot_alerts = check_dependabot_alerts()
         evidence_base = check_release_plan_evidence_base(version)
         pattern_parity = check_sensitive_pattern_parity()
     except PreflightError as exc:
@@ -401,6 +499,7 @@ def main() -> int:
         "version": version,
         "ui_harness_dependencies": dependencies,
         "dependency_advisories": advisories,
+        "dependabot_alerts": dependabot_alerts,
         "evidence_base_commit": evidence_base,
         "sensitive_pattern_parity": pattern_parity,
     }
@@ -408,7 +507,12 @@ def main() -> int:
         print(json.dumps(result, sort_keys=True))
     else:
         for line in _report_lines(
-            version, dependencies, advisories, evidence_base, pattern_parity
+            version,
+            dependencies,
+            advisories,
+            dependabot_alerts,
+            evidence_base,
+            pattern_parity,
         ):
             print(line)
     return 0

--- a/scripts/tests/test_release_preflight.py
+++ b/scripts/tests/test_release_preflight.py
@@ -297,3 +297,73 @@ class SensitivePatternParityTest(unittest.TestCase):
         arguments = run.call_args.args[0]
         self.assertIn("--require-env-patterns", arguments)
         self.assertIn("--protected-history", arguments)
+
+
+def _dependabot_alert(*, ghsa, severity, package="sqlparse"):
+    return {
+        "security_advisory": {"ghsa_id": ghsa, "severity": severity},
+        "dependency": {"package": {"name": package}},
+    }
+
+
+class DependabotAlertsTest(unittest.TestCase):
+    """Pins the gap `constraints.txt`-only `pip-audit` cannot see: a
+    transitive dependency's advisory (the real sqlparse alerts Dependabot
+    caught after v2.9.0 shipped, unpinned in `constraints.txt`)."""
+
+    def setUp(self):
+        patcher = mock.patch.object(
+            preflight, "_dependabot_token", return_value="test-token"
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_no_open_alerts_passes_silently(self):
+        with mock.patch.object(preflight.provenance, "_github_json", return_value=[]):
+            result = preflight.check_dependabot_alerts()
+        self.assertIn("no open high/critical", result)
+
+    def test_a_medium_severity_alert_does_not_block(self):
+        alerts = [_dependabot_alert(ghsa="GHSA-medium", severity="medium")]
+        with mock.patch.object(
+            preflight.provenance, "_github_json", return_value=alerts
+        ):
+            result = preflight.check_dependabot_alerts()
+        self.assertIn("no open high/critical", result)
+
+    def test_an_unaccepted_high_severity_alert_blocks(self):
+        alerts = [_dependabot_alert(ghsa="GHSA-high-one", severity="high")]
+        with mock.patch.object(
+            preflight.provenance, "_github_json", return_value=alerts
+        ):
+            with self.assertRaises(preflight.PreflightError) as caught:
+                preflight.check_dependabot_alerts()
+        self.assertIn("sqlparse", str(caught.exception))
+        self.assertIn("GHSA-high-one", str(caught.exception))
+
+    def test_an_accepted_high_severity_alert_does_not_block(self):
+        alerts = [_dependabot_alert(ghsa="GHSA-high-one", severity="high")]
+        with mock.patch.object(
+            preflight, "ACCEPTED_DEPENDABOT_ALERTS", {"GHSA-high-one"}
+        ):
+            with mock.patch.object(
+                preflight.provenance, "_github_json", return_value=alerts
+            ):
+                result = preflight.check_dependabot_alerts()
+        self.assertIn("GHSA-high-one", result)
+
+    def test_no_token_available_fails_closed(self):
+        with mock.patch.object(preflight, "_dependabot_token") as token:
+            token.side_effect = preflight.PreflightError("no token")
+            with self.assertRaises(preflight.PreflightError):
+                preflight.check_dependabot_alerts()
+
+    def test_a_transport_failure_is_translated_and_does_not_pass_silently(self):
+        with mock.patch.object(
+            preflight.provenance,
+            "_github_json",
+            side_effect=preflight.provenance.ProvenanceError("boom"),
+        ):
+            with self.assertRaises(preflight.PreflightError) as caught:
+                preflight.check_dependabot_alerts()
+        self.assertIn("boom", str(caught.exception))


### PR DESCRIPTION
## Summary

`check_dependency_advisories()` only audits `constraints.txt` - a small,
hand-curated pin set for packages this project pins deliberately
(cryptography, httpx, the optional NetBox plugins). It was never the full
dependency closure, so a transitive dependency's advisory can pass every
local and CI `pip-audit` run while GitHub's own Dependabot scan (reads the
whole `poetry.lock`) already has it open. That happened for real: 4 sqlparse
advisories (Django pulls it in with only a floor pin) surfaced via Dependabot
right after v2.9.0 shipped, invisible to `pip-audit` the whole time.

`check_dependabot_alerts()` closes that gap the same way the pip-audit check
closes its own: fail closed on any open high/critical alert not named in
`ACCEPTED_DEPENDABOT_ALERTS`, ten seconds before the forty-minute gate.
`release.yml` calls the same function so the accepted-alert list lives in
exactly one place, matching `ACCEPTED_DEPENDENCY_ADVISORIES`'s pattern.

## Consequence - not a bug

**Three open high-severity sqlparse alerts exist right now, unaccepted.**
Merging this makes `invoke ci` fail at the preflight step for everyone until
`sqlparse` is bumped to `0.6.0` (no constraint conflict blocks it - Django
only requires `>=0.5.0`) or the alerts are explicitly accepted here. That is
the intended forcing function. **Left unmerged for now** - timing the
team-wide gate going red is a separate decision from writing the check.

## Test plan

- [x] `scripts/tests/test_release_preflight.py`: 25/25 tests OK (6 new,
      covering pass/block/accept/no-token/transport-failure cases)
- [x] pre-commit clean on all three touched files
- [x] Ran the real check against this repo's live Dependabot alerts:
      correctly blocks on the 3 open high-severity sqlparse alerts, correctly
      ignores the 1 open medium-severity one

Claude-Session: https://claude.ai/code/session_012Qfd3hTSxZtmFHuzRJnZre