### PR TITLE
feat: measure drift for tagged items, the first adapter-only model

### DIFF
--- a/docs/03_Plans/active/2026-08-24-adapter-model-drift-taggeditem.md
+++ b/docs/03_Plans/active/2026-08-24-adapter-model-drift-taggeditem.md
@@ -1,0 +1,151 @@
+# Measure drift for the adapter-only models, starting with tagged items
+
+## Goal
+
+Give the adapter-only models a real drift comparison, the way the bulk-ORM
+models got one in `2026-08-15-measure-real-drift.md`. This is slice one of
+eight: `extras.taggeditem`.
+
+## Why
+
+`in_sync` on the drift report is deliberately unanswerable today, and the
+reason is named in that plan's Open section and in #206: the adapter-only
+models - the lifecycle rows, cables, inventory items, modules, tagged items,
+FHRP groups, routing and peering - have no bulk path, so none of the preview
+machinery reaches them. Every one of them reports an upper bound, which is
+honest and useless, and while any model is uncompared the estate is never
+"fully measured".
+
+Tagged items go first because they are the smallest of the eight: one
+dependent object, one assignment, no recursive dependency chain, and seven
+existing regression tests already covering the apply.
+
+## Constraints
+
+- **The comparison must reuse the apply's own resolution and comparator.** A
+  second implementation drifts from the first and reports a number that is
+  wrong in whichever direction is least noticeable. Same constraint as the
+  bulk slices, and the reason `last_upsert_would_change` is computed with
+  `_model_field_value_matches` rather than a fresh comparison.
+- **A preview must write nothing**, and for this path that is two writes, not
+  one - see below.
+- No new Forward calls. This is a NetBox-side read.
+- A model that cannot be compared must keep reporting an upper bound rather
+  than a zero. Absence from `_ADAPTER_COMPARISONS` is that answer.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/sync_interface.py` - `apply_extras_taggeditem`
+  gains `preview`
+- `forward_netbox/utilities/drift_comparison.py` - a read-only
+  `_upsert_values_from_defaults` on `PreviewRunner`, the per-row adapter
+  comparison, and the dispatch
+- `forward_netbox/tests/test_taggeditem_drift_comparison.py` (new)
+
+## Approach
+
+The bulk models classify a batch and return counts. The adapter models apply
+one row at a time, so the loop belongs to the caller: `_compare_extras_
+taggeditem` iterates, calls the apply with `preview=True`, and tallies the
+per-row verdict. That shape is what the remaining seven will reuse.
+
+`_ADAPTER_COMPARISONS` maps a model string to its comparison. Absence from it
+is the "no comparison" answer, so adding a model is a deliberate act that
+follows an audit of that path's `runner.` calls - not just a grep for ORM
+writes, which is the method that missed `_ensure_vrf` in the bulk work.
+
+### The two writes, and why one needed a flag
+
+`runner._upsert_values_from_defaults` writes the `Tag` row. That is behind a
+`runner.` call, so the preview runner's firewall covers it: the override
+resolves through the same coalesce lookups and stops. This is the primitive
+EVERY adapter model writes through, so the one override is most of what makes
+the remaining seven reachable.
+
+`device.tags.add(tag)` is the other, and it is a different shape from anything
+the bulk slices hit. It is an M2M write reached through a module-level helper
+(`_device_add_tag`), not through a `runner.` method - so the firewall does not
+see it and cannot neutralise it. That is why `apply_extras_taggeditem` takes a
+`preview` flag rather than relying on the shim: this write has to be skipped
+by name, in the function.
+
+Worth stating plainly for the next slice: **the firewall is not total.** It
+covers writes behind `runner.`, and a path that writes directly - or through a
+module-level helper, or through a NetBox-core `save()` side effect - needs its
+own guard. Cables (`cable.save()`, `cable.delete()`, and NetBox core creating
+`CableTermination` rows) and modules (`Module.save()` with `_adopt_components`,
+where NetBox core instantiates component rows) are both in that category.
+
+### Classification
+
+- tag absent in NetBox -> `creates`. NetBox cannot already carry an assignment
+  to a tag it does not have.
+- tag present, not assigned -> `creates`.
+- tag present and assigned, tag fields match -> `unchanged`.
+- tag present and assigned, tag fields differ -> `updates`. The apply would
+  rewrite the `Tag` row, and calling that unchanged would under-report drift.
+- device unresolvable, or the row missing its keys -> `rejected`, counted
+  apart from drift. A defect in the row is not a difference between the two
+  systems.
+
+An outcome the comparison does not recognise refuses the whole model rather
+than falling into `unchanged`, which is the confident-zero failure this
+feature keeps producing and the one with a real consequence.
+
+## Validation
+
+12 tests, of which three are the negative space, and each was run as its own
+negative control rather than assumed:
+
+- Reintroducing `device.tags.add()` under preview made
+  `test_a_preview_does_not_assign_a_tag_that_already_exists` fail.
+- Making the read-only upsert create the `Tag` made
+  `test_a_preview_creates_no_tag_and_no_assignment` fail.
+
+Those are two DIFFERENT tests catching two DIFFERENT writes, and running the
+controls separately is what established that. The first control failed only
+one of the two, because when the tag is absent the shim returns `None` and
+there is no assignment to make - so neither test is redundant and neither
+covers both writes. A single combined control would have suggested otherwise.
+
+Two parity tests apply for real afterwards and assert the preview predicted
+the write count, which is the property the number actually sells.
+
+Full run: 300 tests green across `test_taggeditem_drift_comparison`,
+`test_drift_comparison`, `test_preview_runner_satisfies_the_priming_contract`,
+`test_preview_primes_its_lookup_caches`,
+`test_empty_comparison_is_not_a_measurement`,
+`test_drift_coverage_is_explained` and `test_sync.ForwardSyncRunnerTest`.
+
+## Rollback
+
+Remove `extras.taggeditem` from `_ADAPTER_COMPARISONS`; it returns to an upper
+bound, which is where every adapter model is today. The `preview` parameter
+defaults to `False`, so the apply path is unchanged for every existing caller.
+
+## Decision Log
+
+- **Per-row loop in the caller, not a batch API on the apply.** The adapter
+  models have no batch to classify, and inventing one would be the parallel
+  implementation this feature's first constraint rules out.
+- **`updates` counts a drifted `Tag` row.** The apply writes it, so the
+  preview must count it. The alternative - counting only the assignment -
+  reports zero for a run that would write.
+- **A flag on the apply, not another shim method.** Routing the M2M write
+  through a `runner.` method purely so the firewall could catch it would add
+  indirection to the write path - this repository's highest-incident code -
+  to serve the preview. The flag is honest about which write is being skipped
+  and why.
+
+## Open
+
+- Seven models remain: cables, inventory items, FHRP groups, lifecycle
+  (netbox-dlm), modules, peering, routing. Suggested order is roughly that,
+  with routing and peering last and together: peering is 30 lines but calls
+  `_ensure_netbox_routing_bgppeer` as its first step, so it inherits the whole
+  7-deep BGP-peer chain (VRF, two ASNs, an RIR, an IPAddress, BGPRouter,
+  BGPScope, then the peer).
+- `in_sync` stays `None` until all eight land. That is unchanged by this slice
+  and correct.
+- `dcim.virtualchassis` remains deliberately unmeasured; see
+  `2026-08-15-measure-real-drift.md`.

--- a/forward_netbox/tests/test_taggeditem_drift_comparison.py
+++ b/forward_netbox/tests/test_taggeditem_drift_comparison.py
@@ -1,0 +1,253 @@
+# The first adapter-only model to get a drift comparison.
+#
+# The bulk-ORM models classify a whole batch and return counts; the adapter
+# models have no bulk path at all, so each row is applied on its own and the
+# loop belongs to the caller. `extras.taggeditem` is the smallest of the eight
+# and goes first for that reason - it proves the shape the rest will use.
+#
+# It also carries the trap that makes these paths different from the bulk ones.
+# `apply_extras_taggeditem` writes twice: the `Tag` row through
+# `runner._upsert_values_from_defaults`, which the preview runner overrides, and
+# `device.tags.add(tag)` - an M2M write reached through a module-level helper
+# rather than a `runner.` call, so the preview runner's firewall does NOT stop
+# it. A grep for `bulk_create`/`.save(`/`.delete(` sees neither.
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import Manufacturer
+from dcim.models import Site
+from django.test import TestCase
+from extras.models import Tag
+from extras.models import TaggedItem
+
+from forward_netbox.utilities.drift_comparison import compare_model_rows
+
+
+class TaggedItemPreviewTest(TestCase):
+    def setUp(self):
+        site = Site.objects.create(name="T Site", slug="t-site")
+        mfr = Manufacturer.objects.create(name="T Mfr", slug="t-mfr")
+        dtype = DeviceType.objects.create(manufacturer=mfr, model="T DT", slug="t-dt")
+        role = DeviceRole.objects.create(name="T Role", slug="t-role")
+        self.device = Device.objects.create(
+            name="tagged-dev",
+            site=site,
+            device_type=dtype,
+            role=role,
+            status="active",
+        )
+
+    def _row(self, **extra):
+        row = {
+            "device": "tagged-dev",
+            "tag": "Prot BGP",
+            "tag_slug": "prot-bgp",
+            "tag_color": "9e9e9e",
+        }
+        row.update(extra)
+        return row
+
+    # --- the negative space -------------------------------------------------
+    #
+    # This is the assertion the feature is built around. Every other test here
+    # could pass against a preview that quietly tagged the operator's devices.
+
+    def test_a_preview_creates_no_tag_and_no_assignment(self):
+        tags_before = Tag.objects.count()
+        assignments_before = TaggedItem.objects.count()
+
+        result = compare_model_rows(None, "extras.taggeditem", [self._row()])
+
+        self.assertEqual(Tag.objects.count(), tags_before)
+        self.assertEqual(TaggedItem.objects.count(), assignments_before)
+        self.assertFalse(Tag.objects.filter(slug="prot-bgp").exists())
+        # And it still answered, rather than declining.
+        self.assertEqual(result["creates"], 1)
+
+    def test_a_preview_does_not_assign_a_tag_that_already_exists(self):
+        # The tag is present but unassigned, so only the M2M write is left to
+        # suppress - the case where the `_upsert_values_from_defaults` override
+        # alone would not have been enough.
+        Tag.objects.create(name="Prot BGP", slug="prot-bgp", color="9e9e9e")
+        self.assertEqual(self.device.tags.count(), 0)
+
+        result = compare_model_rows(None, "extras.taggeditem", [self._row()])
+
+        self.device.refresh_from_db()
+        self.assertEqual(self.device.tags.count(), 0)
+        self.assertEqual(result["creates"], 1)
+
+    def test_a_preview_does_not_rewrite_a_drifted_tag(self):
+        Tag.objects.create(name="Prot BGP", slug="prot-bgp", color="ff0000")
+        self.device.tags.add(Tag.objects.get(slug="prot-bgp"))
+
+        compare_model_rows(None, "extras.taggeditem", [self._row()])
+
+        self.assertEqual(Tag.objects.get(slug="prot-bgp").color, "ff0000")
+
+    # --- classification -----------------------------------------------------
+
+    def test_an_absent_tag_is_a_create(self):
+        result = compare_model_rows(None, "extras.taggeditem", [self._row()])
+
+        self.assertEqual(
+            result, {"creates": 1, "updates": 0, "unchanged": 0, "rejected": 0}
+        )
+
+    def test_an_existing_assignment_is_unchanged(self):
+        tag = Tag.objects.create(name="Prot BGP", slug="prot-bgp", color="9e9e9e")
+        self.device.tags.add(tag)
+
+        result = compare_model_rows(None, "extras.taggeditem", [self._row()])
+
+        self.assertEqual(
+            result, {"creates": 0, "updates": 0, "unchanged": 1, "rejected": 0}
+        )
+
+    def test_an_assigned_tag_whose_colour_drifted_is_an_update(self):
+        # The assignment exists, so this is not a create - but the apply would
+        # still rewrite the Tag row, and a preview that called that "unchanged"
+        # would under-report drift.
+        tag = Tag.objects.create(name="Prot BGP", slug="prot-bgp", color="ff0000")
+        self.device.tags.add(tag)
+
+        result = compare_model_rows(None, "extras.taggeditem", [self._row()])
+
+        self.assertEqual(
+            result, {"creates": 0, "updates": 1, "unchanged": 0, "rejected": 0}
+        )
+
+    def test_a_tag_matched_by_name_when_the_slug_differs_is_not_a_create(self):
+        # The apply coalesces on slug first, then name, so a hand-created tag
+        # with the same name and a different slug is REUSED rather than created.
+        # The comparison has to agree, or it reports a create for a row the
+        # apply would not create.
+        tag = Tag.objects.create(
+            name="Prot BGP", slug="prot-bgp-legacy", color="9e9e9e"
+        )
+        self.device.tags.add(tag)
+
+        result = compare_model_rows(None, "extras.taggeditem", [self._row()])
+
+        self.assertEqual(result["creates"], 0)
+
+    def test_a_row_naming_an_unknown_device_is_rejected_not_zero_drift(self):
+        result = compare_model_rows(
+            None, "extras.taggeditem", [self._row(device="no-such-device")]
+        )
+
+        self.assertEqual(result["rejected"], 1)
+        self.assertEqual(result["creates"], 0)
+        self.assertEqual(result["unchanged"], 0)
+
+    def test_a_row_missing_its_device_key_is_rejected(self):
+        result = compare_model_rows(
+            None, "extras.taggeditem", [{"tag": "X", "tag_slug": "x"}]
+        )
+
+        self.assertEqual(result["rejected"], 1)
+        self.assertEqual(result["unchanged"], 0)
+
+    def test_a_mixed_batch_is_not_all_or_nothing(self):
+        tag = Tag.objects.create(name="Prot BGP", slug="prot-bgp", color="9e9e9e")
+        self.device.tags.add(tag)
+
+        result = compare_model_rows(
+            None,
+            "extras.taggeditem",
+            [
+                self._row(),
+                self._row(tag="Prot OSPF", tag_slug="prot-ospf"),
+                self._row(device="no-such-device"),
+            ],
+        )
+
+        self.assertEqual(
+            result, {"creates": 1, "updates": 0, "unchanged": 1, "rejected": 1}
+        )
+
+    # --- parity with the apply ----------------------------------------------
+
+    def test_the_preview_count_matches_what_an_apply_actually_writes(self):
+        """The property the feature sells: preview and apply agree.
+
+        A comparison that is merely self-consistent is worth nothing; what makes
+        the number usable is that applying afterwards changes exactly as many
+        rows as the preview said it would.
+        """
+        rows = [
+            self._row(),
+            self._row(tag="Prot OSPF", tag_slug="prot-ospf"),
+        ]
+
+        predicted = compare_model_rows(None, "extras.taggeditem", rows)
+
+        assignments_before = self.device.tags.count()
+        self._apply_for_real(rows)
+        self.device.refresh_from_db()
+        actually_written = self.device.tags.count() - assignments_before
+
+        self.assertEqual(predicted["creates"], actually_written)
+
+    def test_a_second_preview_after_the_apply_reports_no_drift(self):
+        rows = [self._row()]
+        self._apply_for_real(rows)
+
+        result = compare_model_rows(None, "extras.taggeditem", rows)
+
+        self.assertEqual(result["unchanged"], 1)
+        self.assertEqual(result["creates"], 0)
+
+    def _apply_for_real(self, rows):
+        from forward_netbox.utilities.sync_interface import apply_extras_taggeditem
+
+        runner = _WritingRunner()
+        for row in rows:
+            apply_extras_taggeditem(runner, row)
+
+
+class _WritingRunner:
+    """The real primitives, no preview - so the parity tests apply for real."""
+
+    def __init__(self):
+        self._content_types = {}
+        self._device_by_name_cache = {}
+        self._missing_device_by_name_cache = set()
+        self._tag_by_name_cache = {}
+        self._tag_by_slug_cache = {}
+        self._unique_lookup_cache = {}
+        self._primed_missing_unique_lookup_keys = set()
+        self._model_coalesce_fields = {}
+        self._device_tag_ids_cache = {}
+        self.logger = _NullLogger()
+
+    def _get_device_by_name(self, name):
+        from forward_netbox.utilities.sync_primitives import get_device_by_name
+
+        return get_device_by_name(self, name)
+
+    def _upsert_values_from_defaults(self, *args, **kwargs):
+        from forward_netbox.utilities.sync_primitives import (
+            upsert_values_from_defaults,
+        )
+
+        return upsert_values_from_defaults(self, *args, **kwargs)
+
+    def _dependency_failed(self, model_string, key):
+        return False
+
+    def _record_issue(self, *args, **kwargs):
+        return None
+
+    def _conflict_policy(self, model_string):
+        # What the real runner defaults to for a model with no configured
+        # policy. `coalesce_upsert` asks for it on every write.
+        return "strict"
+
+
+class _NullLogger:
+    def increment_statistics(self, *args, **kwargs):
+        return None
+
+    def log_warning(self, *args, **kwargs):
+        return None

--- a/forward_netbox/utilities/drift_comparison.py
+++ b/forward_netbox/utilities/drift_comparison.py
@@ -101,6 +101,11 @@ class PreviewRunner:
         self._scope_matched_tags = {}
         self._scope_tag_objs = {}
         self.rejected_rows = 0
+        # Set by `_upsert_values_from_defaults` for the row it just resolved.
+        # False rather than None so a path that reads it without an upsert
+        # having run reports "no change" instead of raising - the adapter
+        # comparison only reads it after an upsert it made itself.
+        self.last_upsert_would_change = False
 
     def _record_issue(self, *args, **kwargs):
         # Deliberately signature-agnostic. Callers pass different keyword sets
@@ -195,6 +200,65 @@ class PreviewRunner:
             return None
         return Manufacturer.objects.filter(name=name).order_by("pk").first()
 
+    def _upsert_values_from_defaults(
+        self,
+        model_string,
+        model,
+        *,
+        values,
+        coalesce_sets,
+        create_instance_attrs=None,
+    ):
+        """Find the row, never create or update it, and say whether it differs.
+
+        This is the primitive every adapter-only model writes through, so it is
+        the single override that makes them previewable at all. The real one
+        creates the row when absent and saves the fields that differ; this one
+        resolves through the same coalesce lookups and stops.
+
+        ``last_upsert_would_change`` records whether the apply would have
+        written, computed with ``_model_field_value_matches`` - the comparator
+        the real upsert uses - so a preview cannot disagree with the apply about
+        what counts as a difference. A second comparison written here would be
+        wrong in whichever direction is least noticeable, which is the failure
+        this whole feature exists to avoid.
+
+        ``create_instance_attrs`` is accepted and ignored on purpose: it exists
+        for side effects of ``save()`` (``dcim.Module``'s ``_adopt_components``,
+        which makes NetBox core instantiate component rows), and a preview never
+        saves.
+        """
+        from .sync_primitives import _authoritative_update_values
+        from .sync_primitives import _dedupe_lookups
+        from .sync_primitives import _model_field_value_matches
+        from .sync_primitives import coalesce_lookup
+        from .sync_primitives import get_unique_or_raise
+
+        lookups = _dedupe_lookups(
+            [coalesce_lookup(values, *coalesce_set) for coalesce_set in coalesce_sets]
+        )
+        obj = None
+        for lookup in lookups:
+            if not lookup:
+                continue
+            obj = get_unique_or_raise(self, model, lookup)
+            if obj is not None:
+                break
+        if obj is None:
+            # Absent, so the apply would create it. Reported as a create by the
+            # caller; `would_change` is not the question for a row that is not
+            # there at all.
+            self.last_upsert_would_change = False
+            return None, True
+        self.last_upsert_would_change = any(
+            not _model_field_value_matches(model, obj, field, value)
+            for field, value in _authoritative_update_values(
+                model._meta.label_lower,
+                values,
+            ).items()
+        )
+        return obj, False
+
     def _ensure_vrf(self, row, *, update_existing=True):
         """Find the VRF, never create or update it.
 
@@ -232,6 +296,56 @@ class PreviewRunner:
 
     def _record_aggregated_skip_warning(self, **kwargs):
         return None
+
+
+def _compare_extras_taggeditem(runner, rows):
+    """Classify feature-tag assignments one row at a time.
+
+    The adapter-only models have no bulk path, so there is nothing to call with
+    ``preview=True`` and return counts from; each row is applied on its own.
+    That makes the loop the caller's job rather than the apply function's, and
+    it is the shape every remaining adapter model will use.
+    """
+    from ..exceptions import ForwardDependencySkipError
+    from ..exceptions import ForwardSearchError
+    from .sync_interface import apply_extras_taggeditem
+
+    counts = {"creates": 0, "updates": 0, "unchanged": 0, "rejected": 0}
+    for row in rows:
+        try:
+            outcome = apply_extras_taggeditem(runner, row, preview=True)
+        except (ForwardDependencySkipError, ForwardSearchError):
+            # An unusable row is a defect in the row, not a difference between
+            # the two systems, so it is counted apart from drift rather than
+            # inflating it. The apply raises the same pair for a device it
+            # cannot resolve.
+            counts["rejected"] += 1
+            continue
+        except KeyError:
+            # `row["device"]` / `row["tag"]` absent. Same class as above: the
+            # row cannot be applied, and calling that zero drift would be the
+            # confident-zero failure this feature exists to prevent.
+            counts["rejected"] += 1
+            continue
+        if outcome not in counts:
+            # An outcome this function does not recognise must not be silently
+            # dropped into "unchanged". Refusing the whole model is the honest
+            # answer, and the caller falls back to the upper bound for it.
+            return None
+        counts[outcome] += 1
+    return counts
+
+
+# Adapter-only models that can be compared, and the function that does it.
+#
+# Absence from this mapping is the "no comparison" answer for a model, which is
+# what every adapter model gave before this: the caller keeps its upper-bound
+# estimate rather than reporting a zero nothing measured. Adding a model here
+# means auditing its `runner.` calls, not just grepping it for ORM writes - the
+# writes that matter in these paths hide behind `_ensure_*` and `_upsert_*`.
+_ADAPTER_COMPARISONS = {
+    "extras.taggeditem": _compare_extras_taggeditem,
+}
 
 
 def compare_model_rows(sync, model_string, rows):
@@ -284,6 +398,9 @@ def compare_model_rows(sync, model_string, rows):
     # against a cold one must return the same counts; `test_preview_primes_its_
     # lookup_caches` pins that they do, so this stays a cost change only.
     prime_dependency_lookup_caches(runner, model_string, rows)
+    adapter_comparison = _ADAPTER_COMPARISONS.get(model_string)
+    if adapter_comparison is not None:
+        return adapter_comparison(runner, rows)
     counts = bulk_orm_apply_simple_models(
         runner,
         model_string,

--- a/forward_netbox/utilities/sync_interface.py
+++ b/forward_netbox/utilities/sync_interface.py
@@ -71,7 +71,24 @@ def delete_dcim_macaddress(runner, row):
     )
 
 
-def apply_extras_taggeditem(runner, row):
+def apply_extras_taggeditem(runner, row, *, preview=False):
+    """Assign the feature tag, or - with ``preview`` - classify and write nothing.
+
+    ``preview`` returns ``"creates"``, ``"updates"`` or ``"unchanged"`` for the
+    one row and performs neither write this function normally makes. There are
+    two, and only one of them is visible to a grep for ORM calls:
+
+    * ``runner._upsert_values_from_defaults`` writes the ``Tag`` row itself. The
+      preview runner overrides it with a lookup, the same treatment
+      ``_ensure_vrf`` and ``_ensure_platform`` already get.
+    * ``device.tags.add(tag)`` is an M2M write reached through a module-level
+      helper rather than a ``runner.`` call, so the preview runner's firewall
+      does NOT cover it. That is exactly why this function takes a flag instead
+      of relying on the shim: the write has to be skipped here, by name.
+
+    A tag NetBox does not have cannot already be assigned, so a row whose tag is
+    absent classifies as a create rather than as unmeasured.
+    """
     from extras.models import Tag
 
     try:
@@ -107,7 +124,21 @@ def apply_extras_taggeditem(runner, row):
         # unique-name constraint. Mirrors _ensure_scope_tag in sync_device.py.
         coalesce_sets=[("slug",), ("name",)],
     )
-    _device_add_tag(runner, device, tag)
+    if preview:
+        if tag is None:
+            # The preview runner's lookup found no such tag. NetBox cannot
+            # already carry an assignment to a tag it does not have, so this is
+            # a create - not an "unknown", and emphatically not an unchanged.
+            return "creates"
+        if not _device_has_tag(runner, device, tag):
+            return "creates"
+        # The assignment is already there. The apply would still rewrite the
+        # `Tag` row if its name, slug or colour had drifted, and that is a write
+        # this model's apply performs - so it is an update rather than a
+        # no-change, and the preview runner reports it from the same comparator
+        # the real upsert uses.
+        return "updates" if runner.last_upsert_would_change else "unchanged"
+    _device_add_tag(runner, device, tag)  # NEGATIVE-CONTROL-MARKER
 
 
 def apply_dcim_macaddress(runner, row):


### PR DESCRIPTION
## Summary

Slice one of eight toward closing #206's remaining scope.

The adapter-only models named there — lifecycle rows, cables, inventory items,
modules, tagged items, FHRP groups, routing and peering — have no bulk-ORM
path, so none of the preview machinery built for the bulk models reaches them
and every one reports an upper bound. That is why `in_sync` is *unanswerable*
rather than merely unanswered.

`extras.taggeditem` goes first because it is the smallest of the eight: one
dependent object, one assignment, no recursive dependency chain, and seven
existing regression tests already covering the apply.

## The shape the remaining seven will reuse

The bulk models classify a batch and return counts; the adapter models apply
one row at a time, so the loop belongs to the caller rather than to a batch API
that does not exist. `_ADAPTER_COMPARISONS` maps a model to its comparison, and
**absence from it is the "no comparison" answer** — an unaudited path keeps its
upper bound instead of reporting a zero nothing measured.

## Two writes, and only one was the expected shape

- `runner._upsert_values_from_defaults` writes the `Tag` row. Behind a
  `runner.` call, so the preview runner's firewall covers it with a
  lookup-only override. **This is the primitive every adapter model writes
  through**, so this one override is most of what makes the remaining seven
  reachable.
- `device.tags.add(tag)` is an M2M write reached through a module-level helper,
  *not* a `runner.` method — so the firewall neither sees nor stops it. Hence
  the `preview` flag on the apply: this write is skipped by name.

Worth flagging for the next slices: **the firewall is not total.** Cables
(`cable.save()`/`delete()`, plus NetBox core creating `CableTermination` rows)
and modules (`Module.save()` with `_adopt_components`, where NetBox core
instantiates component rows) are in the same category.

`last_upsert_would_change` is computed with `_model_field_value_matches` — the
comparator the real upsert uses — so the preview cannot disagree with the apply
about what counts as a difference.

## Test plan

- [x] 12 new tests; 300 green in total across
      `test_taggeditem_drift_comparison`, `test_drift_comparison`,
      `test_preview_runner_satisfies_the_priming_contract`,
      `test_preview_primes_its_lookup_caches`,
      `test_empty_comparison_is_not_a_measurement`,
      `test_drift_coverage_is_explained`, `test_sync.ForwardSyncRunnerTest`
      (includes the 7 pre-existing tagged-item tests)
- [x] pre-commit clean; `check_harness.py --base origin/main` passes
- [x] **Negative controls run separately, per write:**
      reintroducing `device.tags.add()` under preview failed
      `test_a_preview_does_not_assign_a_tag_that_already_exists`; making the
      read-only upsert create the Tag failed
      `test_a_preview_creates_no_tag_and_no_assignment`.
      Running them separately is what established the two tests catch two
      *different* writes and neither is redundant — the first control failed
      only one of the two, because when the tag is absent the shim returns
      `None` and there is no assignment to make.

## Rollback

Remove `extras.taggeditem` from `_ADAPTER_COMPARISONS` and it returns to an
upper bound. `preview` defaults to `False`, so every existing caller of the
apply is unchanged.

Refs #206

Claude-Session: https://claude.ai/code/session_012Qfd3hTSxZtmFHuzRJnZre