### PR TITLE
feat: measure drift for inventory items, declining the delete branch

### DIFF
--- a/docs/03_Plans/active/2026-08-24-adapter-model-drift-inventoryitem.md
+++ b/docs/03_Plans/active/2026-08-24-adapter-model-drift-inventoryitem.md
@@ -1,0 +1,113 @@
+# Measure drift for inventory items
+
+## Goal
+
+Slice three of the adapter-only drift comparison: `dcim.inventoryitem`.
+
+## Why
+
+Unchanged from slices one and two. Every adapter-only model reports a workload
+upper bound, so `in_sync` stays unanswerable while any of the eight is
+uncompared.
+
+## Constraints
+
+- Reuse the apply's own resolution; do not reimplement the comparison.
+- Write nothing.
+- Never report a count the contract cannot express.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/sync_inventory_module.py` -
+  `apply_dcim_inventoryitem` gains `preview`, and a sentinel
+- `forward_netbox/utilities/drift_comparison.py` - four shims, a null-sync
+  method, and `uncomparable_outcomes` on the shared loop
+- `forward_netbox/tests/test_inventoryitem_drift_comparison.py` (new)
+
+## Approach
+
+### The writes were the easy half
+
+All three are behind `runner.` calls - `_ensure_manufacturer` (already
+overridden for the device path), `_ensure_inventory_item_role`, and
+`_upsert_values_from_defaults` - so the firewall covers them and the flag does
+not have to. `_ensure_inventory_item_role` is a new override and is the same
+trap as `_ensure_vrf` and `_ensure_platform`: an upsert reached during
+classification that a grep for ORM calls cannot see. It becomes a lookup
+returning `None` for an absent role, which classifies the item as a create -
+correct, because the item cannot already exist under a role NetBox lacks.
+
+### The delete branch, which is not a write problem
+
+When `dcim.module` is enabled, a module-native inventory row is DELETED rather
+than upserted (`apply_dcim_inventoryitem` calls `delete_dcim_inventoryitem`).
+Suppressing the delete is trivial - `_delete_by_coalesce` returns `False`. What
+is not trivial is what to COUNT.
+
+The report reads drift as `creates + updates` (`views.py:513`) and accounts for
+deletes separately. So:
+
+- counting it as an update double-counts it against that separate accounting;
+- counting it as unchanged is a confident zero for a row that will change;
+- counting it as rejected reports a perfectly good row as unusable, and feeds
+  `comparison_rejected_rows`, which means something else.
+
+There is no honest bucket. So the row returns
+`MODULE_NATIVE_ROW_NOT_COMPARABLE` and the comparison declines the whole model,
+which keeps its upper bound - the documented "no comparison" answer, and the
+only one that cannot mislead in either direction.
+
+The refusal is scoped to batches that actually contain such a row. A
+deployment without module-native inventory still gets a real measurement, and
+one with `dcim.module` disabled is unaffected because the branch is gated on
+it. Both are pinned by tests, the second specifically so a future reader does
+not "simplify" the gate away and silently drop the model for everyone.
+
+Declining the whole model rather than the row is deliberate: a partial count
+would understate drift by however many rows were dropped, silently.
+
+## Validation
+
+12 tests. Both guards proven by their own negative control, run separately:
+
+- Making `_ensure_inventory_item_role` write failed
+  `test_a_preview_creates_no_inventory_item_role`.
+- Removing the module-native decline failed
+  `test_a_module_native_row_declines_the_whole_model` and
+  `test_one_module_native_row_declines_the_batch_it_is_in`.
+
+Full run: 325 tests green across the three adapter suites, the bulk drift
+suite, the preview contract and priming suites, and `ForwardSyncRunnerTest`.
+
+## Rollback
+
+Remove `dcim.inventoryitem` from `_ADAPTER_COMPARISONS`. `preview` defaults to
+`False`, so the apply is unchanged for every existing caller.
+
+## Decision Log
+
+- **Decline rather than invent a bucket for the delete.** The contract has
+  four keys and a delete is none of them. Adding a fifth would change what
+  `views.py` and the report consume, which is a wider change than this slice
+  should carry - and worth doing deliberately, not as a side effect.
+- **Decline the model, not the row.** A partial count understates drift
+  silently, which is the failure this feature exists to prevent.
+- **`is_model_enabled` returns False on the null sync.** Matches the existing
+  `_scope_tags_enabled` degradation: production always passes the real sync,
+  and guessing that a delete applies would be worse than classifying the
+  ordinary upsert.
+
+## Open
+
+- **Whether the comparison should carry deletes at all.** Today it cannot
+  express one, and `dcim.inventoryitem` is the first path where that costs a
+  measurement. If a later slice hits the same wall, a fifth count key plus the
+  `views.py` and report changes to consume it is probably the right answer -
+  but it should be its own change, with the double-counting question against
+  the existing delete accounting settled first.
+- Five models remain: FHRP groups, lifecycle (netbox-dlm), modules, peering,
+  routing.
+- Modules are the next real step up: `Module.save()` with `_adopt_components`
+  makes NetBox core instantiate component rows, and Manufacturer, ModuleType
+  and ModuleBay are written beneath it.
+- Routing and peering last, and together.

--- a/forward_netbox/tests/test_inventoryitem_drift_comparison.py
+++ b/forward_netbox/tests/test_inventoryitem_drift_comparison.py
@@ -1,0 +1,249 @@
+# Slice three of the adapter-only drift comparison: `dcim.inventoryitem`.
+#
+# Every write on this path is behind a `runner.` call - `_ensure_manufacturer`,
+# `_ensure_inventory_item_role`, `_upsert_values_from_defaults` - so the
+# preview runner's firewall covers them, unlike cables where both writes were
+# direct. `_ensure_inventory_item_role` is the new one, and it is the same trap
+# as `_ensure_vrf`: an upsert reached during classification that a grep for ORM
+# calls cannot see.
+#
+# The branch that needed real thought is not a write at all. When `dcim.module`
+# is enabled a module-native row is DELETED rather than upserted, and this
+# comparison's contract has no slot for a delete - the report reads drift as
+# `creates + updates` and accounts for deletes separately. Such a row declines
+# the whole model rather than being folded into a bucket that would double-count
+# it or zero it.
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import InventoryItem
+from dcim.models import InventoryItemRole
+from dcim.models import Manufacturer
+from dcim.models import Site
+from django.test import TestCase
+
+from forward_netbox.utilities.drift_comparison import compare_model_rows
+
+
+class _ModuleEnabledSync:
+    """A sync that says `dcim.module` is on, so the delete branch is live."""
+
+    class _Source:
+        parameters = {}
+
+    source = _Source()
+    pk = None
+    name = ""
+
+    def is_model_enabled(self, model_string):
+        return model_string == "dcim.module"
+
+
+class InventoryItemPreviewTest(TestCase):
+    def setUp(self):
+        site = Site.objects.create(name="I Site", slug="i-site")
+        self.mfr = Manufacturer.objects.create(name="I Mfr", slug="i-mfr")
+        dtype = DeviceType.objects.create(
+            manufacturer=self.mfr, model="I DT", slug="i-dt"
+        )
+        role = DeviceRole.objects.create(name="I Role", slug="i-role")
+        self.device = Device.objects.create(
+            name="inv-dev", site=site, device_type=dtype, role=role, status="active"
+        )
+
+    def _row(self, **extra):
+        row = {
+            "device": "inv-dev",
+            "name": "Slot 1",
+            "part_id": "PN-1",
+            "serial": "SN-1",
+            "status": "active",
+            "discovered": True,
+            "role": "Transceiver",
+            "role_slug": "transceiver",
+            "role_color": "9e9e9e",
+            "manufacturer": "I Mfr",
+            "manufacturer_slug": "i-mfr",
+        }
+        row.update(extra)
+        return row
+
+    # --- the negative space -------------------------------------------------
+
+    def test_a_preview_creates_no_inventory_item(self):
+        before = InventoryItem.objects.count()
+
+        result = compare_model_rows(None, "dcim.inventoryitem", [self._row()])
+
+        self.assertEqual(InventoryItem.objects.count(), before)
+        self.assertEqual(result["creates"], 1)
+
+    def test_a_preview_creates_no_inventory_item_role(self):
+        # `_ensure_inventory_item_role` upserts on the real runner, and it is
+        # reached during classification - the `_ensure_vrf` trap again.
+        before = InventoryItemRole.objects.count()
+
+        compare_model_rows(None, "dcim.inventoryitem", [self._row()])
+
+        self.assertEqual(InventoryItemRole.objects.count(), before)
+        self.assertFalse(InventoryItemRole.objects.filter(slug="transceiver").exists())
+
+    def test_a_preview_creates_no_manufacturer(self):
+        before = Manufacturer.objects.count()
+
+        compare_model_rows(
+            None,
+            "dcim.inventoryitem",
+            [
+                self._row(
+                    manufacturer="Mfr That Does Not Exist",
+                    manufacturer_slug="mfr-that-does-not-exist",
+                )
+            ],
+        )
+
+        self.assertEqual(Manufacturer.objects.count(), before)
+
+    def test_a_preview_does_not_rewrite_a_drifted_item(self):
+        role = InventoryItemRole.objects.create(
+            name="Transceiver", slug="transceiver", color="9e9e9e"
+        )
+        item = InventoryItem.objects.create(
+            device=self.device,
+            name="Slot 1",
+            part_id="PN-1",
+            serial="SN-1",
+            status="active",
+            discovered=True,
+            role=role,
+            manufacturer=self.mfr,
+            description="original",
+        )
+
+        compare_model_rows(
+            None, "dcim.inventoryitem", [self._row(description="changed")]
+        )
+
+        item.refresh_from_db()
+        self.assertEqual(item.description, "original")
+
+    # --- classification -----------------------------------------------------
+
+    def test_an_absent_item_is_a_create(self):
+        result = compare_model_rows(None, "dcim.inventoryitem", [self._row()])
+
+        self.assertEqual(
+            result, {"creates": 1, "updates": 0, "unchanged": 0, "rejected": 0}
+        )
+
+    def test_a_matching_item_is_unchanged(self):
+        role = InventoryItemRole.objects.create(
+            name="Transceiver", slug="transceiver", color="9e9e9e"
+        )
+        InventoryItem.objects.create(
+            device=self.device,
+            name="Slot 1",
+            part_id="PN-1",
+            serial="SN-1",
+            status="active",
+            discovered=True,
+            role=role,
+            manufacturer=self.mfr,
+        )
+
+        result = compare_model_rows(None, "dcim.inventoryitem", [self._row()])
+
+        self.assertEqual(
+            result, {"creates": 0, "updates": 0, "unchanged": 1, "rejected": 0}
+        )
+
+    def test_a_drifted_item_is_an_update(self):
+        role = InventoryItemRole.objects.create(
+            name="Transceiver", slug="transceiver", color="9e9e9e"
+        )
+        InventoryItem.objects.create(
+            device=self.device,
+            name="Slot 1",
+            part_id="PN-1",
+            serial="SN-1",
+            status="active",
+            discovered=True,
+            role=role,
+            manufacturer=self.mfr,
+            description="original",
+        )
+
+        result = compare_model_rows(
+            None, "dcim.inventoryitem", [self._row(description="changed")]
+        )
+
+        self.assertEqual(
+            result, {"creates": 0, "updates": 1, "unchanged": 0, "rejected": 0}
+        )
+
+    def test_an_unknown_device_is_rejected(self):
+        result = compare_model_rows(
+            None, "dcim.inventoryitem", [self._row(device="no-such-device")]
+        )
+
+        self.assertEqual(result["rejected"], 1)
+        self.assertEqual(result["creates"], 0)
+
+    # --- the delete branch: declines rather than guesses ---------------------
+
+    def test_a_module_native_row_declines_the_whole_model(self):
+        # `dcim.module` enabled + a module-native part type means the apply
+        # DELETES this row. The contract has no slot for that, so the honest
+        # answer is no comparison at all.
+        result = compare_model_rows(
+            _ModuleEnabledSync(),
+            "dcim.inventoryitem",
+            [self._row(part_type="LINE CARD")],
+        )
+
+        self.assertIsNone(result)
+
+    def test_a_module_native_row_deletes_nothing_while_declining(self):
+        role = InventoryItemRole.objects.create(
+            name="Transceiver", slug="transceiver", color="9e9e9e"
+        )
+        InventoryItem.objects.create(
+            device=self.device,
+            name="Slot 1",
+            part_id="PN-1",
+            serial="SN-1",
+            status="active",
+            discovered=True,
+            role=role,
+        )
+        before = InventoryItem.objects.count()
+
+        compare_model_rows(
+            _ModuleEnabledSync(),
+            "dcim.inventoryitem",
+            [self._row(part_type="LINE CARD")],
+        )
+
+        self.assertEqual(InventoryItem.objects.count(), before)
+
+    def test_one_module_native_row_declines_the_batch_it_is_in(self):
+        # Not merely the row: the whole model, because a partial count would
+        # understate drift by however many rows were dropped.
+        result = compare_model_rows(
+            _ModuleEnabledSync(),
+            "dcim.inventoryitem",
+            [self._row(), self._row(name="Slot 2", part_type="LINE CARD")],
+        )
+
+        self.assertIsNone(result)
+
+    def test_a_module_native_row_is_compared_normally_when_modules_are_off(self):
+        # The delete branch is gated on `dcim.module` being enabled. With it
+        # off the row is an ordinary inventory item and must be measured, not
+        # declined - otherwise every deployment without modules loses the model.
+        result = compare_model_rows(
+            None, "dcim.inventoryitem", [self._row(part_type="LINE CARD")]
+        )
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["creates"], 1)

--- a/forward_netbox/utilities/drift_comparison.py
+++ b/forward_netbox/utilities/drift_comparison.py
@@ -55,6 +55,16 @@ class _NullSync:
     pk = None
     name = ""
 
+    def is_model_enabled(self, model_string):
+        """No model is enabled when there is no sync to ask.
+
+        `apply_dcim_inventoryitem` asks this to decide whether a module-native
+        row should be deleted instead of upserted. Production always passes the
+        real sync; this only affects callers with none, and it degrades to the
+        plain upsert classification rather than guessing that a delete applies.
+        """
+        return False
+
 
 class PreviewRunner:
     """A runner that records nothing and writes nothing.
@@ -134,6 +144,61 @@ class PreviewRunner:
 
     def _record_aggregated_conflict_warning(self, **kwargs):
         return None
+
+    def _coalesce_sets_for(self, model_string, default_sets):
+        from .sync_primitives import coalesce_sets_for
+
+        return coalesce_sets_for(self, model_string, default_sets)
+
+    def _is_module_native_inventory_row(self, row):
+        """Read-only, and read from the apply's own table.
+
+        It decides whether `apply_dcim_inventoryitem` deletes the row instead
+        of upserting it, so a preview that answered differently would classify
+        a deletion as a create.
+        """
+        from .sync import ForwardSyncRunner
+
+        if row.get("module_component") is True:
+            return True
+        return (
+            row.get("part_type") in ForwardSyncRunner.MODULE_NATIVE_INVENTORY_PART_TYPES
+        )
+
+    def _ensure_inventory_item_role(self, row):
+        """Find the role, never create it.
+
+        The real one upserts an `InventoryItemRole` through
+        `_upsert_row_from_defaults`, reached during classification - the same
+        trap as `_ensure_vrf` and `_ensure_platform`, and likewise invisible to
+        a grep for ORM calls. Returning `None` for an absent role matches how
+        every other absent dependency is treated: the item cannot already exist
+        under a role NetBox does not have.
+        """
+        from dcim.models import InventoryItemRole
+
+        role_name = row.get("role")
+        if not role_name:
+            return None
+        slug = str(row.get("role_slug") or "").strip()
+        if slug:
+            match = InventoryItemRole.objects.filter(slug=slug).order_by("pk").first()
+            if match is not None:
+                return match
+        return (
+            InventoryItemRole.objects.filter(name=str(role_name)).order_by("pk").first()
+        )
+
+    def _delete_by_coalesce(self, model, lookups):
+        """Never delete while measuring.
+
+        Reached from `apply_dcim_inventoryitem`, which deletes a module-native
+        row rather than upserting it when `dcim.module` is enabled. Raising
+        would be the firewall's usual answer, but this method is a legitimate
+        part of that path, so it returns "nothing was deleted" and the
+        comparison refuses the model instead - see `_compare_dcim_inventoryitem`.
+        """
+        return False
 
     def _lookup_device_by_name(self, device_name):
         from .sync_primitives import lookup_device_by_name
@@ -325,7 +390,7 @@ class PreviewRunner:
         return None
 
 
-def _compare_adapter_rows(runner, rows, apply_row):
+def _compare_adapter_rows(runner, rows, apply_row, *, uncomparable_outcomes=()):
     """Classify adapter-only rows one at a time.
 
     The bulk models hand a whole batch to a classifier that returns counts. The
@@ -364,6 +429,13 @@ def _compare_adapter_rows(runner, rows, apply_row):
             # confident-zero failure this feature exists to prevent.
             counts["rejected"] += 1
             continue
+        if outcome in uncomparable_outcomes:
+            # This row is a change the count keys cannot express - a delete,
+            # for the one path that has them. Declining the whole model keeps
+            # its upper bound, which is honest; folding it into creates or
+            # updates would be counted twice against the separate delete
+            # accounting, and unchanged would be a confident zero.
+            return None
         if outcome is False or outcome is None:
             counts["rejected"] += 1
             continue
@@ -388,6 +460,31 @@ def _compare_dcim_cable(runner, rows):
     return _compare_adapter_rows(runner, rows, apply_dcim_cable)
 
 
+def _compare_dcim_inventoryitem(runner, rows):
+    """Compare inventory items, unless the batch contains a deletion.
+
+    A module-native row on a deployment with `dcim.module` enabled is DELETED
+    by the apply, not upserted, and this comparison's contract has no slot for
+    a delete - the report reads drift as `creates + updates` and accounts for
+    deletes separately. Rather than fold it into either bucket, one such row
+    declines the whole model, which keeps its honest upper bound.
+
+    The refusal is scoped to batches that actually contain one, so deployments
+    without module-native inventory still get a real measurement. That is the
+    whole reason it is detected per row rather than per deployment.
+    """
+    from .sync_inventory_module import MODULE_NATIVE_ROW_NOT_COMPARABLE
+    from .sync_inventory_module import apply_dcim_inventoryitem
+
+    counts = _compare_adapter_rows(
+        runner,
+        rows,
+        apply_dcim_inventoryitem,
+        uncomparable_outcomes=(MODULE_NATIVE_ROW_NOT_COMPARABLE,),
+    )
+    return counts
+
+
 # Adapter-only models that can be compared, and the function that does it.
 #
 # Absence from this mapping is the "no comparison" answer for a model, which is
@@ -399,6 +496,7 @@ def _compare_dcim_cable(runner, rows):
 _ADAPTER_COMPARISONS = {
     "extras.taggeditem": _compare_extras_taggeditem,
     "dcim.cable": _compare_dcim_cable,
+    "dcim.inventoryitem": _compare_dcim_inventoryitem,
 }
 
 

--- a/forward_netbox/utilities/sync_inventory_module.py
+++ b/forward_netbox/utilities/sync_inventory_module.py
@@ -84,7 +84,29 @@ def delete_dcim_module(runner, row):
     )
 
 
-def apply_dcim_inventoryitem(runner, row):
+MODULE_NATIVE_ROW_NOT_COMPARABLE = "module-native-row-not-comparable"
+
+
+def apply_dcim_inventoryitem(runner, row, *, preview=False):
+    """Upsert the inventory item, or - with ``preview`` - classify and write.
+
+    ``preview`` returns ``"creates"``, ``"updates"``, ``"unchanged"``, ``False``
+    for a row this declines, or ``MODULE_NATIVE_ROW_NOT_COMPARABLE``.
+
+    The writes are all behind ``runner.`` calls - ``_ensure_manufacturer``,
+    ``_ensure_inventory_item_role`` and ``_upsert_values_from_defaults`` - so
+    unlike cables the preview runner's firewall covers them and this flag only
+    has to handle the one branch that is not an upsert at all.
+
+    That branch is why the sentinel exists. When ``dcim.module`` is enabled a
+    module-native row is DELETED rather than upserted, and the comparison
+    contract has no slot for a delete: the report computes drift as
+    ``creates + updates`` and counts deletes separately. Calling it an update
+    would double-count it against that separate accounting; calling it
+    unchanged would be a confident zero; calling it rejected would report a
+    perfectly good row as unusable. So the row says it cannot be compared and
+    the caller declines the whole model, which keeps its upper bound.
+    """
     from dcim.models import InventoryItem
 
     try:
@@ -108,6 +130,8 @@ def apply_dcim_inventoryitem(runner, row):
     if runner.sync.is_model_enabled(
         "dcim.module"
     ) and runner._is_module_native_inventory_row(row):
+        if preview:
+            return MODULE_NATIVE_ROW_NOT_COMPARABLE
         return None if delete_dcim_inventoryitem(runner, row) else False
     manufacturer = None
     if row.get("manufacturer"):
@@ -115,7 +139,7 @@ def apply_dcim_inventoryitem(runner, row):
             {"name": row["manufacturer"], "slug": row["manufacturer_slug"]}
         )
     role = runner._ensure_inventory_item_role(row)
-    runner._upsert_values_from_defaults(
+    _, created = runner._upsert_values_from_defaults(
         "dcim.inventoryitem",
         InventoryItem,
         values={
@@ -140,6 +164,10 @@ def apply_dcim_inventoryitem(runner, row):
             ],
         ),
     )
+    if preview:
+        if created:
+            return "creates"
+        return "updates" if runner.last_upsert_would_change else "unchanged"
 
 
 def apply_dcim_module(runner, row):


### PR DESCRIPTION
## Summary

Slice three of eight toward #206's remaining scope. **Stacked on #290** — base
is `feat/cable-drift-comparison`, so this diff shows only the inventory work.
Review order: #289 → #290 → this.

## The writes were the easy half

All three are behind `runner.` calls, so the firewall covers them and the
`preview` flag does not have to. `_ensure_inventory_item_role` is a new
override and is the same trap as `_ensure_vrf`: an upsert reached during
classification that a grep for ORM calls cannot see.

## The delete branch is not a write problem — it is a counting one

When `dcim.module` is enabled, a module-native inventory row is **deleted**
rather than upserted. Suppressing the delete is trivial. What to *count* is not:

- the report reads drift as `creates + updates` (`views.py:513`) and accounts
  for deletes **separately**, so counting it as an update double-counts it;
- `unchanged` is a confident zero for a row that will change;
- `rejected` reports a perfectly good row as unusable and feeds
  `comparison_rejected_rows`, which means something else.

There is no honest bucket, so the row declines and the model keeps its upper
bound — the documented "no comparison" answer, and the only one that cannot
mislead in either direction.

**The refusal is scoped to batches that actually contain such a row.** A
deployment without module-native inventory still gets a real measurement, and
one with `dcim.module` disabled is unaffected because the branch is gated on
it. Both are pinned by tests — the second specifically so the gate is not
"simplified" away later and the model silently dropped for everyone.

Declining the **model**, not the row, is deliberate: a partial count would
understate drift by however many rows were dropped, silently.

## Test plan

- [x] 12 new tests; **325 green** across three adapter suites, the bulk drift
      suite, the preview contract/priming suites, and `ForwardSyncRunnerTest`
- [x] pre-commit clean; `check_harness.py --base origin/main` passes
- [x] **Negative controls run separately:** making `_ensure_inventory_item_role`
      write failed `test_a_preview_creates_no_inventory_item_role`; removing the
      decline failed `test_a_module_native_row_declines_the_whole_model` and
      `test_one_module_native_row_declines_the_batch_it_is_in`.

## Open question worth a maintainer's view

**Should the comparison carry deletes at all?** Today it cannot express one, and
this is the first path where that costs a measurement. If a later slice hits the
same wall, a fifth count key plus the `views.py`/report changes to consume it is
probably right — but it should be its own change, with the double-counting
question against the existing delete accounting settled first.

Refs #206

Claude-Session: https://claude.ai/code/session_012Qfd3hTSxZtmFHuzRJnZre