### PR TITLE
feat: measure drift for FHRP groups

### DIFF
--- a/docs/03_Plans/active/2026-08-24-adapter-model-drift-fhrpgroup.md
+++ b/docs/03_Plans/active/2026-08-24-adapter-model-drift-fhrpgroup.md
@@ -1,0 +1,113 @@
+# Measure drift for FHRP groups
+
+## Goal
+
+Slice four of the adapter-only drift comparison: `ipam.fhrpgroup`.
+
+## Why
+
+Unchanged. Every adapter-only model reports an upper bound, so `in_sync` stays
+unanswerable while any of the eight is uncompared.
+
+## Constraints
+
+- Reuse the apply's own resolution and comparisons.
+- Write nothing - and this path writes in three places, two of them direct.
+- A row the apply refuses must not read as drift.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/sync_ipam.py` - `apply_ipam_fhrpgroup` and
+  `_ensure_fhrp_vip` gain `preview`
+- `forward_netbox/utilities/drift_comparison.py` -
+  `_coalesce_update_or_create` override, and the dispatch entry
+- `forward_netbox/tests/test_fhrpgroup_drift_comparison.py` (new)
+
+## Approach
+
+### Three objects, one verdict
+
+A single row means up to three persisted objects: the `FHRPGroup`, its
+virtual-IP `IPAddress`, and the `FHRPGroupAssignment` binding it to an
+interface. The row's verdict is the strongest of the three - a create if any
+would be created, an update if any would be rewritten, unchanged only when all
+three already match. Anything less would under-report: a group that exists with
+a drifted VIP is drift.
+
+### The other upsert primitive
+
+`_upsert_values_from_defaults` funnels into `coalesce_update_or_create`, but
+FHRP calls `runner._coalesce_update_or_create` DIRECTLY with explicit lookups,
+for both the group and the assignment. Overriding only the first left the
+firewall with a hole exactly where the caller was most explicit about what it
+was writing. Both are overridden now.
+
+### Three writes, two of them direct
+
+- the group and the assignment go through `_coalesce_update_or_create`
+  (covered by the new override);
+- the VIP saves directly inside `_ensure_fhrp_vip`, on both its create and its
+  update branch;
+- the canonical-name migration is a direct `group.save(update_fields=["name"])`
+  in the apply itself.
+
+The rollback `group.delete()` is unreachable under preview, because nothing is
+ever created to roll back.
+
+### The refusals
+
+A VIP owned by another kind of object is a conflict the apply refuses -
+`rejected`. A VIP shared with another FHRP GROUP is different and deliberately
+so: the apply leaves it where it is, writes nothing for it, and still creates
+the group and assignment. That is the fix for the 13-group add/remove churn
+this module documents, so the comparison must call it `unchanged` rather than a
+perpetual update.
+
+## Validation
+
+12 tests. Three write guards, three separate negative controls, all confirmed
+failing without their guard.
+
+**One of those controls found a real coverage gap rather than confirming a
+test.** Removing the VIP-create guard broke nothing: when the group is absent
+the row short-circuits to a create before `_ensure_fhrp_vip` is ever called, so
+the guard was unreachable in every test that existed. The case that reaches it
+- group present, VIP absent - was missing.
+`test_a_group_present_without_its_vip_creates_no_address` now covers it, and
+re-running the same control against it fails as it should. A control that
+passes is a finding, not a pass.
+
+**And the sweep caught a real regression in the apply path.** Reading
+`runner.last_upsert_would_change` unconditionally raised `AttributeError` on
+the real runner - that attribute exists only on the preview runner - breaking
+fourteen existing FHRP tests. It is now read only under `preview`. Worth
+recording because the unit tests for this slice all passed while it was broken:
+they only ever exercise the preview runner. The existing apply tests are what
+caught it, which is the argument for running the whole module rather than the
+new file.
+
+Full run: 412 tests green, including all of `test_sync`.
+
+## Rollback
+
+Remove `ipam.fhrpgroup` from `_ADAPTER_COMPARISONS`. `preview` defaults to
+`False` on both functions. The `_coalesce_update_or_create` override should
+stay - it corrects the firewall regardless of which models are wired up.
+
+## Decision Log
+
+- **Strongest-of-three for the row verdict.** Any weaker rule under-reports,
+  and under-reporting drift is the failure this feature exists to prevent.
+- **A shared VIP is `unchanged`, not an update.** The apply writes nothing for
+  it by design; calling it drift would make the report show a difference that
+  every subsequent run also shows.
+- **Override both upsert primitives.** One override is a firewall with a hole
+  in it.
+
+## Open
+
+- Four models remain: lifecycle (netbox-dlm), modules, peering, routing.
+- Modules next: `Module.save()` with `_adopt_components` makes NetBox core
+  instantiate component rows, beneath Manufacturer/ModuleType/ModuleBay writes.
+- Routing and peering last, and together.
+- The delete question from the inventory slice is unchanged and still open.

--- a/forward_netbox/tests/test_fhrpgroup_drift_comparison.py
+++ b/forward_netbox/tests/test_fhrpgroup_drift_comparison.py
@@ -1,0 +1,259 @@
+# Slice four of the adapter-only drift comparison: `ipam.fhrpgroup`.
+#
+# One row means up to THREE persisted objects - the FHRPGroup, its virtual-IP
+# IPAddress, and the FHRPGroupAssignment binding it to an interface - so the
+# row's verdict is the strongest of the three. Unchanged only when all three
+# already match.
+#
+# The writes come in both shapes seen so far: the group and the assignment go
+# through `runner._coalesce_update_or_create` (the OTHER upsert primitive,
+# newly overridden here), while the VIP saves directly inside
+# `_ensure_fhrp_vip` and the canonical-name migration is a direct
+# `group.save()`.
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import Interface
+from dcim.models import Manufacturer
+from dcim.models import Site
+from django.test import TestCase
+from ipam.models import FHRPGroup
+from ipam.models import FHRPGroupAssignment
+from ipam.models import IPAddress
+
+from forward_netbox.utilities.drift_comparison import compare_model_rows
+
+
+class FhrpGroupPreviewTest(TestCase):
+    def setUp(self):
+        site = Site.objects.create(name="F Site", slug="f-site")
+        mfr = Manufacturer.objects.create(name="F Mfr", slug="f-mfr")
+        dtype = DeviceType.objects.create(manufacturer=mfr, model="F DT", slug="f-dt")
+        role = DeviceRole.objects.create(name="F Role", slug="f-role")
+        self.device = Device.objects.create(
+            name="fhrp-dev", site=site, device_type=dtype, role=role, status="active"
+        )
+        self.interface = Interface.objects.create(
+            device=self.device, name="Vlan100", type="virtual"
+        )
+
+    def _row(self, **extra):
+        row = {
+            "device": "fhrp-dev",
+            "interface": "Vlan100",
+            "group_id": 100,
+            "protocol": "hsrp",
+            "address": "10.0.0.1/24",
+            "status": "active",
+            "priority": 100,
+        }
+        row.update(extra)
+        return row
+
+    def _existing(self, *, priority=100, status="active", name=None):
+        group = FHRPGroup.objects.create(
+            protocol="hsrp",
+            group_id=100,
+            name=name or "hsrp-100-10.0.0.1",
+            description="Forward FHRP group",
+            comments="",
+        )
+        from django.contrib.contenttypes.models import ContentType
+
+        IPAddress.objects.create(
+            address="10.0.0.1/24",
+            status=status,
+            role="hsrp",
+            assigned_object_type=ContentType.objects.get_for_model(FHRPGroup),
+            assigned_object_id=group.pk,
+        )
+        FHRPGroupAssignment.objects.create(
+            interface_type=ContentType.objects.get_for_model(Interface),
+            interface_id=self.interface.pk,
+            group=group,
+            priority=priority,
+        )
+        return group
+
+    # --- the negative space -------------------------------------------------
+
+    def test_a_preview_creates_no_group_vip_or_assignment(self):
+        groups = FHRPGroup.objects.count()
+        addresses = IPAddress.objects.count()
+        assignments = FHRPGroupAssignment.objects.count()
+
+        result = compare_model_rows(None, "ipam.fhrpgroup", [self._row()])
+
+        self.assertEqual(FHRPGroup.objects.count(), groups)
+        self.assertEqual(IPAddress.objects.count(), addresses)
+        self.assertEqual(FHRPGroupAssignment.objects.count(), assignments)
+        self.assertEqual(result["creates"], 1)
+
+    def test_a_preview_does_not_rewrite_a_drifted_vip(self):
+        self._existing(status="deprecated")
+
+        result = compare_model_rows(None, "ipam.fhrpgroup", [self._row()])
+
+        self.assertEqual(
+            IPAddress.objects.get(address="10.0.0.1/24").status, "deprecated"
+        )
+        self.assertEqual(result["updates"], 1)
+
+    def test_a_preview_does_not_migrate_a_group_name(self):
+        # The apply rewrites a group's name to canonical form with a direct
+        # `group.save(update_fields=["name"])`.
+        group = self._existing(name="Legacy Name")
+
+        compare_model_rows(None, "ipam.fhrpgroup", [self._row()])
+
+        group.refresh_from_db()
+        self.assertEqual(group.name, "Legacy Name")
+
+    def test_a_preview_does_not_rewrite_an_assignment_priority(self):
+        group = self._existing(priority=50)
+
+        result = compare_model_rows(None, "ipam.fhrpgroup", [self._row()])
+
+        assignment = FHRPGroupAssignment.objects.get(group=group)
+        self.assertEqual(assignment.priority, 50)
+        self.assertEqual(result["updates"], 1)
+
+    # --- classification -----------------------------------------------------
+
+    def test_an_absent_group_is_a_create(self):
+        result = compare_model_rows(None, "ipam.fhrpgroup", [self._row()])
+
+        self.assertEqual(
+            result, {"creates": 1, "updates": 0, "unchanged": 0, "rejected": 0}
+        )
+
+    def test_a_fully_matching_row_is_unchanged(self):
+        self._existing()
+
+        result = compare_model_rows(None, "ipam.fhrpgroup", [self._row()])
+
+        self.assertEqual(
+            result, {"creates": 0, "updates": 0, "unchanged": 1, "rejected": 0}
+        )
+
+    def test_a_group_present_without_its_assignment_is_a_create(self):
+        # The group and VIP exist but this interface is not bound to it, so the
+        # assignment is genuinely new.
+        from django.contrib.contenttypes.models import ContentType
+
+        group = FHRPGroup.objects.create(
+            protocol="hsrp",
+            group_id=100,
+            name="hsrp-100-10.0.0.1",
+            description="Forward FHRP group",
+            comments="",
+        )
+        IPAddress.objects.create(
+            address="10.0.0.1/24",
+            status="active",
+            role="hsrp",
+            assigned_object_type=ContentType.objects.get_for_model(FHRPGroup),
+            assigned_object_id=group.pk,
+        )
+
+        result = compare_model_rows(None, "ipam.fhrpgroup", [self._row()])
+
+        self.assertEqual(result["creates"], 1)
+
+    def test_a_group_present_without_its_vip_creates_no_address(self):
+        """The VIP-create guard is only reachable through this shape.
+
+        When the group is absent the row short-circuits to a create before
+        `_ensure_fhrp_vip` is ever called, so the guard inside it is dead code
+        for every other test here. A negative control found that: removing the
+        guard broke nothing until this case existed.
+        """
+        FHRPGroup.objects.create(
+            protocol="hsrp",
+            group_id=100,
+            name="hsrp-100-10.0.0.1",
+            description="Forward FHRP group",
+            comments="",
+        )
+        addresses = IPAddress.objects.count()
+
+        result = compare_model_rows(None, "ipam.fhrpgroup", [self._row()])
+
+        self.assertEqual(IPAddress.objects.count(), addresses)
+        self.assertEqual(result["creates"], 1)
+
+    def test_an_unknown_device_is_rejected(self):
+        result = compare_model_rows(
+            None, "ipam.fhrpgroup", [self._row(device="no-such-device")]
+        )
+
+        self.assertEqual(result["rejected"], 1)
+        self.assertEqual(result["creates"], 0)
+
+    def test_an_unknown_interface_is_rejected(self):
+        result = compare_model_rows(
+            None, "ipam.fhrpgroup", [self._row(interface="Vlan999")]
+        )
+
+        self.assertEqual(result["rejected"], 1)
+        self.assertEqual(result["creates"], 0)
+
+    def test_a_vip_owned_by_another_object_is_rejected_not_a_create(self):
+        # An address assigned to something that is not an FHRP group is a
+        # conflict the apply refuses, so it must not read as drift.
+        from django.contrib.contenttypes.models import ContentType
+
+        IPAddress.objects.create(
+            address="10.0.0.1/24",
+            status="active",
+            assigned_object_type=ContentType.objects.get_for_model(Interface),
+            assigned_object_id=self.interface.pk,
+        )
+        FHRPGroup.objects.create(
+            protocol="hsrp",
+            group_id=100,
+            name="hsrp-100-10.0.0.1",
+            description="Forward FHRP group",
+            comments="",
+        )
+
+        result = compare_model_rows(None, "ipam.fhrpgroup", [self._row()])
+
+        self.assertEqual(result["rejected"], 1)
+        self.assertEqual(result["creates"], 0)
+
+    def test_a_shared_vip_is_not_drift(self):
+        # Two groups legitimately share a VIP; the apply leaves it on the group
+        # that owns it and writes nothing for it. With the group and assignment
+        # already present the row is unchanged, not a perpetual update.
+        other = FHRPGroup.objects.create(
+            protocol="hsrp", group_id=200, name="hsrp-200-10.0.0.1"
+        )
+        from django.contrib.contenttypes.models import ContentType
+
+        IPAddress.objects.create(
+            address="10.0.0.1/24",
+            status="active",
+            role="hsrp",
+            assigned_object_type=ContentType.objects.get_for_model(FHRPGroup),
+            assigned_object_id=other.pk,
+        )
+        group = FHRPGroup.objects.create(
+            protocol="hsrp",
+            group_id=100,
+            name="hsrp-100-10.0.0.1",
+            description="Forward FHRP group",
+            comments="",
+        )
+        FHRPGroupAssignment.objects.create(
+            interface_type=ContentType.objects.get_for_model(Interface),
+            interface_id=self.interface.pk,
+            group=group,
+            priority=100,
+        )
+
+        result = compare_model_rows(None, "ipam.fhrpgroup", [self._row()])
+
+        self.assertEqual(result["rejected"], 0)
+        self.assertEqual(result["creates"], 0)
+        self.assertEqual(result["unchanged"], 1)

--- a/forward_netbox/utilities/drift_comparison.py
+++ b/forward_netbox/utilities/drift_comparison.py
@@ -351,6 +351,58 @@ class PreviewRunner:
         )
         return obj, False
 
+    def _coalesce_update_or_create(
+        self,
+        model,
+        *,
+        coalesce_lookups,
+        create_values,
+        update_values=None,
+        conflict_policy="strict",
+        return_change=False,
+        create_instance_attrs=None,
+    ):
+        """The other upsert primitive, read-only.
+
+        `_upsert_values_from_defaults` funnels into this one, but several
+        adapter paths - FHRP groups and their assignments among them - call it
+        directly with explicit lookups rather than coalesce sets. Both have to
+        be overridden or the firewall has a hole exactly where the caller was
+        most explicit about what it was writing.
+
+        Returns the same shape the real one does, with ``created`` reporting
+        what WOULD happen, and records the field comparison on
+        ``last_upsert_would_change``.
+        """
+        from .sync_primitives import _authoritative_update_values
+        from .sync_primitives import _model_field_value_matches
+        from .sync_primitives import get_unique_or_raise
+
+        obj = None
+        for lookup in coalesce_lookups or []:
+            if not lookup:
+                continue
+            obj = get_unique_or_raise(self, model, lookup)
+            if obj is not None:
+                break
+        if obj is None:
+            self.last_upsert_would_change = False
+            if return_change:
+                return None, True, True
+            return None, True
+        values = create_values if update_values is None else update_values
+        changed = any(
+            not _model_field_value_matches(model, obj, field, value)
+            for field, value in _authoritative_update_values(
+                model._meta.label_lower,
+                values,
+            ).items()
+        )
+        self.last_upsert_would_change = changed
+        if return_change:
+            return obj, False, changed
+        return obj, False
+
     def _ensure_vrf(self, row, *, update_existing=True):
         """Find the VRF, never create or update it.
 
@@ -460,6 +512,12 @@ def _compare_dcim_cable(runner, rows):
     return _compare_adapter_rows(runner, rows, apply_dcim_cable)
 
 
+def _compare_ipam_fhrpgroup(runner, rows):
+    from .sync_ipam import apply_ipam_fhrpgroup
+
+    return _compare_adapter_rows(runner, rows, apply_ipam_fhrpgroup)
+
+
 def _compare_dcim_inventoryitem(runner, rows):
     """Compare inventory items, unless the batch contains a deletion.
 
@@ -497,6 +555,7 @@ _ADAPTER_COMPARISONS = {
     "extras.taggeditem": _compare_extras_taggeditem,
     "dcim.cable": _compare_dcim_cable,
     "dcim.inventoryitem": _compare_dcim_inventoryitem,
+    "ipam.fhrpgroup": _compare_ipam_fhrpgroup,
 }
 
 

--- a/forward_netbox/utilities/sync_ipam.py
+++ b/forward_netbox/utilities/sync_ipam.py
@@ -249,7 +249,19 @@ def _find_fhrp_group_by_vip(runner, host_ip, vrf, protocol, group_id):
     ).first()
 
 
-def _ensure_fhrp_vip(runner, row, *, group, vrf, protocol):
+def _ensure_fhrp_vip(runner, row, *, group, vrf, protocol, preview=False):
+    """Attach the virtual IP, or - with ``preview`` - say what would happen.
+
+    Under ``preview`` returns ``"creates"``, ``"updates"``, ``"unchanged"`` or
+    ``False``, and performs neither of this function's two DIRECT saves. Both
+    are outside any ``runner.`` call, so the preview runner's firewall does not
+    reach them - the same shape as cables.
+
+    The two skip paths keep their meaning: a VIP already owned by ANOTHER FHRP
+    group is a legitimate shared VIP and still lets the group and assignment
+    proceed, and a VIP owned by some other kind of object is a conflict the
+    apply refuses.
+    """
     from ipam.models import FHRPGroup
     from ipam.models import IPAddress
 
@@ -262,6 +274,8 @@ def _ensure_fhrp_vip(runner, row, *, group, vrf, protocol):
         {"address__net_host": host_ip, "vrf": vrf},
     )
     if existing is None:
+        if preview:
+            return "creates"
         ip_address = IPAddress(
             address=row["address"],
             vrf=vrf,
@@ -304,7 +318,10 @@ def _ensure_fhrp_vip(runner, row, *, group, vrf, protocol):
                 ),
                 sample=f"{row.get('device')}/group {row['group_id']}",
             )
-            return True
+            # A shared VIP is not drift: the apply deliberately leaves it on the
+            # group that owns it and writes nothing here, while still letting
+            # the group and its assignment proceed.
+            return "unchanged" if preview else True
         runner._record_aggregated_skip_warning(
             model_string="ipam.fhrpgroup",
             reason="vip-conflict",
@@ -330,13 +347,32 @@ def _ensure_fhrp_vip(runner, row, *, group, vrf, protocol):
         existing.assigned_object_type = desired_assigned_object_type
         existing.assigned_object_id = desired_assigned_object_id
         update_fields.extend(["assigned_object_type", "assigned_object_id"])
+    if preview:
+        # Computed from the same field comparisons the apply just made, before
+        # the save rather than after it.
+        return "updates" if update_fields else "unchanged"
     if update_fields:
         existing.full_clean()
         existing.save(update_fields=update_fields)
     return True
 
 
-def apply_ipam_fhrpgroup(runner, row):
+def apply_ipam_fhrpgroup(runner, row, *, preview=False):
+    """Apply the FHRP group, or - with ``preview`` - classify and write nothing.
+
+    A single row means up to THREE persisted objects: the `FHRPGroup`, its
+    virtual-IP `IPAddress`, and the `FHRPGroupAssignment` binding it to an
+    interface. The row's verdict is the strongest of the three - a create if
+    any would be created, an update if any would be rewritten, unchanged only
+    when all three already match.
+
+    Writes come in both shapes here. The group and the assignment go through
+    `runner._coalesce_update_or_create`, which the preview runner overrides;
+    the VIP saves directly inside `_ensure_fhrp_vip`, and the canonical-name
+    migration is a direct `group.save()` right here. The rollback
+    `group.delete()` is unreachable under preview because nothing is ever
+    created to roll back.
+    """
     from dcim.models import Interface
     from ipam.models import FHRPGroup
     from ipam.models import FHRPGroupAssignment
@@ -397,11 +433,14 @@ def apply_ipam_fhrpgroup(runner, row):
         if host_ip
         else None
     )
+    group_would_change = False
     if group is not None:
         # Migrate name to canonical form if it changed (e.g. VRF appeared).
         if group.name != group_name:
-            group.name = group_name
-            group.save(update_fields=["name"])
+            group_would_change = True
+            if not preview:
+                group.name = group_name
+                group.save(update_fields=["name"])
     else:
         group, group_created = runner._coalesce_update_or_create(
             FHRPGroup,
@@ -424,14 +463,50 @@ def apply_ipam_fhrpgroup(runner, row):
                 "comments": "",
             },
         )
+        if preview:
+            if group is None:
+                # Preview only: the shim reports what WOULD be created and
+                # returns no object. Nothing downstream can be resolved against
+                # a group NetBox does not have - not its VIP, not its
+                # assignment - so the whole row is a create and there is
+                # nothing further to inspect.
+                return "creates"
+            # `last_upsert_would_change` exists only on the preview runner.
+            # Reading it unconditionally raised AttributeError on the real one
+            # and broke fourteen existing FHRP tests.
+            group_would_change = group_would_change or runner.last_upsert_would_change
 
-    vip_applied = _ensure_fhrp_vip(
+    vip_outcome = _ensure_fhrp_vip(
         runner,
         row,
         group=group,
         vrf=vrf,
         protocol=protocol,
+        preview=preview,
     )
+    if preview:
+        if vip_outcome is False:
+            # The VIP belongs to some other kind of object; the apply refuses
+            # the row and writes nothing.
+            return False
+        assignment_lookup = {
+            "interface_type": runner._content_type_for(Interface),
+            "interface_id": interface.pk,
+            "group": group,
+        }
+        assignment = runner._get_unique_or_raise(FHRPGroupAssignment, assignment_lookup)
+        if assignment is None:
+            return "creates"
+        assignment_would_change = int(getattr(assignment, "priority", 0) or 0) != int(
+            row.get("priority") or 100
+        )
+        if vip_outcome == "creates":
+            return "creates"
+        if vip_outcome == "updates" or group_would_change or assignment_would_change:
+            return "updates"
+        return "unchanged"
+
+    vip_applied = vip_outcome
     if not vip_applied:
         if (
             group_created


### PR DESCRIPTION
## Summary

Slice four of eight toward #206's remaining scope, and the most tangled so far.
**Stacked on #291.** Review order: #289 → #290 → #291 → this.

A single row means up to **three** persisted objects — the `FHRPGroup`, its
virtual-IP `IPAddress`, and the `FHRPGroupAssignment`. The row's verdict is the
strongest of the three: a create if any would be created, an update if any
would be rewritten, unchanged only when all three match. Anything weaker
under-reports — a group that exists with a drifted VIP *is* drift.

## Both upsert primitives now overridden

FHRP calls `runner._coalesce_update_or_create` **directly** with explicit
lookups, for both the group and the assignment. Overriding only
`_upsert_values_from_defaults` left the firewall with a hole exactly where the
caller was most explicit about what it was writing.

## The refusals

A VIP owned by another kind of object is a conflict the apply refuses →
`rejected`. A VIP shared with another FHRP **group** is deliberately different:
the apply leaves it in place, writes nothing, and still creates the group and
assignment — that is the fix for the 13-group add/remove churn this module
documents — so it is `unchanged`, not a perpetual update.

## Two findings from verification, not from writing the code

**A negative control passed — which is a finding, not a pass.** Removing the
VIP-create guard broke nothing, because when the group is absent the row
short-circuits before `_ensure_fhrp_vip` is ever called; the guard was
unreachable in every test that existed. The case that reaches it (group present,
VIP absent) was missing. It now exists, and the same control fails against it.

**The sweep caught a real regression in the apply path.**
`runner.last_upsert_would_change` exists only on the preview runner, and reading
it unconditionally raised `AttributeError` on the real one — breaking fourteen
existing FHRP tests. Every unit test for this slice passed while that was
broken, because they only exercise the preview runner. The **existing apply
tests** caught it, which is the argument for running the whole module rather
than just the new file.

## Test plan

- [x] 12 new tests; **412 green**, including all of `test_sync`
- [x] pre-commit clean; `check_harness.py --base origin/main` passes
- [x] Three write guards, three separate negative controls, each confirmed
      failing without its guard (after the coverage gap above was closed)

## Rollback

Remove `ipam.fhrpgroup` from `_ADAPTER_COMPARISONS`. The
`_coalesce_update_or_create` override should stay — it corrects the firewall
regardless of which models are wired up.

Refs #206

Claude-Session: https://claude.ai/code/session_012Qfd3hTSxZtmFHuzRJnZre