### PR TITLE
feat: measure drift for modules, including the components NetBox creates

### DIFF
--- a/docs/03_Plans/active/2026-08-24-adapter-model-drift-module.md
+++ b/docs/03_Plans/active/2026-08-24-adapter-model-drift-module.md
@@ -1,0 +1,106 @@
+# Measure drift for modules
+
+## Goal
+
+Slice five of the adapter-only drift comparison: `dcim.module`.
+
+## Why
+
+Unchanged. `in_sync` stays unanswerable while any adapter model is uncompared.
+
+## Constraints
+
+- Reuse the apply's own resolution and comparator.
+- Write nothing - including writes NetBox core performs on our behalf.
+- A row the apply skips must not read as drift.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/sync_inventory_module.py` - `apply_dcim_module`
+  gains `preview`
+- `forward_netbox/utilities/drift_comparison.py` - `_lookup_module_bay`,
+  `_ensure_module_bay`, `_ensure_module_type`, dispatch entry
+- `forward_netbox/tests/test_module_drift_comparison.py` (new)
+
+## Approach
+
+### The write that is not ours
+
+Every write on this path is behind a `runner.` call, so the firewall covers
+them: `_ensure_module_bay` upserts a `ModuleBay`, `_ensure_module_type` upserts
+a `ModuleType` and a `Manufacturer` beneath it, and the module itself goes
+through `_upsert_values_from_defaults`.
+
+What makes this slice different is what that last call does. It passes
+`create_instance_attrs={"_adopt_components": True}`, and NetBox core's
+`Module.save()` then walks the module type's component templates and
+instantiates them - console ports, interfaces, power ports, module bays - as
+real rows on the device. So a preview that reached the save would not create
+one row; it would create a dozen, on hardware the operator only asked a
+question about.
+
+The existing override never saves, and it accepts and ignores
+`create_instance_attrs` for exactly this reason. The assertion that proves it
+counts `Interface` rows before and after with an `InterfaceTemplate` present:
+under a negative control that made the shim write, that count went 0 -> 1, so
+the test catches the component instantiation specifically and not merely the
+module row.
+
+### Absent dependencies short-circuit
+
+The preview runner resolves rather than creates, so an absent bay or module
+type comes back `None`. The row is then unambiguously a create - a module
+cannot already exist in a bay NetBox does not have, or with a type it does not
+have - and short-circuiting also avoids a coalesce lookup on a null dependency
+matching some unrelated row.
+
+### The skip is not drift
+
+A module type whose templates would create a component name already claimed by
+a DIFFERENT module cannot be applied: NetBox adopts only components belonging
+to no module, so the template instantiation trips the per-device unique-name
+constraint. The apply reports and skips. The comparison counts it `rejected`,
+because a row the apply refuses is not a difference between the two systems -
+counting it as a create would show drift that no run could ever clear.
+
+## Validation
+
+11 tests. Two negative controls, each confirmed failing without its guard:
+
+- Making the upsert shim write for real failed
+  `test_a_preview_instantiates_no_components` (on the Interface count, 1 != 0 -
+  the component instantiation itself), plus the two drifted-module tests.
+- Disabling the unadoptable-component detection failed
+  `test_a_component_claimed_by_another_module_is_rejected_not_a_create`,
+  confirming that test is not passing vacuously - it was written defensively
+  enough that it could have been.
+
+Full run: 416 tests green, including `test_module_readiness` and all of
+`test_sync`.
+
+## Rollback
+
+Remove `dcim.module` from `_ADAPTER_COMPARISONS`. `preview` defaults to
+`False`, so the apply is unchanged for every existing caller.
+
+## Decision Log
+
+- **Assert on component rows, not just the module row.** The module row is the
+  obvious thing to count and the least informative: the damage a preview could
+  do here is the components NetBox core creates underneath it.
+- **Short-circuit absent bay/type rather than resolving further.** Consistent
+  with every prior slice, and it avoids a null-dependency coalesce lookup.
+- **The unadoptable-component skip is `rejected`.** Same reasoning as the LAG
+  endpoint in cables: a row the apply permanently refuses must not be reported
+  as drift a future run will fix.
+
+## Open
+
+- Three models remain: lifecycle (netbox-dlm), peering, routing.
+- Routing and peering last and together: peering is 30 lines but calls
+  `_ensure_netbox_routing_bgppeer` first, inheriting a 7-deep write chain
+  (VRF, two ASNs, an RIR, an IPAddress, BGPRouter, BGPScope, then the peer).
+- netbox-dlm is 7 sub-models with cross-dependencies and an M2M inside a
+  transaction; it has its own test modules, which makes it self-contained but
+  not small.
+- The delete question from the inventory slice is unchanged and still open.

--- a/docs/03_Plans/active/2026-08-24-adapter-model-drift-review-fixes.md
+++ b/docs/03_Plans/active/2026-08-24-adapter-model-drift-review-fixes.md
@@ -1,0 +1,149 @@
+# Review fixes for the adapter-model drift stack
+
+## Goal
+
+Correct six defects found by reviewing the five-slice adapter-model drift stack
+(#289-#293) as one cumulative diff, before any of it merges.
+
+## Why
+
+The stack was built slice by slice, each with its own negative controls, and
+each slice passed. Reviewing the five together surfaced defects that no single
+slice's tests could have shown - three of them the same shape: the preview and
+the apply disagreeing about the same row, in a direction that reports drift no
+run will ever clear.
+
+## Constraints
+
+- Each fix must leave the apply path byte-identical in behaviour; these are
+  preview-side corrections plus one shared-instance bug that affected both.
+- No fix may depend on which models are wired into `_ADAPTER_COMPARISONS`.
+- Every fix needs a test that fails without it.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/sync_ipam.py` - compute the VIP diff before
+  mutating
+- `forward_netbox/utilities/sync_inventory_module.py` - skip-check ordering,
+  identity-aware short-circuit, None-safe warning
+- `forward_netbox/utilities/drift_comparison.py` - cached/ambiguity-raising
+  module-type lookup, cleaned-name bay lookup, real coalesce fields
+- `forward_netbox/utilities/sync_interface.py` - remove leftover marker
+- tests for each
+
+## Approach
+
+Take the six defects in severity order, each with a test that fails first.
+Three share a root cause worth naming: the preview and the apply resolving the
+same row differently, in the direction that reports drift no run will clear.
+The rest are a mutated cache, a dead marker, and a wasted priming.
+
+## The fixes
+
+### 1. A cached object was mutated while measuring (found before review)
+
+`_ensure_fhrp_vip` assigned `existing.address`, `.status` and `.role` while
+computing what would change, and only then checked `preview`.
+`get_unique_or_raise` caches the resolved INSTANCE, so the next row resolving
+the same VIP got an already-corrected object and compared clean.
+
+Two routers in one HSRP group is the ordinary topology, not an exotic one, and
+the second one's drift silently disappeared. The diff is now computed into a
+list of `(field, value)` pairs and applied only on the write path.
+`test_two_devices_in_one_group_both_report_the_drifted_vip` failed `1 != 2`
+before the fix.
+
+### 2. The permanent-skip check ran after an absent-dependency short-circuit
+
+`apply_dcim_module` short-circuited on a missing `module_bay` BEFORE
+`_unadoptable_component_names`. But the apply creates the bay and then hits the
+collision and skips permanently, so the preview reported a create for a row no
+run will ever apply. The skip verdict does not depend on the bay existing, so
+it now comes first.
+
+Reordering exposed a second defect immediately: the skip's warning message
+dereferenced `module_bay.name`, which is `None` under preview because the
+preview resolves where the apply creates. It reads the name from the row now.
+
+### 3. An absent module type is not a create
+
+The short-circuit also fired on a missing `module_type`, justified as "a module
+cannot exist with a type NetBox does not have". That is wrong: the module's
+coalesce set is `("device", "module_bay")`, so the type is not part of its
+identity. A bay that already holds a module gets an UPDATE when the card is
+swapped for an unseen type. Only the bay short-circuits now.
+
+### 4. The module-type lookup threw away the priming
+
+`_ensure_module_type` issued a raw `ModuleType.objects.filter(...).first()` per
+row. `prime_dependency_lookup_caches` had already bulk-loaded exactly that
+lookup, so the priming was wasted and the per-row resolution cost 2.8.7 exists
+to remove was reintroduced for this model. It goes through
+`_get_unique_or_raise` now, which also RAISES on an ambiguous match where
+`.first()` silently took the lowest pk - letting a preview succeed on a row the
+apply refuses.
+
+### 5. The bay lookup missed the cleaned name
+
+The real `_ensure_module_bay` coalesces on `module_bay_plan_row(row)["name"]`,
+which is stripped and clipped. The override matched only the raw name, so a
+Forward `"Slot 1 "` missed a NetBox `"Slot 1"` and became a phantom create. It
+falls back to the cleaned name.
+
+### 6. The preview used default coalesce sets, not the operator's
+
+`_coalesce_sets_for` reads `_model_coalesce_fields`, which the real runner
+fills from resolved query specs (`sync_execution.py:115`). A preview never runs
+that resolution, so the dict stayed empty and every call fell back to the
+hard-coded defaults at the call site.
+
+An operator who narrows `dcim.inventoryitem` coalescing to `("device", "name")`
+because serials are unreliable gets an apply that resolves and updates the
+existing row, and a preview that misses it and reports a create - phantom
+drift on every such row, every run. Resolved lazily and memoised, falling back
+to the caller's defaults if a spec cannot be resolved.
+
+### 7. Test scaffolding left in production
+
+`# NEGATIVE-CONTROL-MARKER` in `sync_interface.py`, from this session's own
+negative control. Nothing referenced it. Removed.
+
+## Validation
+
+436 tests green across all five adapter suites, the bulk drift suite, the
+preview contract/priming/cost suites, `test_module_readiness` and all of
+`test_sync`.
+
+Two new tests pin the review findings directly:
+`test_a_claimed_component_is_rejected_even_when_the_bay_is_absent` (which
+errored on the `None` dereference before that was fixed too) and
+`test_a_swapped_card_in_an_existing_bay_is_an_update_not_a_create`.
+
+## Rollback
+
+Each fix is independent of the others and of which models are wired up. The
+`_conflict_policy`, `_coalesce_sets_for` and VIP-mutation fixes correct the
+preview runner and the apply respectively, and should survive any rollback of
+an individual model's dispatch entry.
+
+## Decision Log
+
+- **Review the stack cumulatively, not slice by slice.** Every slice passed its
+  own tests and its own negative controls. Three of these six defects are
+  disagreements between preview and apply that only a reader holding both sides
+  at once would notice.
+- **Resolve coalesce fields lazily rather than eagerly in `__init__`.** Only
+  the adapter models ask, and a spec lookup per model on every preview
+  construction would cost callers that never use it.
+
+## Open
+
+- The remaining review findings are lower severity and NOT fixed here: an empty
+  coalesce-lookup list classifies as "would create" where the apply raises
+  `ValueError` (a row with neither tag nor tag_slug); `.get()` versus indexing
+  makes preview and apply disagree about a malformed row (create versus
+  rejected); `_unadoptable_component_names` costs ~8 uncached queries per
+  module row. The first two are honest-but-wrong classifications of rows that
+  are already broken; the third is a cost question that wants a measurement
+  rather than a guess.
+- Three models still uncompared: lifecycle (netbox-dlm), peering, routing.

--- a/forward_netbox/tests/test_fhrpgroup_drift_comparison.py
+++ b/forward_netbox/tests/test_fhrpgroup_drift_comparison.py
@@ -182,6 +182,59 @@ class FhrpGroupPreviewTest(TestCase):
         self.assertEqual(IPAddress.objects.count(), addresses)
         self.assertEqual(result["creates"], 1)
 
+    def test_two_devices_in_one_group_both_report_the_drifted_vip(self):
+        """Two rows sharing a VIP must not launder each other's drift.
+
+        `get_unique_or_raise` caches the resolved object INSTANCE. If the
+        preview mutates that instance while computing what would change, the
+        next row to resolve the same VIP gets the already-corrected object and
+        compares clean - so a real difference is reported as unchanged. Two
+        routers in one HSRP group is the ordinary case, not an exotic one.
+        """
+        from django.contrib.contenttypes.models import ContentType
+
+        second = Device.objects.create(
+            name="fhrp-dev-b",
+            site=self.device.site,
+            device_type=self.device.device_type,
+            role=self.device.role,
+            status="active",
+        )
+        second_interface = Interface.objects.create(
+            device=second, name="Vlan100", type="virtual"
+        )
+        group = FHRPGroup.objects.create(
+            protocol="hsrp",
+            group_id=100,
+            name="hsrp-100-10.0.0.1",
+            description="Forward FHRP group",
+            comments="",
+        )
+        # The VIP is drifted: both rows want "active".
+        IPAddress.objects.create(
+            address="10.0.0.1/24",
+            status="deprecated",
+            role="hsrp",
+            assigned_object_type=ContentType.objects.get_for_model(FHRPGroup),
+            assigned_object_id=group.pk,
+        )
+        for interface in (self.interface, second_interface):
+            FHRPGroupAssignment.objects.create(
+                interface_type=ContentType.objects.get_for_model(Interface),
+                interface_id=interface.pk,
+                group=group,
+                priority=100,
+            )
+
+        result = compare_model_rows(
+            None,
+            "ipam.fhrpgroup",
+            [self._row(), self._row(device="fhrp-dev-b")],
+        )
+
+        self.assertEqual(result["updates"], 2)
+        self.assertEqual(result["unchanged"], 0)
+
     def test_an_unknown_device_is_rejected(self):
         result = compare_model_rows(
             None, "ipam.fhrpgroup", [self._row(device="no-such-device")]

--- a/forward_netbox/tests/test_module_drift_comparison.py
+++ b/forward_netbox/tests/test_module_drift_comparison.py
@@ -195,6 +195,67 @@ class ModulePreviewTest(TestCase):
         self.assertEqual(result["rejected"], 1)
         self.assertEqual(result["creates"], 0)
 
+    def test_a_claimed_component_is_rejected_even_when_the_bay_is_absent(self):
+        """The permanent-skip verdict does not depend on the bay existing.
+
+        The apply creates the missing bay and THEN hits the collision and skips,
+        so a preview that short-circuited on the absent bay reported a create
+        for a row no run will ever apply. Found by review; the sibling test
+        creates the bay first and so never covered this ordering.
+        """
+        module_type = self._module_type()
+        from dcim.models import InterfaceTemplate
+
+        InterfaceTemplate.objects.create(
+            module_type=module_type, name="Ethernet1/1", type="1000base-t"
+        )
+        other_bay = ModuleBay.objects.create(device=self.device, name="Slot 9")
+        other_module = Module.objects.create(
+            device=self.device,
+            module_bay=other_bay,
+            module_type=module_type,
+            status="active",
+        )
+        Interface.objects.filter(device=self.device, name="Ethernet1/1").update(
+            module=other_module
+        )
+        # Deliberately NO "Slot 1" bay.
+        self.assertFalse(
+            ModuleBay.objects.filter(device=self.device, name="Slot 1").exists()
+        )
+
+        result = compare_model_rows(None, "dcim.module", [self._row()])
+
+        self.assertEqual(result["creates"], 0)
+        self.assertEqual(result["rejected"], 1)
+
+    def test_a_swapped_card_in_an_existing_bay_is_an_update_not_a_create(self):
+        """`module_type` is not part of the module's identity.
+
+        The coalesce set is ("device", "module_bay"), so a bay that already
+        holds a module gets an UPDATE when the card is swapped for a type
+        NetBox has not seen yet. Treating an absent type as a create split
+        creates and updates wrongly for every hardware replacement.
+        """
+        bay = self._bay()
+        old_type = ModuleType.objects.create(
+            manufacturer=self.mfr, model="MT-OLD", part_number="", description=""
+        )
+        Module.objects.create(
+            device=self.device,
+            module_bay=bay,
+            module_type=old_type,
+            status="active",
+            serial="SN-1",
+        )
+        # The row names MT-1, which NetBox does not have.
+        self.assertFalse(ModuleType.objects.filter(model="MT-1").exists())
+
+        result = compare_model_rows(None, "dcim.module", [self._row()])
+
+        self.assertEqual(result["creates"], 0)
+        self.assertEqual(result["updates"], 1)
+
     def test_a_component_claimed_by_another_module_is_rejected_not_a_create(self):
         # NetBox can only adopt a component belonging to NO module. One already
         # claimed by a different module makes the template instantiation fail

--- a/forward_netbox/tests/test_module_drift_comparison.py
+++ b/forward_netbox/tests/test_module_drift_comparison.py
@@ -1,0 +1,233 @@
+# Slice five of the adapter-only drift comparison: `dcim.module`.
+#
+# Every write here is behind a `runner.` call, so the firewall covers them:
+# `_ensure_module_bay` (upserts a ModuleBay), `_ensure_module_type` (upserts a
+# ModuleType and a Manufacturer beneath it), `_upsert_values_from_defaults`.
+#
+# That last one is the one that matters. It passes
+# `create_instance_attrs={"_adopt_components": True}`, and NetBox core's
+# `Module.save()` then instantiates the module type's component templates -
+# interfaces, console ports, power ports - as real rows on the device. A
+# preview that saved would not create one row, it would create a dozen, on
+# hardware the operator only asked about.
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import Interface
+from dcim.models import Manufacturer
+from dcim.models import Module
+from dcim.models import ModuleBay
+from dcim.models import ModuleType
+from dcim.models import Site
+from django.test import TestCase
+
+from forward_netbox.utilities.drift_comparison import compare_model_rows
+
+
+class ModulePreviewTest(TestCase):
+    def setUp(self):
+        site = Site.objects.create(name="M Site", slug="m-site")
+        self.mfr = Manufacturer.objects.create(name="M Mfr", slug="m-mfr")
+        dtype = DeviceType.objects.create(
+            manufacturer=self.mfr, model="M DT", slug="m-dt"
+        )
+        role = DeviceRole.objects.create(name="M Role", slug="m-role")
+        self.device = Device.objects.create(
+            name="mod-dev", site=site, device_type=dtype, role=role, status="active"
+        )
+
+    def _row(self, **extra):
+        row = {
+            "device": "mod-dev",
+            "module_bay": "Slot 1",
+            "manufacturer": "M Mfr",
+            "manufacturer_slug": "m-mfr",
+            "model": "MT-1",
+            "status": "active",
+            "serial": "SN-1",
+        }
+        row.update(extra)
+        return row
+
+    def _module_type(self):
+        return ModuleType.objects.create(
+            manufacturer=self.mfr, model="MT-1", part_number="", description=""
+        )
+
+    def _bay(self):
+        return ModuleBay.objects.create(device=self.device, name="Slot 1")
+
+    # --- the negative space -------------------------------------------------
+
+    def test_a_preview_creates_no_module_bay_or_type(self):
+        bays = ModuleBay.objects.count()
+        types = ModuleType.objects.count()
+        modules = Module.objects.count()
+
+        result = compare_model_rows(None, "dcim.module", [self._row()])
+
+        self.assertEqual(ModuleBay.objects.count(), bays)
+        self.assertEqual(ModuleType.objects.count(), types)
+        self.assertEqual(Module.objects.count(), modules)
+        self.assertEqual(result["creates"], 1)
+
+    def test_a_preview_creates_no_manufacturer(self):
+        before = Manufacturer.objects.count()
+
+        compare_model_rows(
+            None,
+            "dcim.module",
+            [
+                self._row(
+                    manufacturer="Mfr That Does Not Exist",
+                    manufacturer_slug="mfr-that-does-not-exist",
+                )
+            ],
+        )
+
+        self.assertEqual(Manufacturer.objects.count(), before)
+
+    def test_a_preview_instantiates_no_components(self):
+        """The assertion this slice exists for.
+
+        With the bay and type both present, the apply would reach
+        `Module.save()` with `_adopt_components`, and NetBox core would
+        instantiate every component template on the module type as a real row
+        on the device. Counting interfaces before and after is what catches a
+        preview that got as far as the save.
+        """
+        self._bay()
+        module_type = self._module_type()
+        from dcim.models import InterfaceTemplate
+
+        InterfaceTemplate.objects.create(
+            module_type=module_type, name="Ethernet1/1", type="1000base-t"
+        )
+        interfaces_before = Interface.objects.count()
+        modules_before = Module.objects.count()
+
+        result = compare_model_rows(None, "dcim.module", [self._row()])
+
+        self.assertEqual(Interface.objects.count(), interfaces_before)
+        self.assertEqual(Module.objects.count(), modules_before)
+        self.assertEqual(result["creates"], 1)
+
+    def test_a_preview_does_not_rewrite_a_drifted_module(self):
+        bay = self._bay()
+        module_type = self._module_type()
+        module = Module.objects.create(
+            device=self.device,
+            module_bay=bay,
+            module_type=module_type,
+            status="active",
+            serial="OLD-SERIAL",
+        )
+
+        result = compare_model_rows(None, "dcim.module", [self._row()])
+
+        module.refresh_from_db()
+        self.assertEqual(module.serial, "OLD-SERIAL")
+        self.assertEqual(result["updates"], 1)
+
+    # --- classification -----------------------------------------------------
+
+    def test_an_absent_bay_is_a_create(self):
+        self._module_type()
+
+        result = compare_model_rows(None, "dcim.module", [self._row()])
+
+        self.assertEqual(
+            result, {"creates": 1, "updates": 0, "unchanged": 0, "rejected": 0}
+        )
+
+    def test_an_absent_module_type_is_a_create(self):
+        self._bay()
+
+        result = compare_model_rows(None, "dcim.module", [self._row()])
+
+        self.assertEqual(result["creates"], 1)
+
+    def test_a_matching_module_is_unchanged(self):
+        bay = self._bay()
+        module_type = self._module_type()
+        Module.objects.create(
+            device=self.device,
+            module_bay=bay,
+            module_type=module_type,
+            status="active",
+            serial="SN-1",
+        )
+
+        result = compare_model_rows(None, "dcim.module", [self._row()])
+
+        self.assertEqual(
+            result, {"creates": 0, "updates": 0, "unchanged": 1, "rejected": 0}
+        )
+
+    def test_a_drifted_module_is_an_update(self):
+        bay = self._bay()
+        module_type = self._module_type()
+        Module.objects.create(
+            device=self.device,
+            module_bay=bay,
+            module_type=module_type,
+            status="active",
+            serial="OLD-SERIAL",
+        )
+
+        result = compare_model_rows(None, "dcim.module", [self._row()])
+
+        self.assertEqual(
+            result, {"creates": 0, "updates": 1, "unchanged": 0, "rejected": 0}
+        )
+
+    def test_an_unknown_device_is_rejected(self):
+        result = compare_model_rows(
+            None, "dcim.module", [self._row(device="no-such-device")]
+        )
+
+        self.assertEqual(result["rejected"], 1)
+        self.assertEqual(result["creates"], 0)
+
+    def test_a_row_without_a_module_bay_is_rejected(self):
+        result = compare_model_rows(None, "dcim.module", [self._row(module_bay="")])
+
+        self.assertEqual(result["rejected"], 1)
+        self.assertEqual(result["creates"], 0)
+
+    def test_a_component_claimed_by_another_module_is_rejected_not_a_create(self):
+        # NetBox can only adopt a component belonging to NO module. One already
+        # claimed by a different module makes the template instantiation fail
+        # the unique-name constraint, so the apply skips the row - and a skip
+        # is not drift.
+        self._bay()
+        module_type = self._module_type()
+        from dcim.models import InterfaceTemplate
+
+        InterfaceTemplate.objects.create(
+            module_type=module_type, name="Ethernet1/1", type="1000base-t"
+        )
+        other_bay = ModuleBay.objects.create(device=self.device, name="Slot 9")
+        other_module = Module.objects.create(
+            device=self.device,
+            module_bay=other_bay,
+            module_type=module_type,
+            status="active",
+        )
+        Interface.objects.filter(device=self.device, name="Ethernet1/1").update(
+            module=other_module
+        )
+        if not Interface.objects.filter(
+            device=self.device, name="Ethernet1/1"
+        ).exists():
+            Interface.objects.create(
+                device=self.device,
+                name="Ethernet1/1",
+                type="1000base-t",
+                module=other_module,
+            )
+
+        result = compare_model_rows(None, "dcim.module", [self._row()])
+
+        self.assertEqual(result["creates"], 0)
+        self.assertEqual(result["rejected"], 1)

--- a/forward_netbox/utilities/drift_comparison.py
+++ b/forward_netbox/utilities/drift_comparison.py
@@ -14,6 +14,8 @@ figure wrong in whichever direction is least noticeable - worse than no figure,
 because an operator would act on it.
 """
 
+from rq.timeouts import JobTimeoutException
+
 
 class _PreviewStatistics:
     """Absorb the per-row outcome calls the classification makes."""
@@ -146,9 +148,46 @@ class PreviewRunner:
         return None
 
     def _coalesce_sets_for(self, model_string, default_sets):
+        """The coalesce sets the APPLY would use, not this call site's defaults.
+
+        `coalesce_sets_for` reads `_model_coalesce_fields`, which the real
+        runner fills from the resolved query specs before ingestion
+        (`sync_execution.py:115`). A preview never runs that resolution, so the
+        dict stayed empty and every lookup silently fell back to the hard-coded
+        defaults passed in here.
+
+        That is not cosmetic: an operator who narrows `dcim.inventoryitem`
+        coalescing to ("device", "name") because serials are unreliable gets an
+        apply that resolves and UPDATES the existing row, and a preview that
+        misses it and reports a create - phantom drift on every such row, every
+        run. Resolved lazily and memoised, because it costs a spec lookup and
+        only the adapter models ask.
+        """
         from .sync_primitives import coalesce_sets_for
 
+        if model_string not in self._model_coalesce_fields:
+            self._model_coalesce_fields[model_string] = self._resolved_coalesce_fields(
+                model_string
+            )
         return coalesce_sets_for(self, model_string, default_sets)
+
+    def _resolved_coalesce_fields(self, model_string):
+        """What the apply would resolve for this model, or `[]` to fall back."""
+        from .model_contracts import architecture_default_coalesce_fields_for_model
+        from .query_registry import get_query_specs
+
+        try:
+            specs = get_query_specs(model_string)
+            if specs and specs[0].coalesce_fields:
+                return [list(field_set) for field_set in specs[0].coalesce_fields]
+            return architecture_default_coalesce_fields_for_model(model_string) or []
+        except JobTimeoutException:
+            # A worker boundary must never be swallowed by a lookup.
+            raise
+        except Exception:  # noqa: BLE001 - fall back to the caller's defaults
+            # A preview must not fail because a spec could not be resolved; the
+            # caller's defaults are what this method returned before it existed.
+            return []
 
     def _is_module_native_inventory_row(self, row):
         """Read-only, and read from the apply's own table.
@@ -411,11 +450,21 @@ class PreviewRunner:
     def _ensure_module_bay(self, device, row):
         """Find the bay, never create it.
 
-        The real one upserts a `ModuleBay` when the device has none. An absent
-        bay means the module cannot already exist, so the caller classifies the
-        row as a create - the same treatment every absent dependency gets.
+        The real one upserts a `ModuleBay` when the device has none, coalescing
+        on the CLEANED name from `module_bay_plan_row` rather than the raw one.
+        The same cleaning is applied here, or a bay Forward reports as
+        ``"Slot 1 "`` would miss a NetBox ``"Slot 1"`` and the row would be
+        classified a create against a module that already exists.
         """
-        return self._lookup_module_bay(device, row.get("module_bay"))
+        from .module_readiness import module_bay_plan_row
+
+        existing = self._lookup_module_bay(device, row.get("module_bay"))
+        if existing is not None:
+            return existing
+        cleaned = (module_bay_plan_row(row) or {}).get("name")
+        if not cleaned or cleaned == row.get("module_bay"):
+            return None
+        return self._lookup_module_bay(device, cleaned)
 
     def _ensure_module_type(self, row):
         """Find the module type, never create it - nor a manufacturer under it.
@@ -423,6 +472,14 @@ class PreviewRunner:
         The real one upserts a `ModuleType` and calls `_ensure_manufacturer`
         beneath it, both reached during classification. Same trap as
         `_ensure_platform`, which nests the same manufacturer write.
+
+        Resolved through `get_unique_or_raise` rather than a raw queryset, for
+        two reasons. It reads the cache `prime_dependency_lookup_caches` has
+        already filled for this model - a raw `.filter()` per row threw that
+        priming away and reintroduced the per-row resolution cost 2.8.7 exists
+        to remove. And it RAISES on an ambiguous match, where `.first()` would
+        silently take the lowest pk and let a preview succeed on a row the
+        apply refuses.
         """
         from dcim.models.modules import ModuleType
 
@@ -432,13 +489,12 @@ class PreviewRunner:
                 "slug": (row or {}).get("manufacturer_slug"),
             }
         )
-        model = str((row or {}).get("model") or "").strip()
+        model = (row or {}).get("model")
         if manufacturer is None or not model:
             return None
-        return (
-            ModuleType.objects.filter(manufacturer=manufacturer, model=model)
-            .order_by("pk")
-            .first()
+        return self._get_unique_or_raise(
+            ModuleType,
+            {"manufacturer": manufacturer, "model": model},
         )
 
     def _ensure_vrf(self, row, *, update_existing=True):

--- a/forward_netbox/utilities/drift_comparison.py
+++ b/forward_netbox/utilities/drift_comparison.py
@@ -403,6 +403,44 @@ class PreviewRunner:
             return obj, False, changed
         return obj, False
 
+    def _lookup_module_bay(self, device, module_bay_name):
+        from .sync_primitives import lookup_module_bay
+
+        return lookup_module_bay(self, device, module_bay_name)
+
+    def _ensure_module_bay(self, device, row):
+        """Find the bay, never create it.
+
+        The real one upserts a `ModuleBay` when the device has none. An absent
+        bay means the module cannot already exist, so the caller classifies the
+        row as a create - the same treatment every absent dependency gets.
+        """
+        return self._lookup_module_bay(device, row.get("module_bay"))
+
+    def _ensure_module_type(self, row):
+        """Find the module type, never create it - nor a manufacturer under it.
+
+        The real one upserts a `ModuleType` and calls `_ensure_manufacturer`
+        beneath it, both reached during classification. Same trap as
+        `_ensure_platform`, which nests the same manufacturer write.
+        """
+        from dcim.models.modules import ModuleType
+
+        manufacturer = self._ensure_manufacturer(
+            {
+                "name": (row or {}).get("manufacturer"),
+                "slug": (row or {}).get("manufacturer_slug"),
+            }
+        )
+        model = str((row or {}).get("model") or "").strip()
+        if manufacturer is None or not model:
+            return None
+        return (
+            ModuleType.objects.filter(manufacturer=manufacturer, model=model)
+            .order_by("pk")
+            .first()
+        )
+
     def _ensure_vrf(self, row, *, update_existing=True):
         """Find the VRF, never create or update it.
 
@@ -512,6 +550,12 @@ def _compare_dcim_cable(runner, rows):
     return _compare_adapter_rows(runner, rows, apply_dcim_cable)
 
 
+def _compare_dcim_module(runner, rows):
+    from .sync_inventory_module import apply_dcim_module
+
+    return _compare_adapter_rows(runner, rows, apply_dcim_module)
+
+
 def _compare_ipam_fhrpgroup(runner, rows):
     from .sync_ipam import apply_ipam_fhrpgroup
 
@@ -556,6 +600,7 @@ _ADAPTER_COMPARISONS = {
     "dcim.cable": _compare_dcim_cable,
     "dcim.inventoryitem": _compare_dcim_inventoryitem,
     "ipam.fhrpgroup": _compare_ipam_fhrpgroup,
+    "dcim.module": _compare_dcim_module,
 }
 
 

--- a/forward_netbox/utilities/sync_interface.py
+++ b/forward_netbox/utilities/sync_interface.py
@@ -138,7 +138,7 @@ def apply_extras_taggeditem(runner, row, *, preview=False):
         # no-change, and the preview runner reports it from the same comparator
         # the real upsert uses.
         return "updates" if runner.last_upsert_would_change else "unchanged"
-    _device_add_tag(runner, device, tag)  # NEGATIVE-CONTROL-MARKER
+    _device_add_tag(runner, device, tag)
 
 
 def apply_dcim_macaddress(runner, row):

--- a/forward_netbox/utilities/sync_inventory_module.py
+++ b/forward_netbox/utilities/sync_inventory_module.py
@@ -231,13 +231,15 @@ def apply_dcim_module(runner, row, *, preview=False):
         return False
     module_bay = runner._ensure_module_bay(device, row)
     module_type = runner._ensure_module_type(row)
-    if preview and (module_bay is None or module_type is None):
-        # The preview runner resolves rather than creates, so a `None` here
-        # means NetBox has no such bay or type. The module cannot already exist
-        # under one it does not have, which makes this unambiguously a create -
-        # and short-circuiting avoids a coalesce lookup on a null dependency
-        # matching some unrelated row.
-        return "creates"
+    # The unadoptable-component check comes FIRST, before any absent-dependency
+    # short-circuit.
+    #
+    # It decides whether the apply will EVER write this row, and that verdict
+    # does not depend on whether the bay exists yet: the apply creates the bay,
+    # then hits this and skips permanently. Short-circuiting on a missing bay
+    # ahead of it reported a create for a row no run will ever apply - drift
+    # that never clears, which is the non-convergence the `rejected`
+    # classification exists to prevent.
     blocking = _unadoptable_component_names(device, module_type)
     if blocking:
         # `_adopt_components` cannot cover this. NetBox builds its adoption
@@ -253,7 +255,13 @@ def apply_dcim_module(runner, row, *, preview=False):
             model_string="dcim.module",
             reason="component-claimed-by-another-module",
             warning_message=(
-                f"Skipping module in bay `{module_bay.name}` on `{device.name}`: "
+                # The bay name comes from the ROW, not from `module_bay`. The
+                # apply always has a bay here because `_ensure_module_bay`
+                # creates one; a preview resolves instead, so an absent bay is
+                # `None` and dereferencing it raised. The row's name is what
+                # that bay would be called either way.
+                f"Skipping module in bay `{row.get('module_bay')}` on "
+                f"`{device.name}`: "
                 f"its module type would create {len(blocking)} component(s) whose "
                 "names are already used on the device by a different module, "
                 "which NetBox cannot adopt."
@@ -261,6 +269,17 @@ def apply_dcim_module(runner, row, *, preview=False):
             sample=device.name,
         )
         return False
+    if preview and module_bay is None:
+        # The bay is the module's IDENTITY - the coalesce set is
+        # ("device", "module_bay") - so with no bay in NetBox there is no
+        # module row to resolve against and this is a create.
+        #
+        # An absent module_type deliberately does NOT short-circuit here.
+        # `module_type` is not part of that identity, so a bay that already
+        # holds a module gets an UPDATE when the card is swapped for a type
+        # NetBox has not seen; calling it a create would split creates and
+        # updates wrongly for every hardware replacement.
+        return "creates"
     _, created = runner._upsert_values_from_defaults(
         "dcim.module",
         Module,

--- a/forward_netbox/utilities/sync_inventory_module.py
+++ b/forward_netbox/utilities/sync_inventory_module.py
@@ -170,7 +170,27 @@ def apply_dcim_inventoryitem(runner, row, *, preview=False):
         return "updates" if runner.last_upsert_would_change else "unchanged"
 
 
-def apply_dcim_module(runner, row):
+def apply_dcim_module(runner, row, *, preview=False):
+    """Apply the module, or - with ``preview`` - classify and write nothing.
+
+    Every write on this path is behind a ``runner.`` call, so the firewall
+    covers them: ``_ensure_module_bay`` (upserts a ModuleBay),
+    ``_ensure_module_type`` (upserts a ModuleType and a Manufacturer beneath
+    it) and ``_upsert_values_from_defaults``.
+
+    That last one is the dangerous one, and the reason a returned-early preview
+    would not have been enough on its own. It passes
+    ``create_instance_attrs={"_adopt_components": True}``, and NetBox core's
+    ``Module.save()`` then instantiates the module type's component templates -
+    console ports, interfaces, power ports and the rest - as real rows on the
+    device. The preview override never saves, so none of that happens, and
+    ``create_instance_attrs`` is accepted and ignored precisely because it only
+    matters to a save.
+
+    An absent bay or module type classifies the row as a create rather than
+    being resolved: a module cannot already exist in a bay NetBox does not
+    have, or with a type it does not have.
+    """
     from dcim.models import Module
 
     try:
@@ -211,6 +231,13 @@ def apply_dcim_module(runner, row):
         return False
     module_bay = runner._ensure_module_bay(device, row)
     module_type = runner._ensure_module_type(row)
+    if preview and (module_bay is None or module_type is None):
+        # The preview runner resolves rather than creates, so a `None` here
+        # means NetBox has no such bay or type. The module cannot already exist
+        # under one it does not have, which makes this unambiguously a create -
+        # and short-circuiting avoids a coalesce lookup on a null dependency
+        # matching some unrelated row.
+        return "creates"
     blocking = _unadoptable_component_names(device, module_type)
     if blocking:
         # `_adopt_components` cannot cover this. NetBox builds its adoption
@@ -234,7 +261,7 @@ def apply_dcim_module(runner, row):
             sample=device.name,
         )
         return False
-    runner._upsert_values_from_defaults(
+    _, created = runner._upsert_values_from_defaults(
         "dcim.module",
         Module,
         values={
@@ -256,3 +283,7 @@ def apply_dcim_module(runner, row):
         # IntegrityError (dcim_interface_unique_device_name, etc.).
         create_instance_attrs={"_adopt_components": True},
     )
+    if preview:
+        if created:
+            return "creates"
+        return "updates" if runner.last_upsert_would_change else "unchanged"

--- a/forward_netbox/utilities/sync_ipam.py
+++ b/forward_netbox/utilities/sync_ipam.py
@@ -333,24 +333,30 @@ def _ensure_fhrp_vip(runner, row, *, group, vrf, protocol, preview=False):
         )
         return False
 
-    update_fields = []
+    # Decide what differs BEFORE changing anything on the instance.
+    #
+    # `get_unique_or_raise` caches the resolved object, so this instance is
+    # shared with every later row that resolves the same VIP. Mutating it while
+    # merely computing a preview handed the next row an already-corrected
+    # object, which then compared clean - two routers in one HSRP group, and
+    # the second one's drift silently disappeared. Ordinary topology, and
+    # exactly the confident-zero failure this feature exists to prevent.
+    desired = []
     if str(existing.address) != str(row["address"]):
-        existing.address = row["address"]
-        update_fields.append("address")
+        desired.append(("address", row["address"]))
     if existing.status != row["status"]:
-        existing.status = row["status"]
-        update_fields.append("status")
+        desired.append(("status", row["status"]))
     if existing.role != desired_role:
-        existing.role = desired_role
-        update_fields.append("role")
+        desired.append(("role", desired_role))
     if is_unassigned:
-        existing.assigned_object_type = desired_assigned_object_type
-        existing.assigned_object_id = desired_assigned_object_id
-        update_fields.extend(["assigned_object_type", "assigned_object_id"])
+        desired.append(("assigned_object_type", desired_assigned_object_type))
+        desired.append(("assigned_object_id", desired_assigned_object_id))
     if preview:
-        # Computed from the same field comparisons the apply just made, before
-        # the save rather than after it.
-        return "updates" if update_fields else "unchanged"
+        return "updates" if desired else "unchanged"
+    update_fields = []
+    for field, value in desired:
+        setattr(existing, field, value)
+        update_fields.append(field)
     if update_fields:
         existing.full_clean()
         existing.save(update_fields=update_fields)


### PR DESCRIPTION
## Summary

Slice five of eight toward #206's remaining scope. **Stacked on #292.**
Review order: #289 → #290 → #291 → #292 → this.

## The write that is not ours

Every write here is behind a `runner.` call, so the firewall covers them. What
makes this slice different is what the module upsert *does*: it passes
`create_instance_attrs={"_adopt_components": True}`, and NetBox core's
`Module.save()` then walks the module type's component templates and
instantiates them — console ports, interfaces, power ports, module bays — as
real rows on the device.

A preview that reached that save would not create one row. It would create a
dozen, on hardware the operator only asked a question about.

So the assertion counts **`Interface` rows** with an `InterfaceTemplate`
present, not just `Module` rows. Under a negative control that made the shim
write, that count went **0 → 1** — the test catches the component
instantiation specifically, which counting the module row alone would have
missed.

## Skips are not drift

A module type whose templates would collide with a component already claimed by
a *different* module is skipped by the apply (NetBox adopts only components
belonging to no module). That counts as `rejected` — a row the apply
permanently refuses must not show as drift a future run will clear. Same
reasoning as the LAG endpoint in #290.

## Test plan

- [x] 11 new tests; **416 green**, including `test_module_readiness` and all of
      `test_sync`
- [x] pre-commit clean; `check_harness.py --base origin/main` passes
- [x] **Two negative controls:** making the upsert shim write failed
      `test_a_preview_instantiates_no_components` (on the Interface count,
      `1 != 0`); disabling the unadoptable-component detection failed
      `test_a_component_claimed_by_another_module_is_rejected_not_a_create`,
      confirming that one is not passing vacuously — it was written defensively
      enough that it could have been.

## Rollback

Remove `dcim.module` from `_ADAPTER_COMPARISONS`. `preview` defaults to `False`.

Refs #206

Claude-Session: https://claude.ai/code/session_012Qfd3hTSxZtmFHuzRJnZre