### PR TITLE
fix: close the three deferred review findings on the adapter-drift stack

### DIFF
--- a/docs/03_Plans/active/2026-08-24-adapter-model-drift-review-fixes.md
+++ b/docs/03_Plans/active/2026-08-24-adapter-model-drift-review-fixes.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Correct six defects found by reviewing the five-slice adapter-model drift stack
+Correct nine defects found by reviewing the five-slice adapter-model drift stack
 (#289-#293) as one cumulative diff, before any of it merges.
 
 ## Why
@@ -110,11 +110,16 @@ negative control. Nothing referenced it. Removed.
 
 ## Validation
 
-436 tests green across all five adapter suites, the bulk drift suite, the
+439 tests green across all five adapter suites, the bulk drift suite, the
 preview contract/priming/cost suites, `test_module_readiness` and all of
 `test_sync`.
 
-Two new tests pin the review findings directly:
+Each of the last three fixes has its own negative control, all confirmed
+failing without their fix: removing the `ValueError` raise, reverting the
+`.get()`, and disabling the claimed-name cache each broke exactly the test
+that names it.
+
+Tests pinning the review findings directly:
 `test_a_claimed_component_is_rejected_even_when_the_bay_is_absent` (which
 errored on the `None` dereference before that was fixed too) and
 `test_a_swapped_card_in_an_existing_bay_is_an_update_not_a_create`.
@@ -136,14 +141,36 @@ an individual model's dispatch entry.
   the adapter models ask, and a spec lookup per model on every preview
   construction would cost callers that never use it.
 
+### 8. An empty coalesce-lookup list read as "would create"
+
+Both shims skipped falsy lookups and fell through to `obj is None`, so a row
+yielding no usable lookup - a tag row with neither `tag` nor `tag_slug` -
+counted as drift. The real `coalesce_update_or_create` raises `ValueError`
+there, so the apply could never resolve it and the drift never cleared. Both
+shims now raise the same `ValueError`, and `_compare_adapter_rows` counts it
+rejected alongside `KeyError`: a row the apply cannot process is a defect in
+the row, not a difference between the systems.
+
+### 9. `.get()` where the apply indexes
+
+`_ensure_module_type` and `_ensure_inventory_item_role` read row keys with
+`.get()` while their real counterparts index them. A row missing
+`manufacturer` or `role_slug` raises `KeyError` in the apply and is counted
+rejected; the overrides returned `None` and classified the same row a create.
+They index now, so both paths agree the row is malformed.
+
+### 10. Eight uncached queries per module row
+
+`_unadoptable_component_names` scanned each of the eight component collections
+per row. It now takes an OPT-IN `claimed_cache`, and only the preview runner
+supplies one - deliberately, because an apply CREATES modules as it goes, so a
+device's claimed names change mid-run and a cache there would answer with
+stale state. A preview writes nothing, so they cannot change. The real apply's
+behaviour is byte-identical: it passes no cache.
+
 ## Open
 
-- The remaining review findings are lower severity and NOT fixed here: an empty
-  coalesce-lookup list classifies as "would create" where the apply raises
-  `ValueError` (a row with neither tag nor tag_slug); `.get()` versus indexing
-  makes preview and apply disagree about a malformed row (create versus
-  rejected); `_unadoptable_component_names` costs ~8 uncached queries per
-  module row. The first two are honest-but-wrong classifications of rows that
-  are already broken; the third is a cost question that wants a measurement
-  rather than a guess.
 - Three models still uncompared: lifecycle (netbox-dlm), peering, routing.
+- The delete question from the inventory slice is unchanged: the comparison
+  contract has no slot for a delete, and routing has cascading deletes, so it
+  will likely come due there.

--- a/forward_netbox/tests/test_module_drift_comparison.py
+++ b/forward_netbox/tests/test_module_drift_comparison.py
@@ -181,6 +181,60 @@ class ModulePreviewTest(TestCase):
             result, {"creates": 0, "updates": 1, "unchanged": 0, "rejected": 0}
         )
 
+    def test_a_row_missing_its_manufacturer_key_is_rejected_not_a_create(self):
+        """Preview and apply must agree that a malformed row is malformed.
+
+        The real `_ensure_module_type` indexes `row["manufacturer"]` and raises
+        KeyError, which is counted as a rejected row. The override used
+        `.get()`, returned None, and classified the same row as a create.
+        """
+        row = self._row()
+        del row["manufacturer"]
+
+        result = compare_model_rows(None, "dcim.module", [row])
+
+        self.assertEqual(result["rejected"], 1)
+        self.assertEqual(result["creates"], 0)
+
+    def test_the_claimed_component_scan_is_not_repeated_per_row(self):
+        """Eight queries a row, for a scan whose answer cannot change.
+
+        A preview writes nothing, so a device's claimed component names are
+        fixed for the whole run. Without the cache this cost eight queries per
+        module row on top of the resolution ones.
+        """
+        module_type = self._module_type()
+        from dcim.models import InterfaceTemplate
+
+        InterfaceTemplate.objects.create(
+            module_type=module_type, name="Ethernet1/1", type="1000base-t"
+        )
+        other_bay = ModuleBay.objects.create(device=self.device, name="Slot 9")
+        other_module = Module.objects.create(
+            device=self.device,
+            module_bay=other_bay,
+            module_type=module_type,
+            status="active",
+        )
+        Interface.objects.filter(device=self.device, name="Ethernet1/1").update(
+            module=other_module
+        )
+        rows = [self._row(module_bay=f"Slot {index}") for index in range(2, 12)]
+
+        from django.test.utils import CaptureQueriesContext
+        from django.db import connection
+
+        with CaptureQueriesContext(connection) as captured:
+            compare_model_rows(None, "dcim.module", rows)
+        repeated = [
+            query
+            for query in captured.captured_queries
+            if "dcim_interface" in query["sql"] and "module_id" in query["sql"]
+        ]
+
+        # One scan for the device, not one per row.
+        self.assertLessEqual(len(repeated), 1, f"{len(repeated)} repeated scans")
+
     def test_an_unknown_device_is_rejected(self):
         result = compare_model_rows(
             None, "dcim.module", [self._row(device="no-such-device")]

--- a/forward_netbox/tests/test_taggeditem_drift_comparison.py
+++ b/forward_netbox/tests/test_taggeditem_drift_comparison.py
@@ -148,6 +148,24 @@ class TaggedItemPreviewTest(TestCase):
         self.assertEqual(result["rejected"], 1)
         self.assertEqual(result["unchanged"], 0)
 
+    def test_a_row_with_no_usable_coalesce_lookup_is_rejected(self):
+        """A row yielding no lookup is a bad row, not drift.
+
+        `coalesce_update_or_create` raises ValueError when handed no usable
+        lookup. The preview shim previously fell through to "would create", so
+        a tag row with neither `tag` nor `tag_slug` showed as drift that every
+        subsequent run also showed - the apply raised the same way each time
+        and never resolved it.
+        """
+        result = compare_model_rows(
+            None,
+            "extras.taggeditem",
+            [self._row(tag="", tag_slug="")],
+        )
+
+        self.assertEqual(result["rejected"], 1)
+        self.assertEqual(result["creates"], 0)
+
     def test_a_mixed_batch_is_not_all_or_nothing(self):
         tag = Tag.objects.create(name="Prot BGP", slug="prot-bgp", color="9e9e9e")
         self.device.tags.add(tag)

--- a/forward_netbox/utilities/drift_comparison.py
+++ b/forward_netbox/utilities/drift_comparison.py
@@ -110,6 +110,11 @@ class PreviewRunner:
         self._model_coalesce_fields = {}
         self._device_tag_ids_cache = {}
         self._cable_between_cache = {}
+        # Per-device claimed component names, for `_unadoptable_component_names`.
+        # Safe here and ONLY here: a preview writes nothing, so a device's
+        # claimed names cannot change mid-run. The real runner deliberately has
+        # no such attribute, because an apply creates modules as it goes.
+        self._claimed_component_names_cache = {}
         self._scope_matched_tags = {}
         self._scope_tag_objs = {}
         self.rejected_rows = 0
@@ -219,14 +224,17 @@ class PreviewRunner:
         role_name = row.get("role")
         if not role_name:
             return None
-        slug = str(row.get("role_slug") or "").strip()
+        # `row["role_slug"]` is INDEXED, not `.get()`, because the real
+        # `_ensure_inventory_item_role` indexes it. A row missing that key
+        # raises KeyError there and is counted as a rejected row; a `.get()`
+        # here returned None and classified the same row as a create, so the
+        # two paths disagreed about a row that is simply malformed.
+        slug = str(row["role_slug"] or "").strip()
         if slug:
-            match = InventoryItemRole.objects.filter(slug=slug).order_by("pk").first()
+            match = self._get_unique_or_raise(InventoryItemRole, {"slug": slug})
             if match is not None:
                 return match
-        return (
-            InventoryItemRole.objects.filter(name=str(role_name)).order_by("pk").first()
-        )
+        return self._get_unique_or_raise(InventoryItemRole, {"name": str(role_name)})
 
     def _delete_by_coalesce(self, model, lookups):
         """Never delete while measuring.
@@ -368,10 +376,16 @@ class PreviewRunner:
         lookups = _dedupe_lookups(
             [coalesce_lookup(values, *coalesce_set) for coalesce_set in coalesce_sets]
         )
+        usable = [lookup for lookup in lookups if lookup]
+        if not usable:
+            # Exactly what `coalesce_update_or_create` raises. Falling through
+            # to "would create" instead reported drift for a row the apply
+            # cannot process at all - a tag row with neither `tag` nor
+            # `tag_slug`, say - and that drift never cleared, because every
+            # subsequent run raised the same way.
+            raise ValueError("At least one coalesce lookup must be provided.")
         obj = None
-        for lookup in lookups:
-            if not lookup:
-                continue
+        for lookup in usable:
             obj = get_unique_or_raise(self, model, lookup)
             if obj is not None:
                 break
@@ -417,10 +431,12 @@ class PreviewRunner:
         from .sync_primitives import _model_field_value_matches
         from .sync_primitives import get_unique_or_raise
 
+        usable = [lookup for lookup in (coalesce_lookups or []) if lookup]
+        if not usable:
+            # Same refusal the real primitive makes; see the sibling override.
+            raise ValueError("At least one coalesce lookup must be provided.")
         obj = None
-        for lookup in coalesce_lookups or []:
-            if not lookup:
-                continue
+        for lookup in usable:
             obj = get_unique_or_raise(self, model, lookup)
             if obj is not None:
                 break
@@ -483,13 +499,14 @@ class PreviewRunner:
         """
         from dcim.models.modules import ModuleType
 
+        # Indexed, not `.get()`, to match the real `_ensure_module_type`. A row
+        # missing `manufacturer`, `manufacturer_slug` or `model` raises
+        # KeyError in the apply and is counted rejected; `.get()` here turned
+        # the same malformed row into a create.
         manufacturer = self._ensure_manufacturer(
-            {
-                "name": (row or {}).get("manufacturer"),
-                "slug": (row or {}).get("manufacturer_slug"),
-            }
+            {"name": row["manufacturer"], "slug": row["manufacturer_slug"]}
         )
-        model = (row or {}).get("model")
+        model = row["model"]
         if manufacturer is None or not model:
             return None
         return self._get_unique_or_raise(
@@ -569,10 +586,14 @@ def _compare_adapter_rows(runner, rows, apply_row, *, uncomparable_outcomes=()):
             # inflating it.
             counts["rejected"] += 1
             continue
-        except KeyError:
-            # A row missing a key the apply indexes directly (`row["device"]`).
-            # Same class as above; calling it zero drift would be the
-            # confident-zero failure this feature exists to prevent.
+        except (KeyError, ValueError):
+            # KeyError: a row missing a key the apply indexes directly
+            # (`row["device"]`). ValueError: a row that yields no usable
+            # coalesce lookup, which `coalesce_update_or_create` refuses.
+            # Both are rows the apply cannot process, so both are defects in
+            # the row rather than differences between the two systems -
+            # calling either zero drift would be the confident-zero failure
+            # this feature exists to prevent.
             counts["rejected"] += 1
             continue
         if outcome in uncomparable_outcomes:

--- a/forward_netbox/utilities/sync_inventory_module.py
+++ b/forward_netbox/utilities/sync_inventory_module.py
@@ -44,13 +44,20 @@ _MODULE_COMPONENT_TEMPLATES = (
 )
 
 
-def _unadoptable_component_names(device, module_type):
+def _unadoptable_component_names(device, module_type, claimed_cache=None):
     """Component names this module type would create that are already claimed.
 
     NetBox adopts an existing component only when it belongs to no module
     (`module__isnull=True`). One already assigned to a different module is
     neither adoptable nor replaceable, so instantiating the template violates
     the per-device unique name constraint. Returns the colliding names.
+
+    ``claimed_cache`` memoises the per-device claimed-name sets, which is eight
+    queries a row otherwise. It is OPT-IN and the real runner does not offer
+    one, deliberately: an apply CREATES modules as it goes, so a device's
+    claimed names change during the run and a cache would answer with stale
+    state. A preview writes nothing, so they cannot change, and the preview
+    runner supplies the dict.
     """
     blocking = []
     for template_attribute, component_attribute in _MODULE_COMPONENT_TEMPLATES:
@@ -58,9 +65,15 @@ def _unadoptable_component_names(device, module_type):
         components = getattr(device, component_attribute, None)
         if templates is None or components is None:
             continue
-        claimed = set(
-            components.filter(module__isnull=False).values_list("name", flat=True)
-        )
+        cache_key = (device.pk, component_attribute)
+        if claimed_cache is not None and cache_key in claimed_cache:
+            claimed = claimed_cache[cache_key]
+        else:
+            claimed = set(
+                components.filter(module__isnull=False).values_list("name", flat=True)
+            )
+            if claimed_cache is not None:
+                claimed_cache[cache_key] = claimed
         if not claimed:
             continue
         for name in templates.all().values_list("name", flat=True):
@@ -240,7 +253,12 @@ def apply_dcim_module(runner, row, *, preview=False):
     # ahead of it reported a create for a row no run will ever apply - drift
     # that never clears, which is the non-convergence the `rejected`
     # classification exists to prevent.
-    blocking = _unadoptable_component_names(device, module_type)
+    blocking = _unadoptable_component_names(
+        device,
+        module_type,
+        # Absent on the real runner by design - see the helper's docstring.
+        claimed_cache=getattr(runner, "_claimed_component_names_cache", None),
+    )
     if blocking:
         # `_adopt_components` cannot cover this. NetBox builds its adoption
         # candidates as `device.<components>.filter(module__isnull=True)`, so a


### PR DESCRIPTION
## Summary

The three lower-severity findings from the cumulative review of #289–#293 that
I deferred rather than dropped. **Stacked on #293** (top of the stack).

All three turn out to be the same underlying shape as the six already fixed:
**the preview and the apply disagreeing about the same row**, always in the
direction that reports drift no run will clear.

### 1. An empty coalesce-lookup list read as "would create"

Both shims skipped falsy lookups and fell through to `obj is None`, so a row
yielding no usable lookup — a tag row with neither `tag` nor `tag_slug` —
counted as drift. The real `coalesce_update_or_create` **raises `ValueError`**
there, so the apply could never resolve it and the drift never cleared.

Both shims raise the same `ValueError` now, and `_compare_adapter_rows` counts
it `rejected` alongside `KeyError`.

### 2. `.get()` where the apply indexes

`_ensure_module_type` and `_ensure_inventory_item_role` read row keys with
`.get()` while their real counterparts index them. A row missing `manufacturer`
or `role_slug` raised `KeyError` in the apply (→ rejected) but returned `None`
in preview (→ create). They index now, and both route through
`_get_unique_or_raise` so they read the primed cache and raise on ambiguity as
the apply does.

### 3. Eight uncached queries per module row

`_unadoptable_component_names` scanned each of the eight component collections
per row. It takes an **opt-in** `claimed_cache` now, and **only the preview
runner supplies one** — deliberately: an apply *creates* modules as it goes, so
a device's claimed names change mid-run and a cache there would answer with
stale state. A preview writes nothing, so they cannot change. **The real
apply's behaviour is byte-identical** — it passes no cache.

## Test plan

- [x] 3 new tests; **439 green** across all five adapter suites, the bulk drift
      suite, the preview contract/priming/cost suites, `test_module_readiness`
      and all of `test_sync`
- [x] pre-commit clean; `check_harness.py --base origin/main` passes
- [x] **A negative control per fix, all confirmed failing without it:** removing
      the `ValueError` raise, reverting the `.get()`, and disabling the
      claimed-name cache each broke exactly the test that names it

## Still open (unchanged)

Three models uncompared — lifecycle (netbox-dlm), peering, routing. And the
delete question from #291: the comparison contract has no slot for a delete,
and routing has cascading deletes, so it will likely come due there.

Refs #206

Claude-Session: https://claude.ai/code/session_012Qfd3hTSxZtmFHuzRJnZre