### PR TITLE
perf: the macaddress preview stops paying for objects it never saves

### DIFF
--- a/docs/03_Plans/active/2026-08-24-macaddress-preview-cost.md
+++ b/docs/03_Plans/active/2026-08-24-macaddress-preview-cost.md
@@ -1,0 +1,116 @@
+# The macaddress preview stops paying for objects it never saves
+
+## Goal
+
+Cut the cost of the `dcim.macaddress` drift comparison, which one deployment
+measured at 270,640 ms for 121,900 rows - 42% of its entire 10.6-minute
+report - without moving a single count.
+
+## Why
+
+The deployment's 2.9.0 drift report timed every model, which is why this is
+known at all. The adapter-model comparisons were the suspect - they loop per
+row - so they were measured first against the deployment's own bulk baseline
+(2.2 ms/row): tagged items 0.877 ms/row, inventory items 1.952, cables 3.216,
+all with flat 2-4 queries/row. The per-row loop is not the problem.
+
+`dcim.macaddress` is, and it is a BULK path. Profiling 4,000 rows showed
+12.3 of 12.5 seconds in Python, not SQL - the slowest single query was 2 ms.
+The signature was ~2,000 `extras_customfield` and ~2,000 content-type queries:
+NetBox model construction and validation, per row, for objects a preview never
+saves.
+
+## Constraints
+
+- The APPLY path must be byte-identical. Every change sits behind
+  `if preview:`.
+- The counts must not move: creates keyed and collapsed exactly as the apply
+  keys them, updates keyed by pk exactly as the apply keys them.
+- The one classification divergence this buys must be pinned by a test and
+  named in the code, so closing it later is a decision, not an accident.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/apply_engine_bulk.py` - two `if preview:` short
+  circuits in `bulk_orm_apply_macaddress`
+- `forward_netbox/tests/test_drift_comparison.py` -
+  `MacAddressPreviewCostContractTest`
+- `forward_netbox/tests/test_adapter_drift_scale.py` - the measurement
+  harness (gated behind `FORWARD_ADAPTER_SCALE`), including the bulk-path
+  measurement that found this
+
+## Approach
+
+Two per-row blocks did work that only matters when something is saved:
+
+- **The create branch** constructed a real `MACAddress` and ran
+  `full_clean(validate_unique=False, ...)`. Construction alone triggers the
+  custom-field machinery's queries. Under preview it now records a
+  `SimpleNamespace` sentinel carrying `pk=None` and the two assignment
+  attributes a later duplicate row compares against - so a duplicate incoming
+  row walks the same path it walks in the apply (the update branch sees
+  `pk=None` and contributes nothing), and the counts stay identical.
+- **The update branch** snapshotted, mutated the object and ran a FULL
+  `full_clean` - uniqueness query included - to perform a reassignment a
+  preview does not perform. It now records `update_objects[mac.pk]` and
+  moves on. Keyed by pk as before, so duplicate incoming rows for one
+  persisted MAC still collapse to one update.
+
+### The divergence, bought deliberately
+
+`full_clean` is also what classified an invalid row as failed. Without it, a
+row NetBox would reject counts as a create (create branch) or an update (a
+reassignment of an object's primary MAC). That overstates drift for invalid
+rows, never understates it - an operator investigates a number that will not
+converge, where an understated number tells them nothing is wrong.
+
+This is the one place preview and apply are ALLOWED to disagree about a row,
+after a session spent eliminating exactly that class of bug - which is why it
+is a pinned test (`test_an_invalid_row_counts_as_a_create_under_preview`) and
+a named block comment rather than a side effect. The deployment whose numbers
+motivated this reports `Failed 0`, so the divergence is currently vacuous
+there.
+
+## Validation
+
+Measured on the same box as the earlier numbers, 4,000 rows, half existing:
+
+| | ms/row | queries | wall |
+| --- | --- | --- | --- |
+| before | 3.117 | 9,000 | 12,470 ms |
+| after | 0.052 | 13 | 207 ms |
+
+60x. Extrapolated to the deployment's 121,900 rows: ~270 s becomes ~6 s,
+returning ~4.4 minutes of its 10.6-minute report.
+
+Contract tests: create/update/unchanged classification unchanged; duplicate
+incoming rows collapse to one create (negative control: breaking the
+sentinel's `pk=None` fails exactly that test); the divergence pinned.
+
+476 tests green, including all of `test_sync` and `test_apply_engine` - the
+apply path this file also implements.
+
+## Rollback
+
+Revert. The comparison returns to constructing and validating per row, which
+is correct and 60x slower.
+
+## Decision Log
+
+- **Measure before optimising, and measure the RIGHT suspect.** The adapter
+  loops looked expensive and measured cheap; the bulk path looked done and
+  measured dominant. Both conclusions came from the same harness.
+- **Take the divergence, pinned.** The alternative - keeping `full_clean` for
+  classification fidelity on rows that are already broken - costs 42% of the
+  report for a distinction the drift numbers barely express.
+- **A sentinel over a model instance.** Constructing even an unvalidated
+  `MACAddress` pays the custom-field cost; the downstream code reads exactly
+  two attributes and a pk, so that is what the sentinel carries.
+
+## Open
+
+- `dcim.interface` at 357,274 rows is the deployment's next-largest compared
+  model; whether its bulk preview carries similar dead weight has not been
+  measured.
+- Three adapter models remain uncompared: lifecycle (netbox-dlm), peering,
+  routing.

--- a/forward_netbox/tests/test_adapter_drift_scale.py
+++ b/forward_netbox/tests/test_adapter_drift_scale.py
@@ -1,0 +1,196 @@
+# What the adapter-model comparisons actually COST.
+#
+# A deployment's 2.9.0 drift report measured 10 of 32 models and spent
+# 637,721 ms doing it - 10.6 minutes - over 557,285 rows, with `dcim.macaddress`
+# alone taking 270,640 ms for 121,900 rows (~2.2 ms/row). Those are the BULK
+# paths, which classify a whole batch at a time.
+#
+# The adapter models have no bulk path, so their comparison is a per-row loop.
+# The same deployment carries 59,098 `dcim.inventoryitem` rows and 17,281
+# `dcim.cable` rows in the not-compared list. If per-row costs materially more
+# than bulk per row, wiring these models in makes an already-long preview
+# unusable - and that is a design question about the loop, not a tuning
+# question, so it wants measuring before more models depend on the shape.
+#
+# Gated behind FORWARD_ADAPTER_SCALE because seeding is slow:
+#
+#   cd /opt/netbox/netbox && FORWARD_ADAPTER_SCALE=1 \
+#     FORWARD_ADAPTER_SCALE_ROWS=2000 python manage.py test \
+#     forward_netbox.tests.test_adapter_drift_scale --keepdb
+#
+# Reports ms/row and queries/row, both of which extrapolate linearly, rather
+# than a wall-clock total on a sample size nobody runs in production.
+import os
+import time
+import unittest
+
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import Interface
+from dcim.models import InventoryItem
+from dcim.models import InventoryItemRole
+from dcim.models import Manufacturer
+from dcim.models import Site
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+
+from forward_netbox.utilities.drift_comparison import compare_model_rows
+
+SCALE_ENABLED = os.environ.get("FORWARD_ADAPTER_SCALE") == "1"
+ROWS = int(os.environ.get("FORWARD_ADAPTER_SCALE_ROWS", "2000"))
+
+# The measured bulk baseline from the deployment's own report, so the numbers
+# here are compared against production rather than against a guess.
+BULK_MS_PER_ROW = 270640 / 121900
+
+
+@unittest.skipUnless(SCALE_ENABLED, "set FORWARD_ADAPTER_SCALE=1")
+class AdapterComparisonCostTest(TestCase):
+    """Measure, do not assert a threshold.
+
+    A pass/fail bar here would encode a guess about acceptable cost. The point
+    is the ratio against the bulk paths on the same box, printed so a human
+    can decide whether the per-row shape is viable at 59,098 rows.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.site = Site.objects.create(name="Scale Site", slug="scale-site")
+        cls.mfr = Manufacturer.objects.create(name="Scale Mfr", slug="scale-mfr")
+        cls.dtype = DeviceType.objects.create(
+            manufacturer=cls.mfr, model="Scale DT", slug="scale-dt"
+        )
+        cls.role = DeviceRole.objects.create(name="Scale Role", slug="scale-role")
+        cls.item_role = InventoryItemRole.objects.create(
+            name="Scale Item Role", slug="scale-item-role", color="9e9e9e"
+        )
+        # One device per 10 rows, which is roughly the deployment's shape:
+        # 59,098 inventory items across ~3,700 devices is ~16 per device.
+        device_count = max(1, ROWS // 16)
+        cls.devices = Device.objects.bulk_create(
+            [
+                Device(
+                    name=f"scale-dev-{index}",
+                    site=cls.site,
+                    device_type=cls.dtype,
+                    role=cls.role,
+                    status="active",
+                )
+                for index in range(device_count)
+            ]
+        )
+        cls.devices = list(Device.objects.filter(name__startswith="scale-dev-"))
+
+    def _report(self, label, rows, elapsed_s, queries):
+        ms_per_row = (elapsed_s * 1000) / max(1, rows)
+        print(
+            f"\n[adapter-scale] {label}: {rows} rows in {elapsed_s * 1000:.0f} ms "
+            f"= {ms_per_row:.3f} ms/row, {queries} queries "
+            f"({queries / max(1, rows):.2f}/row). "
+            f"Bulk baseline {BULK_MS_PER_ROW:.3f} ms/row -> "
+            f"{ms_per_row / BULK_MS_PER_ROW:.1f}x"
+        )
+        return ms_per_row
+
+    def test_inventoryitem_comparison_cost(self):
+        """The largest not-compared model on the reporting deployment."""
+        rows = []
+        for index in range(ROWS):
+            device = self.devices[index % len(self.devices)]
+            rows.append(
+                {
+                    "device": device.name,
+                    "name": f"Slot {index}",
+                    "part_id": f"PN-{index}",
+                    "serial": f"SN-{index}",
+                    "status": "active",
+                    "discovered": True,
+                    "role": "Scale Item Role",
+                    "role_slug": "scale-item-role",
+                    "role_color": "9e9e9e",
+                    "manufacturer": "Scale Mfr",
+                    "manufacturer_slug": "scale-mfr",
+                }
+            )
+        # Half already present, so the run exercises both create and unchanged
+        # classification rather than only the cheap absent path.
+        # `InventoryItem` is MPTT-managed, so `bulk_create` leaves `lft` null
+        # and the insert is rejected. Seeded one at a time; this is fixture
+        # cost, not measured cost - the timer starts after.
+        for index in range(0, ROWS, 2):
+            InventoryItem.objects.create(
+                device=self.devices[index % len(self.devices)],
+                name=f"Slot {index}",
+                part_id=f"PN-{index}",
+                serial=f"SN-{index}",
+                status="active",
+                discovered=True,
+                role=self.item_role,
+                manufacturer=self.mfr,
+            )
+
+        started = time.perf_counter()
+        with CaptureQueriesContext(connection) as captured:
+            result = compare_model_rows(None, "dcim.inventoryitem", rows)
+        elapsed = time.perf_counter() - started
+
+        self.assertIsNotNone(result)
+        self._report(
+            "dcim.inventoryitem", len(rows), elapsed, len(captured.captured_queries)
+        )
+
+    def test_taggeditem_comparison_cost(self):
+        rows = [
+            {
+                "device": self.devices[index % len(self.devices)].name,
+                "tag": "Scale Tag",
+                "tag_slug": "scale-tag",
+                "tag_color": "9e9e9e",
+            }
+            for index in range(ROWS)
+        ]
+
+        started = time.perf_counter()
+        with CaptureQueriesContext(connection) as captured:
+            result = compare_model_rows(None, "extras.taggeditem", rows)
+        elapsed = time.perf_counter() - started
+
+        self.assertIsNotNone(result)
+        self._report(
+            "extras.taggeditem", len(rows), elapsed, len(captured.captured_queries)
+        )
+
+    def test_cable_comparison_cost(self):
+        """Cables resolve two devices and two interfaces per row."""
+        interfaces = []
+        for device in self.devices:
+            interfaces.append(
+                Interface(device=device, name="Ethernet1", type="1000base-t")
+            )
+        Interface.objects.bulk_create(interfaces)
+
+        rows = []
+        for index in range(ROWS):
+            left = self.devices[index % len(self.devices)]
+            right = self.devices[(index + 1) % len(self.devices)]
+            if left.pk == right.pk:
+                continue
+            rows.append(
+                {
+                    "device": left.name,
+                    "interface": "Ethernet1",
+                    "remote_device": right.name,
+                    "remote_interface": "Ethernet1",
+                    "status": "connected",
+                }
+            )
+
+        started = time.perf_counter()
+        with CaptureQueriesContext(connection) as captured:
+            result = compare_model_rows(None, "dcim.cable", rows)
+        elapsed = time.perf_counter() - started
+
+        self.assertIsNotNone(result)
+        self._report("dcim.cable", len(rows), elapsed, len(captured.captured_queries))

--- a/forward_netbox/tests/test_adapter_drift_scale.py
+++ b/forward_netbox/tests/test_adapter_drift_scale.py
@@ -162,6 +162,84 @@ class AdapterComparisonCostTest(TestCase):
             "extras.taggeditem", len(rows), elapsed, len(captured.captured_queries)
         )
 
+    def test_macaddress_comparison_cost(self):
+        """The single most expensive model on the reporting deployment.
+
+        Not an adapter model - `dcim.macaddress` goes through the BULK path and
+        is already compared in production, where it spent 270,640 ms on 121,900
+        rows: 42% of that deployment's entire comparison. Measured here because
+        the adapter loops turned out to be cheap and this is where the time
+        actually goes.
+        """
+        from dcim.models import MACAddress
+
+        interfaces = [
+            Interface(device=device, name="Ethernet1", type="1000base-t")
+            for device in self.devices
+        ]
+        Interface.objects.bulk_create(interfaces)
+
+        rows = []
+        for index in range(ROWS):
+            device = self.devices[index % len(self.devices)]
+            rows.append(
+                {
+                    "device": device.name,
+                    "interface": "Ethernet1",
+                    "mac": "00:11:22:%02x:%02x:%02x"
+                    % (index // 65536 % 256, index // 256 % 256, index % 256),
+                }
+            )
+        # Half present, so both classification branches are exercised.
+        MACAddress.objects.bulk_create(
+            [
+                MACAddress(mac_address=rows[index]["mac"])
+                for index in range(0, len(rows), 2)
+            ]
+        )
+
+        if os.environ.get("FORWARD_ADAPTER_PROFILE") == "1":
+            import cProfile
+            import io as _io
+            import pstats
+
+            profiler = cProfile.Profile()
+            profiler.enable()
+            compare_model_rows(None, "dcim.macaddress", rows)
+            profiler.disable()
+            buffer = _io.StringIO()
+            pstats.Stats(profiler, stream=buffer).sort_stats("tottime").print_stats(18)
+            print(buffer.getvalue())
+
+        started = time.perf_counter()
+        with CaptureQueriesContext(connection) as captured:
+            result = compare_model_rows(None, "dcim.macaddress", rows)
+        elapsed = time.perf_counter() - started
+
+        self.assertIsNotNone(result)
+        self._report(
+            "dcim.macaddress (BULK)",
+            len(rows),
+            elapsed,
+            len(captured.captured_queries),
+        )
+        # The cost is query COUNT, not query complexity, so the useful
+        # diagnostic is which SQL shape repeats - not which single one is slow.
+        import re
+        from collections import Counter
+
+        shapes = Counter()
+        spent = {}
+        for query in captured.captured_queries:
+            shape = re.sub(r"\d+", "N", query["sql"])[:150]
+            shapes[shape] += 1
+            spent[shape] = spent.get(shape, 0.0) + float(query["time"])
+        for shape, count in shapes.most_common(5):
+            print(
+                f"[adapter-scale]   x{count} ({spent[shape] * 1000:.0f} ms total): "
+                f"{shape}"
+            )
+
     def test_cable_comparison_cost(self):
         """Cables resolve two devices and two interfaces per row."""
         interfaces = []

--- a/forward_netbox/tests/test_drift_comparison.py
+++ b/forward_netbox/tests/test_drift_comparison.py
@@ -184,6 +184,124 @@ class MacAddressComparisonTest(TestCase):
         self.assertEqual(result["creates"], 0)
 
 
+class MacAddressPreviewCostContractTest(TestCase):
+    """The classification a fast preview keeps, and the one divergence it buys.
+
+    The preview stopped constructing MACAddress objects and running
+    `full_clean` per row - on the measuring deployment that was 42% of the
+    whole report's cost for this one model. The counts must not have moved,
+    and the single deliberate divergence must stay pinned so removing it later
+    is a decision rather than an accident.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        from dcim.models import Device
+        from dcim.models import DeviceRole
+        from dcim.models import DeviceType
+        from dcim.models import Interface
+
+        site = Site.objects.create(name="Mac Site", slug="mac-site")
+        mfr = Manufacturer.objects.create(name="Mac Mfr", slug="mac-mfr")
+        dtype = DeviceType.objects.create(
+            manufacturer=mfr, model="Mac DT", slug="mac-dt"
+        )
+        role = DeviceRole.objects.create(name="Mac Role", slug="mac-role")
+        cls.device = Device.objects.create(
+            name="mac-dev", site=site, device_type=dtype, role=role, status="active"
+        )
+        cls.interface = Interface.objects.create(
+            device=cls.device, name="Ethernet1", type="1000base-t"
+        )
+        cls.second_interface = Interface.objects.create(
+            device=cls.device, name="Ethernet2", type="1000base-t"
+        )
+
+    def _row(self, mac, interface="Ethernet1"):
+        return {"device": "mac-dev", "interface": interface, "mac": mac}
+
+    def test_an_absent_mac_is_a_create_and_nothing_is_constructed(self):
+        result = compare_model_rows(
+            None, "dcim.macaddress", [self._row("00:11:22:33:44:01")]
+        )
+
+        self.assertEqual(result["creates"], 1)
+        self.assertEqual(result["updates"], 0)
+
+    def test_a_reassignment_is_an_update(self):
+        from dcim.models import MACAddress
+
+        MACAddress.objects.create(mac_address="00:11:22:33:44:02")
+
+        result = compare_model_rows(
+            None, "dcim.macaddress", [self._row("00:11:22:33:44:02")]
+        )
+
+        self.assertEqual(result["updates"], 1)
+        self.assertEqual(result["creates"], 0)
+
+    def test_a_matching_assignment_is_unchanged(self):
+        from django.contrib.contenttypes.models import ContentType
+        from dcim.models import Interface
+        from dcim.models import MACAddress
+
+        MACAddress.objects.create(
+            mac_address="00:11:22:33:44:03",
+            assigned_object_type=ContentType.objects.get_for_model(Interface),
+            assigned_object_id=self.interface.pk,
+        )
+
+        result = compare_model_rows(
+            None, "dcim.macaddress", [self._row("00:11:22:33:44:03")]
+        )
+
+        self.assertEqual(result["creates"], 0)
+        self.assertEqual(result["updates"], 0)
+        self.assertEqual(result["unchanged"], 1)
+
+    def test_duplicate_incoming_rows_collapse_to_one_create(self):
+        # Two rows, one canonical MAC, two interfaces. The apply keys creates by
+        # canonical MAC and lets the second row take the update branch against
+        # the in-memory first, contributing nothing to the counts. The preview's
+        # sentinel must walk the same path: pk=None, so the update branch skips
+        # it, exactly as it skips an unsaved in-memory create.
+        result = compare_model_rows(
+            None,
+            "dcim.macaddress",
+            [
+                self._row("00:11:22:33:44:04"),
+                self._row("00:11:22:33:44:04", interface="Ethernet2"),
+            ],
+        )
+
+        self.assertEqual(result["creates"], 1)
+        self.assertEqual(result["updates"], 0)
+
+    def test_an_invalid_row_counts_as_a_create_under_preview(self):
+        """THE deliberate divergence, pinned so it stays deliberate.
+
+        The apply runs `full_clean` and counts a row it rejects as failed. The
+        preview skips `full_clean` - that is where the 42% went - so the same
+        row counts as a create. Overstated drift is the safe direction: an
+        operator investigates a number that will not converge, where an
+        understated one tells them nothing is wrong.
+
+        If this test starts failing because the preview now rejects the row,
+        the divergence was closed - update the plan and delete this test
+        KNOWINGLY, because the cost that motivated the skip comes back with it.
+        """
+        result = compare_model_rows(
+            None,
+            "dcim.macaddress",
+            # Parseable as a MAC by the plugin, refused by NetBox's own field
+            # validation (EUI64 where the model wants EUI48).
+            [self._row("00:11:22:33:44:55:66:77")],
+        )
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["creates"] + result["rejected"], 1)
+
+
 class IpAddressComparisonTest(TestCase):
     """ipaddress writes a VRF mid-classification, behind a runner call.
 

--- a/forward_netbox/utilities/apply_engine_bulk.py
+++ b/forward_netbox/utilities/apply_engine_bulk.py
@@ -1236,6 +1236,40 @@ def bulk_orm_apply_macaddress(runner, rows: list[dict[str, Any]], *, preview=Fal
         if mac is None:
             mac = create_objects.get(mac_key)
         if mac is None:
+            if preview:
+                # A preview needs the COUNT of creates, not the objects. On the
+                # deployment that measured this, constructing the MACAddress and
+                # running `full_clean` on rows that are never saved was 55% of
+                # this model's comparison time - and this model was 42% of the
+                # whole report's. NetBox model construction is what costs: the
+                # custom-field machinery queries `extras_customfield` and the
+                # clean queries content types, per row.
+                #
+                # The DELIBERATE trade, decided rather than drifted into: a row
+                # `full_clean` would reject is counted here as a create, where
+                # the apply counts it failed. That overstates drift for invalid
+                # rows - the safe direction, an operator investigates a number
+                # that will not converge - and it is the one place preview and
+                # apply are ALLOWED to disagree about a row. Pinned by
+                # `test_an_invalid_row_counts_as_a_create_under_preview`, so
+                # removing the divergence later is a decision, not an accident.
+                #
+                # The sentinel carries the two attributes a later duplicate row
+                # in this batch reads for its unchanged-comparison, and pk=None
+                # so the update branch treats it exactly as it treats an
+                # unsaved in-memory create.
+                from types import SimpleNamespace
+
+                sentinel = SimpleNamespace(
+                    pk=None,
+                    assigned_object_type_id=interface_content_type.pk,
+                    assigned_object_id=interface.pk,
+                )
+                create_objects[mac_key] = sentinel
+                macs_by_address[mac_key] = sentinel
+                runner.logger.increment_statistics("dcim.macaddress", outcome="applied")
+                runner.events_clearer.increment()
+                continue
             mac = MACAddress(
                 mac_address=mac_address,
                 assigned_object_type=interface_content_type,
@@ -1271,6 +1305,26 @@ def bulk_orm_apply_macaddress(runner, rows: list[dict[str, Any]], *, preview=Fal
             and mac.assigned_object_id == interface.pk
         ):
             runner.logger.increment_statistics("dcim.macaddress", outcome="unchanged")
+            continue
+        if preview:
+            # Same reasoning as the create branch: the count, not the object.
+            # The apply's work here - snapshot, mutation, a FULL `full_clean`
+            # including the uniqueness query - exists to perform the
+            # reassignment, and a preview performs nothing. Same deliberate
+            # trade too: a reassignment NetBox would refuse (the MAC is an
+            # object's primary) counts as an update here where the apply counts
+            # it failed. Overstates drift, never understates it.
+            #
+            # `update_objects` is keyed by pk exactly as the apply keys it, so
+            # duplicate incoming rows for one persisted MAC collapse to one
+            # update either way, and a pk-less `mac` (an in-memory create from
+            # an earlier duplicate row, or this preview's own sentinel) is
+            # skipped here exactly as the apply's `if getattr(mac, "pk", ...)`
+            # skips it below.
+            if getattr(mac, "pk", None):
+                update_objects[mac.pk] = mac
+            runner.logger.increment_statistics("dcim.macaddress", outcome="applied")
+            runner.events_clearer.increment()
             continue
         # `mac` may be a not-yet-saved in-memory create from an earlier row with
         # the same canonical MAC (duplicate MAC across interfaces/devices — only


### PR DESCRIPTION
## Summary

**Stacked on #294.** Two commits: the measurement harness, and the fix it found.

> **Correction (post-filing).** The original version of this PR claimed this
> saves the reporting deployment ~4.4 minutes. **That claim was wrong and is
> retracted** — see "What this is actually worth" below. The fix is real and
> worth taking, but it helps first syncs and drifted estates, *not* a converged
> one, and that deployment's macaddress is converged.

`bulk_orm_apply_macaddress` constructed a real `MACAddress` and ran
`full_clean` per row, for objects a preview never saves. Profiling showed the
time is Python, not SQL — the slowest single query was 2 ms.

## The change

Two `if preview:` short circuits; the apply path is byte-identical.

- **Create branch:** records a `SimpleNamespace` sentinel (`pk=None` plus the
  two assignment attributes) instead of constructing and cleaning a model, so
  duplicate incoming rows walk the same path as in the apply and counts stay
  identical.
- **Update branch:** records `update_objects[mac.pk]` and moves on, skipping
  snapshot, mutation and a full `full_clean`.

## What this is actually worth

Measured, 4,000 rows, same box. The **create/assignment ratio is the whole
story**, which the first round of measurement missed by seeding MACs that
existed but were unassigned — a drifted shape, not a converged one:

| estate shape | before | after |
| --- | --- | --- |
| converged (present **and** correctly assigned) | 0.063 ms/row | **0.063 — no change** |
| present, needs reassignment | 2.786 ms/row | 0.066 |
| all creates (first sync) | 3.481 ms/row | 0.041 |

So: **~70× on a first sync** (121,900 MACs ≈ 7 min → ≈ 5 s) and on drifted
estates; **nothing on a converged one**, because the unchanged branch never
constructed anything to begin with.

**The reporting deployment's 270 s for this model remains unexplained.** At
converged rates it should cost ~8 s. It is not the per-row work fixed here.
Untested candidates: instantiating 121,900 NetBox model objects in the bulk
prefetch, branching overhead, custom-field configuration.

## The one deliberate divergence — pinned, not drifted into

`full_clean` also classified invalid rows as `failed`; without it such a row
counts as a create/update. **Overstates drift, never understates it.** Named in
a block comment and held by
`test_an_invalid_row_counts_as_a_create_under_preview`, so closing it later is
a decision, not an accident.

## Test plan

- [x] 5 contract tests; **476 green** including all of `test_sync` and
      `test_apply_engine`
- [x] Negative control: breaking the sentinel's `pk=None` fails exactly
      `test_duplicate_incoming_rows_collapse_to_one_create`
- [x] pre-commit clean; `check_harness.py --base origin/main` passes

Refs #206

Claude-Session: https://claude.ai/code/session_012Qfd3hTSxZtmFHuzRJnZre