### PR TITLE
test: measure the create ratio, and retract a claim it disproves

### DIFF
--- a/docs/03_Plans/active/2026-08-24-macaddress-preview-cost.md
+++ b/docs/03_Plans/active/2026-08-24-macaddress-preview-cost.md
@@ -135,11 +135,27 @@ ones.
 
 ## Open
 
-- **That deployment's 270 s for this model is still unexplained.** At converged
-  rates it should cost ~8 s. Whatever it is, it is not the per-row work fixed
-  here. Untested candidates: instantiating 121,900 NetBox model objects in the
-  bulk prefetch, branching overhead during the sync, custom-field
-  configuration. Worth measuring against its data rather than guessing.
+- **That deployment's 270 s for this model is still unexplained, and the local
+  hypotheses are now exhausted.** Converged macaddress measures ~0.065 ms/row
+  and is LINEAR to 64,000 rows (0.071 / 0.065 / 0.091 at 4k / 16k / 64k), so
+  its 121,900 rows should cost ~11 s. Ruled out by measurement, each with a
+  knob left in the harness so the next person does not repeat it:
+
+  | hypothesis | knob | result |
+  | --- | --- | --- |
+  | non-linear at scale | `FORWARD_ADAPTER_SCALE_ROWS` | linear to 64k |
+  | priming scales with estate, not batch | `FORWARD_ADAPTER_IFACES_PER_DEVICE` | 30x the interfaces, 1025 -> 1081 ms |
+  | per-row interface-lookup fallback | `FORWARD_ADAPTER_IFACE_MISS` | 3.8x, so ~30 s at its scale - not 270 |
+  | per-row construct/clean | (this change) | irrelevant when converged |
+  | branch-rewritten queries | read `_dependency_preview_work` | the preview job activates no branch |
+
+  What remains is environmental or a data shape this fixture does not model:
+  its hardware and concurrent load, custom fields configured on `MACAddress`,
+  or rows taking a branch the fixture does not produce. Closing it needs
+  per-model instrumentation from that deployment - a query count and a
+  breakdown by classification outcome - not another local fixture. The fixture
+  only models what it is told to, which is how the retracted claim above
+  happened in the first place.
 - `dcim.interface` at 357,274 rows was measured and is NOT a problem for that
   deployment: 0.060 ms/row converged (~21 s). On a first sync it is 1.799
   ms/row (~10.7 min), so the exposure there is first-sync, and it carries the

--- a/docs/03_Plans/active/2026-08-24-macaddress-preview-cost.md
+++ b/docs/03_Plans/active/2026-08-24-macaddress-preview-cost.md
@@ -2,9 +2,12 @@
 
 ## Goal
 
-Cut the cost of the `dcim.macaddress` drift comparison, which one deployment
-measured at 270,640 ms for 121,900 rows - 42% of its entire 10.6-minute
-report - without moving a single count.
+Stop the `dcim.macaddress` drift comparison constructing and validating model
+objects it never saves, without moving a single count.
+
+Note the goal has been narrowed since this plan was written. It began as "cut
+the 270,640 ms this model cost one deployment"; measurement showed the change
+does not touch that deployment's case at all. See Validation.
 
 ## Why
 
@@ -80,8 +83,24 @@ Measured on the same box as the earlier numbers, 4,000 rows, half existing:
 | before | 3.117 | 9,000 | 12,470 ms |
 | after | 0.052 | 13 | 207 ms |
 
-60x. Extrapolated to the deployment's 121,900 rows: ~270 s becomes ~6 s,
-returning ~4.4 minutes of its 10.6-minute report.
+**That measurement was incomplete, and the conclusion drawn from it was
+wrong.** Seeding MACs that existed but were UNASSIGNED makes every seeded row
+take the update branch - a drifted shape. Re-measured across the shapes that
+actually occur:
+
+| estate shape | before | after |
+| --- | --- | --- |
+| converged (present AND correctly assigned) | 0.063 ms/row | 0.063 - no change |
+| present, needs reassignment | 2.786 ms/row | 0.066 |
+| all creates (first sync) | 3.481 ms/row | 0.041 |
+
+So the win is ~70x on a first sync (121,900 MACs, ~7 min -> ~5 s) and on
+drifted estates, and NOTHING on a converged one, because the unchanged branch
+never constructed anything to begin with.
+
+The reporting deployment's macaddress is converged (drift 0, In sync), so this
+change does not speed up its next run. The earlier claim that it returns ~4.4
+minutes of that report is retracted.
 
 Contract tests: create/update/unchanged classification unchanged; duplicate
 incoming rows collapse to one create (negative control: breaking the
@@ -93,7 +112,8 @@ apply path this file also implements.
 ## Rollback
 
 Revert. The comparison returns to constructing and validating per row, which
-is correct and 60x slower.
+is correct and ~70x slower on create-heavy runs, and identical on converged
+ones.
 
 ## Decision Log
 
@@ -101,16 +121,28 @@ is correct and 60x slower.
   loops looked expensive and measured cheap; the bulk path looked done and
   measured dominant. Both conclusions came from the same harness.
 - **Take the divergence, pinned.** The alternative - keeping `full_clean` for
-  classification fidelity on rows that are already broken - costs 42% of the
-  report for a distinction the drift numbers barely express.
+  classification fidelity on rows that are already broken - costs ~70x on a
+  first sync for a distinction the drift numbers barely express.
+- **Re-measure when the fixture shape is a guess.** The first numbers here
+  were taken at "50% already present", chosen for branch coverage rather than
+  because it modelled anything. It modelled a drifted estate, and the
+  deployment in question is converged - so a real 70x improvement was written
+  up as a saving that deployment will not see. The create/assignment ratio was
+  the whole story and was not a knob until it had already misled a conclusion.
 - **A sentinel over a model instance.** Constructing even an unvalidated
   `MACAddress` pays the custom-field cost; the downstream code reads exactly
   two attributes and a pk, so that is what the sentinel carries.
 
 ## Open
 
-- `dcim.interface` at 357,274 rows is the deployment's next-largest compared
-  model; whether its bulk preview carries similar dead weight has not been
-  measured.
+- **That deployment's 270 s for this model is still unexplained.** At converged
+  rates it should cost ~8 s. Whatever it is, it is not the per-row work fixed
+  here. Untested candidates: instantiating 121,900 NetBox model objects in the
+  bulk prefetch, branching overhead during the sync, custom-field
+  configuration. Worth measuring against its data rather than guessing.
+- `dcim.interface` at 357,274 rows was measured and is NOT a problem for that
+  deployment: 0.060 ms/row converged (~21 s). On a first sync it is 1.799
+  ms/row (~10.7 min), so the exposure there is first-sync, and it carries the
+  same construct-per-create shape this change removed for macaddress.
 - Three adapter models remain uncompared: lifecycle (netbox-dlm), peering,
   routing.

--- a/docs/03_Plans/active/2026-08-24-macaddress-preview-cost.md
+++ b/docs/03_Plans/active/2026-08-24-macaddress-preview-cost.md
@@ -148,14 +148,40 @@ ones.
   | per-row interface-lookup fallback | `FORWARD_ADAPTER_IFACE_MISS` | 3.8x, so ~30 s at its scale - not 270 |
   | per-row construct/clean | (this change) | irrelevant when converged |
   | branch-rewritten queries | read `_dependency_preview_work` | the preview job activates no branch |
+  | custom fields on `MACAddress` | `FORWARD_ADAPTER_CUSTOM_FIELDS` | 100 fields cost 0.077 ms/row - 2,850 would be needed |
+
+  **Custom fields are now off that list.** They were written up as unreachable
+  without knowing the deployment's configuration, which was true of a
+  REPRODUCTION and not of a SENSITIVITY sweep - the sweep does not need their
+  number, only the slope. Converged, 16,000 rows, populated `custom_field_data`
+  on every seeded row:
+
+  | custom fields | ms/row | of which the MAC fetch |
+  | --- | --- | --- |
+  | 0 | 0.065 | 98 ms |
+  | 10 | 0.071 | 134 ms |
+  | 30 | 0.089 | 334 ms |
+  | 100 | 0.142 | 818 ms |
+
+  0.00077 ms/row per field across that range, so explaining 2.26 ms/row takes
+  ~2,850 custom fields on `MACAddress`. Two further things the sweep says: the
+  count stays FLAT at 40 queries for 16,000 rows at every setting, and most of
+  what custom fields DO cost lands in the fetch SQL rather than in Python -
+  wider JSONB coming back, not slower object handling.
 
   What remains is environmental or a data shape this fixture does not model:
-  its hardware and concurrent load, custom fields configured on `MACAddress`,
-  or rows taking a branch the fixture does not produce. Closing it needs
-  per-model instrumentation from that deployment - a query count and a
-  breakdown by classification outcome - not another local fixture. The fixture
-  only models what it is told to, which is how the retracted claim above
-  happened in the first place.
+  its hardware and concurrent load, table bloat or a query plan that flips at
+  122,478 rows, a Postgres a network hop away, or rows taking a branch the
+  fixture does not produce. Closing it needs per-model instrumentation from
+  that deployment - a query count, the share of the runtime spent in SQL, and a
+  breakdown by classification outcome - not another local fixture. The first
+  two now ship; see
+  `docs/03_Plans/active/2026-08-28-preview-reports-its-query-count.md`. The
+  flat 40 queries measured here is exactly why the SQL time had to ship WITH
+  the count: that deployment will report a low count, and a low count on its
+  own reads as Python when this fixture cannot rule out a slow query at its
+  scale. The fixture only models what it is told to, which is how the retracted
+  claim above happened in the first place.
 - `dcim.interface` at 357,274 rows was measured and is NOT a problem for that
   deployment: 0.060 ms/row converged (~21 s). On a first sync it is 1.799
   ms/row (~10.7 min), so the exposure there is first-sync, and it carries the

--- a/forward_netbox/tests/test_adapter_drift_scale.py
+++ b/forward_netbox/tests/test_adapter_drift_scale.py
@@ -216,6 +216,32 @@ class AdapterComparisonCostTest(TestCase):
         from django.contrib.contenttypes.models import ContentType
 
         interface_ct = ContentType.objects.get_for_model(Interface)
+
+        # Custom fields configured on MACAddress: the one suspect left on the
+        # remaining list that a fixture can actually reach. Not a reproduction
+        # - we do not know how many that deployment has - but a SENSITIVITY
+        # sweep, which does not need to. If 30 fields barely move ms/row, the
+        # hypothesis dies whatever their configuration is; if 30 fields move it
+        # a lot, the number to ask them for is finally worth asking.
+        custom_field_count = int(os.environ.get("FORWARD_ADAPTER_CUSTOM_FIELDS", "0"))
+        custom_field_data = {}
+        if custom_field_count:
+            from extras.models import CustomField
+
+            mac_ct = ContentType.objects.get_for_model(MACAddress)
+            for index in range(custom_field_count):
+                field = CustomField.objects.create(
+                    name=f"scale_cf_{index}",
+                    type="text",
+                    label=f"Scale CF {index}",
+                )
+                field.object_types.set([mac_ct])
+                # A populated value, not an empty one: the converged path never
+                # constructs a MACAddress, so if custom fields cost anything
+                # here it is deserializing the JSONB that comes back with the
+                # existing rows - and an empty dict would not carry any.
+                custom_field_data[f"scale_cf_{index}"] = f"scale-value-{index}" * 3
+
         by_device = {
             interface.device_id: interface
             for interface in Interface.objects.filter(name="Ethernet1")
@@ -223,6 +249,8 @@ class AdapterComparisonCostTest(TestCase):
         seeded = []
         for index in range(int(len(rows) * seed_ratio)):
             mac = MACAddress(mac_address=rows[index]["mac"])
+            if custom_field_data:
+                mac.custom_field_data = dict(custom_field_data)
             if seed_assigned:
                 device = self.devices[index % len(self.devices)]
                 target = by_device.get(device.pk)
@@ -253,7 +281,8 @@ class AdapterComparisonCostTest(TestCase):
         self.assertIsNotNone(result)
         self._report(
             f"dcim.macaddress (BULK, {seed_ratio:.0%} present"
-            f"{', assigned' if seed_assigned else ''})",
+            f"{', assigned' if seed_assigned else ''}"
+            f"{f', {custom_field_count} custom fields' if custom_field_count else ''})",
             len(rows),
             elapsed,
             len(captured.captured_queries),

--- a/forward_netbox/tests/test_adapter_drift_scale.py
+++ b/forward_netbox/tests/test_adapter_drift_scale.py
@@ -173,19 +173,33 @@ class AdapterComparisonCostTest(TestCase):
         """
         from dcim.models import MACAddress
 
+        # ESTATE size, not row count. The reporting deployment carries 357,274
+        # interfaces against 121,900 MACs - roughly 3 interfaces per MAC - and
+        # `prime_dependency_lookup_caches` primes interface identity for this
+        # model. If priming scales with the estate rather than the batch, a
+        # fixture with one interface per device cannot see it.
+        per_device = int(os.environ.get("FORWARD_ADAPTER_IFACES_PER_DEVICE", "1"))
         interfaces = [
-            Interface(device=device, name="Ethernet1", type="1000base-t")
+            Interface(device=device, name=f"Ethernet{n}", type="1000base-t")
             for device in self.devices
+            for n in range(1, per_device + 1)
         ]
         Interface.objects.bulk_create(interfaces)
 
+        # Rows whose interface the prefetch cannot resolve fall back to a
+        # PER-ROW `runner._lookup_interface`, which does canonical-name
+        # matching - several queries each. A deployment whose MAC rows name
+        # interfaces NetBox does not carry would pay that on every row, and no
+        # amount of the batch being converged would avoid it.
+        miss_ratio = float(os.environ.get("FORWARD_ADAPTER_IFACE_MISS", "0"))
         rows = []
         for index in range(ROWS):
             device = self.devices[index % len(self.devices)]
+            missing = (index % 100) < int(miss_ratio * 100)
             rows.append(
                 {
                     "device": device.name,
-                    "interface": "Ethernet1",
+                    "interface": "NoSuchIface%d" % index if missing else "Ethernet1",
                     "mac": "00:11:22:%02x:%02x:%02x"
                     % (index // 65536 % 256, index // 256 % 256, index % 256),
                 }

--- a/forward_netbox/tests/test_adapter_drift_scale.py
+++ b/forward_netbox/tests/test_adapter_drift_scale.py
@@ -190,13 +190,33 @@ class AdapterComparisonCostTest(TestCase):
                     % (index // 65536 % 256, index // 256 % 256, index % 256),
                 }
             )
-        # Half present, so both classification branches are exercised.
-        MACAddress.objects.bulk_create(
-            [
-                MACAddress(mac_address=rows[index]["mac"])
-                for index in range(0, len(rows), 2)
-            ]
-        )
+        # Same ratio knob as the interface case, and for the same reason.
+        #
+        # ASSIGNED matters as much as present. A MAC that exists but is not
+        # attached to the incoming interface takes the UPDATE branch; one
+        # already attached takes the unchanged branch. The reporting deployment
+        # shows this model at drift 0 / In sync, so its rows are the second
+        # kind, and only that shape models it.
+        seed_ratio = float(os.environ.get("FORWARD_ADAPTER_SEEDED", "0.5"))
+        seed_assigned = os.environ.get("FORWARD_ADAPTER_ASSIGNED") == "1"
+        from django.contrib.contenttypes.models import ContentType
+
+        interface_ct = ContentType.objects.get_for_model(Interface)
+        by_device = {
+            interface.device_id: interface
+            for interface in Interface.objects.filter(name="Ethernet1")
+        }
+        seeded = []
+        for index in range(int(len(rows) * seed_ratio)):
+            mac = MACAddress(mac_address=rows[index]["mac"])
+            if seed_assigned:
+                device = self.devices[index % len(self.devices)]
+                target = by_device.get(device.pk)
+                if target is not None:
+                    mac.assigned_object_type = interface_ct
+                    mac.assigned_object_id = target.pk
+            seeded.append(mac)
+        MACAddress.objects.bulk_create(seeded)
 
         if os.environ.get("FORWARD_ADAPTER_PROFILE") == "1":
             import cProfile
@@ -218,7 +238,8 @@ class AdapterComparisonCostTest(TestCase):
 
         self.assertIsNotNone(result)
         self._report(
-            "dcim.macaddress (BULK)",
+            f"dcim.macaddress (BULK, {seed_ratio:.0%} present"
+            f"{', assigned' if seed_assigned else ''})",
             len(rows),
             elapsed,
             len(captured.captured_queries),
@@ -239,6 +260,64 @@ class AdapterComparisonCostTest(TestCase):
                 f"[adapter-scale]   x{count} ({spent[shape] * 1000:.0f} ms total): "
                 f"{shape}"
             )
+
+    def test_interface_comparison_cost(self):
+        """The deployment's largest compared model: 357,274 rows.
+
+        Also a BULK path. Measured after `dcim.macaddress` turned out to be
+        spending its time constructing and validating objects a preview never
+        saves - the question is whether this one does the same.
+        """
+        rows = []
+        for index in range(ROWS):
+            device = self.devices[index % len(self.devices)]
+            rows.append(
+                {
+                    "device": device.name,
+                    "name": f"Ethernet{index}",
+                    "type": "1000base-t",
+                    "enabled": True,
+                }
+            )
+        # The create RATIO is the variable that matters here, so it is a knob.
+        # A converged estate (the reporting deployment shows interface drift 0)
+        # is almost all unchanged rows; a first sync is almost all creates. An
+        # optimisation targeting object construction is worth everything in one
+        # case and nothing in the other.
+        seed_ratio = float(os.environ.get("FORWARD_ADAPTER_SEEDED", "0.5"))
+        seeded = int(ROWS * seed_ratio)
+        Interface.objects.bulk_create(
+            [
+                Interface(
+                    device=self.devices[index % len(self.devices)],
+                    name=f"Ethernet{index}",
+                    type="1000base-t",
+                    enabled=True,
+                )
+                for index in range(seeded)
+            ]
+        )
+
+        started = time.perf_counter()
+        with CaptureQueriesContext(connection) as captured:
+            result = compare_model_rows(None, "dcim.interface", rows)
+        elapsed = time.perf_counter() - started
+
+        self.assertIsNotNone(result)
+        self._report(
+            f"dcim.interface (BULK, {seed_ratio:.0%} already present)",
+            len(rows),
+            elapsed,
+            len(captured.captured_queries),
+        )
+        import re
+        from collections import Counter
+
+        shapes = Counter()
+        for query in captured.captured_queries:
+            shapes[re.sub(r"\d+", "N", query["sql"])[:110]] += 1
+        for shape, count in shapes.most_common(4):
+            print(f"[adapter-scale]   x{count}: {shape}")
 
     def test_cable_comparison_cost(self):
         """Cables resolve two devices and two interfaces per row."""


### PR DESCRIPTION
## Summary

**Stacked on #295.** Adds estate-shape knobs to the measurement harness, a
`dcim.interface` case — and corrects a conclusion #295 got wrong.

## What went wrong in #295

Its numbers were taken at "50% already present", a ratio picked for branch
coverage rather than because it modelled any real estate. Worse, the seeded
MACs were **unassigned**, so every one took the *update* branch. That is a
drifted estate. The reporting deployment is converged.

Re-measured across the shapes that actually occur:

| estate shape | before | after |
| --- | --- | --- |
| converged (present **and** assigned) | 0.063 ms/row | **0.063 — no change** |
| present, needs reassignment | 2.786 | 0.066 |
| all creates (first sync) | 3.481 | 0.041 |

So #295 is **~70× on a first sync and on drifted estates, and nothing on a
converged one** — the unchanged branch never constructed anything to begin
with. Its claim to return ~4.4 minutes of that deployment's report is
**retracted**, here, in the plan, and on #295 itself.

The fix is still worth taking: a first sync of 121,900 MACs goes from ~7 min to
~5 s. It just isn't the thing that speeds up that deployment's next run.

## Consequence: a real question is now open again

**That deployment's 270 s for macaddress is unexplained.** At converged rates
it should cost ~8 s. Untested candidates: instantiating 121,900 NetBox model
objects in the bulk prefetch, branching overhead during the sync, custom-field
configuration. Recorded as open rather than guessed at.

## dcim.interface, measured

The next-largest compared model, 357,274 rows:

- converged: **0.060 ms/row** ≈ 21 s — not a problem for that deployment
- first sync: **1.799 ms/row** ≈ 10.7 min — same construct-per-create shape

So the exposure there is first-sync too. Recorded, not fixed.

## Test plan

- [x] Harness only plus plan corrections; no production code changes
- [x] pre-commit clean

Refs #206

Claude-Session: https://claude.ai/code/session_012Qfd3hTSxZtmFHuzRJnZre