### PR TITLE
perf: the interface preview stops validating rows it never writes

### DIFF
--- a/docs/03_Plans/active/2026-08-24-interface-preview-cost.md
+++ b/docs/03_Plans/active/2026-08-24-interface-preview-cost.md
@@ -1,0 +1,113 @@
+# The interface preview stops validating rows it never writes
+
+## Goal
+
+Cut the first-sync cost of the `dcim.interface` drift comparison - the
+largest compared model on the reporting deployment at 357,274 rows - without
+moving a count.
+
+## Why
+
+Measured after the same treatment worked for `dcim.macaddress`. At 16,000
+first-sync rows the comparison cost 29,139 ms and 9,000 queries. Converged, it
+already cost 0.088 ms/row and 36 queries, so the exposure is a first sync or a
+badly drifted estate, not the reporting deployment's steady state - it measures
+~21 s there and needs nothing.
+
+## Constraints
+
+- The APPLY path must be byte-identical; every change sits behind `if preview`.
+- Counts must not move, except the one divergence named below.
+- The object must still be constructed and must still flow into LAG
+  resolution, which reads it.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/apply_engine_bulk.py` - `bulk_orm_apply_interface`
+- `forward_netbox/tests/test_drift_comparison.py` -
+  `InterfacePreviewCostContractTest`
+- `forward_netbox/tests/test_preview_primes_its_lookup_caches.py` - a canary
+  re-aimed, and a documented belief corrected
+
+## Approach
+
+`_validate_interface` runs `full_clean`, which a preview does not need. It is
+skipped on both the create and the update branch. Unlike the macaddress fix
+there is NO sentinel: the `Interface` is still constructed and still flows into
+LAG resolution, because construction turned out to be cheap.
+
+The update branch additionally skips `_snapshot_once` and the `setattr` loop,
+which exist to stage a write. Honest scope on that one, having tried to justify
+it harder and failed: it is not fixing a laundering bug like `_ensure_fhrp_vip`
+had - duplicate rows for one interface are deduplicated upstream, so no second
+row reads the mutated object - and it is not measurable, 36 queries either way.
+It stands on being work a preview provably does not need, nothing more.
+
+### A documented belief, corrected by measurement
+
+`test_preview_primes_its_lookup_caches` stated that a create-path row "is
+instantiated, and NetBox charges two queries per instance for content type and
+custom field defaults", and that "the only way to avoid them is to stop routing
+the preview through the real apply".
+
+The middle step is wrong. The per-row charge came from `full_clean`, not from
+`Interface(**defaults)`. The preview still instantiates, still resolves, still
+classifies through the same code, and the queries went flat anyway.
+Instantiation is cheap; validating is not.
+
+That module's canary asserted the create path costs MORE QUERIES for more rows,
+as proof the preview still went through the real apply. That proxy is dead - and
+asserting a dead proxy would have forced the cost back to keep a test green. It
+now asserts the property it was really protecting: every row is still classified
+individually, checked on the counts, which is also what an operator reads.
+
+### The divergence
+
+Same shape as macaddress, and taken for the same reason: a row `full_clean`
+would reject counts as a create rather than failed. Overstates drift, never
+understates it. Pinned by
+`test_an_invalid_interface_row_counts_as_a_create_under_preview`.
+
+## Validation
+
+16,000 rows, same box:
+
+| | ms/row | queries | wall |
+| --- | --- | --- | --- |
+| first sync, before | 1.821 | 9,000 | 29,139 ms |
+| first sync, after | 0.092 | 36 | 1,467 ms |
+| converged, before | 0.088 | 36 | 1,408 ms |
+| converged, after | 0.079 | 36 | 1,263 ms |
+
+~20x on a first sync; converged unchanged, as expected. Extrapolated to
+357,274 rows: ~10.7 min becomes ~33 s on a first sync.
+
+Negative control: restoring `_validate_interface` under preview puts it back to
+28,883 ms / 9,000 queries, so the win is attributable to that call and nothing
+else.
+
+481 tests green, including all of `test_sync` and `test_apply_engine`.
+
+## Rollback
+
+Revert. The comparison validates every row again, correct and ~20x slower on
+create-heavy runs.
+
+## Decision Log
+
+- **No sentinel here.** macaddress needed one because constructing the model
+  was the cost; here it is not, and the object is read by LAG resolution.
+- **Re-aim the canary rather than delete or satisfy it.** It was protecting a
+  real property through a proxy that this change invalidated. Deleting it would
+  drop the protection; satisfying it would restore the cost to keep a test
+  green.
+- **Say plainly that the snapshot skip is unproven.** It is defensible as dead
+  work and nothing stronger; claiming a bug fix it does not deliver is how the
+  retracted macaddress claim happened.
+
+## Open
+
+- The reporting deployment's unexplained 270 s macaddress cost is unaffected by
+  this and still open; see `2026-08-24-macaddress-preview-cost.md`.
+- Three adapter models remain uncompared: lifecycle (netbox-dlm), peering,
+  routing.

--- a/forward_netbox/tests/test_drift_comparison.py
+++ b/forward_netbox/tests/test_drift_comparison.py
@@ -302,6 +302,98 @@ class MacAddressPreviewCostContractTest(TestCase):
         self.assertEqual(result["creates"] + result["rejected"], 1)
 
 
+class InterfacePreviewCostContractTest(TestCase):
+    """The interface preview stopped validating, and stopped mutating."""
+
+    @classmethod
+    def setUpTestData(cls):
+        from dcim.models import Device
+        from dcim.models import DeviceRole
+        from dcim.models import DeviceType
+
+        site = Site.objects.create(name="IfCost Site", slug="ifcost-site")
+        mfr = Manufacturer.objects.create(name="IfCost Mfr", slug="ifcost-mfr")
+        dtype = DeviceType.objects.create(
+            manufacturer=mfr, model="IfCost DT", slug="ifcost-dt"
+        )
+        role = DeviceRole.objects.create(name="IfCost Role", slug="ifcost-role")
+        cls.device = Device.objects.create(
+            name="ifcost-dev", site=site, device_type=dtype, role=role, status="active"
+        )
+
+    def _row(self, name="Ethernet1", **extra):
+        row = {
+            "device": "ifcost-dev",
+            "name": name,
+            "type": "1000base-t",
+            "enabled": True,
+        }
+        row.update(extra)
+        return row
+
+    def test_an_absent_interface_is_a_create(self):
+        result = compare_model_rows(None, "dcim.interface", [self._row()])
+
+        self.assertEqual(result["creates"], 1)
+        self.assertEqual(result["updates"], 0)
+
+    def test_a_matching_interface_is_unchanged(self):
+        from dcim.models import Interface
+
+        Interface.objects.create(
+            device=self.device, name="Ethernet1", type="1000base-t", enabled=True
+        )
+
+        result = compare_model_rows(None, "dcim.interface", [self._row()])
+
+        self.assertEqual(result["creates"], 0)
+        self.assertEqual(result["updates"], 0)
+        self.assertEqual(result["unchanged"], 1)
+
+    def test_a_drifted_interface_is_an_update(self):
+        from dcim.models import Interface
+
+        Interface.objects.create(
+            device=self.device, name="Ethernet1", type="1000base-t", enabled=False
+        )
+
+        result = compare_model_rows(None, "dcim.interface", [self._row()])
+
+        self.assertEqual(result["updates"], 1)
+        self.assertEqual(result["creates"], 0)
+
+    def test_an_invalid_interface_row_counts_as_a_create_under_preview(self):
+        """The deliberate divergence, same shape as the macaddress one.
+
+        `_validate_interface` runs `full_clean` and classifies a rejected row
+        as failed. The preview skips it - that is the whole win, 29,139 ms to
+        1,467 ms at 16,000 first-sync rows - so such a row counts as a create.
+        Overstates drift, never understates it.
+
+        If this starts failing because the preview now rejects the row, the
+        divergence was closed: update the plan and delete this test KNOWINGLY,
+        because the cost comes back with it.
+        """
+        result = compare_model_rows(
+            None,
+            "dcim.interface",
+            # A type NetBox's own field validation refuses.
+            [self._row("Ethernet7", type="not-a-real-interface-type")],
+        )
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["creates"] + result["rejected"], 1)
+
+    def test_a_preview_creates_no_interface(self):
+        from dcim.models import Interface
+
+        before = Interface.objects.count()
+
+        compare_model_rows(None, "dcim.interface", [self._row("Ethernet99")])
+
+        self.assertEqual(Interface.objects.count(), before)
+
+
 class IpAddressComparisonTest(TestCase):
     """ipaddress writes a VRF mid-classification, behind a runner call.
 

--- a/forward_netbox/tests/test_preview_primes_its_lookup_caches.py
+++ b/forward_netbox/tests/test_preview_primes_its_lookup_caches.py
@@ -23,13 +23,28 @@ Two properties have to hold together, and only one is about speed:
     That is the shape of a converged estate, which is the shape every routine
     preview has.
 
-What is deliberately NOT claimed here is the create path. A row with no
-counterpart is instantiated, and NetBox charges two queries per instance for
-content type and custom field defaults. Those are its costs, not our lookups,
-and the only way to avoid them is to stop routing the preview through the real
-apply - which is exactly the divergence `drift_comparison` exists to prevent.
-So the create cost is measured and pinned as per-row rather than quietly
-described as fixed.
+What was deliberately NOT claimed here was the create path, on the reasoning
+that a row with no counterpart is instantiated, that NetBox charges two queries
+per instance for content type and custom field defaults, and that the only way
+to avoid them is to stop routing the preview through the real apply.
+
+**The middle step of that was wrong, and measurement says so.** The per-row
+charge came from `_validate_interface` - `full_clean` - not from
+`Interface(**defaults)`. The preview now skips the validation and still
+instantiates, still resolves, still classifies through the same code, and the
+query count went from 9,000 to 36 across 16,000 first-sync rows (29,139 ms to
+1,467 ms). Instantiation is cheap; validating is not.
+
+So the create path is no longer charged per row, and that is NOT the divergence
+this module warned about - the preview still routes through the real apply. One
+narrower divergence was bought knowingly: a row `full_clean` would reject counts
+as a create rather than failed, which overstates drift and never understates it,
+pinned by `test_an_invalid_interface_row_counts_as_a_create_under_preview` in
+`test_drift_comparison`.
+
+The canary below is kept, with its assertion moved off query count - which no
+longer varies - and onto the property it was really protecting: that each row
+is still classified individually.
 """
 
 from dcim.models import Device
@@ -147,22 +162,30 @@ class PreviewPrimesItsLookupCachesTest(TestCase):
             "cold one it replaces",
         )
 
-    def test_the_create_path_is_still_charged_per_row(self):
-        # Not a defect to fix here, and pinned so that it is not mistaken for
-        # one that already was. See the module docstring.
+    def test_the_create_path_still_classifies_every_row(self):
+        """The canary this module has always carried, re-aimed.
+
+        It used to assert that the create path costs MORE QUERIES for more
+        rows, as proof the preview was still going through the real apply. That
+        proxy died when the preview stopped validating: queries are flat now
+        (36 for 16,000 rows) while the classification is unchanged. Asserting
+        the dead proxy would have forced the cost back to keep a test happy.
+
+        What it was really protecting is that each row is still put through the
+        classification rather than short-circuited in bulk - so that is what it
+        asserts now, on the counts themselves, which is also the thing an
+        operator reads.
+        """
         few = self._absent(2)
         many = self._absent(8)
 
-        with CaptureQueriesContext(connection) as few_queries:
-            compare_model_rows(None, "dcim.interface", few)
-        with CaptureQueriesContext(connection) as many_queries:
-            compare_model_rows(None, "dcim.interface", many)
+        few_result = compare_model_rows(None, "dcim.interface", few)
+        many_result = compare_model_rows(None, "dcim.interface", many)
 
-        self.assertGreater(
-            len(many_queries),
-            len(few_queries),
-            "a row with no counterpart is instantiated, and NetBox charges for "
-            "that per instance; if this ever goes flat the preview has stopped "
-            "going through the real apply path and the counts can no longer be "
-            "trusted to match it",
-        )
+        # Counted against the row lists themselves rather than hard-coded, so
+        # the assertion survives `_absent` changing how many devices it spans.
+        self.assertEqual(few_result["creates"], len(few))
+        self.assertEqual(many_result["creates"], len(many))
+        self.assertEqual(few_result["unchanged"], 0)
+        self.assertEqual(many_result["unchanged"], 0)
+        self.assertGreater(len(many), len(few))

--- a/forward_netbox/utilities/apply_engine_bulk.py
+++ b/forward_netbox/utilities/apply_engine_bulk.py
@@ -1764,7 +1764,24 @@ def bulk_orm_apply_interface(
                 # DB query (constraint violations still surface via isolate).
                 # Every field of a new interface is written by this row, so a
                 # rejection here is always ours and never pre-existing state.
-                disposition = _validate_interface(interface, row, device, set(defaults))
+                # `_validate_interface` runs `full_clean`, which a preview does
+                # not need and which dominated this model's cost: at 16,000
+                # first-sync rows it was 29,139 ms / 9,000 queries against
+                # 1,467 ms / 36 without it. Constructing the Interface is
+                # CHEAP - it is the validation that queries, so unlike the
+                # macaddress path the object is still built and still flows
+                # into LAG resolution unchanged.
+                #
+                # Same deliberate, pinned divergence as macaddress: a row
+                # `full_clean` would reject counts here as a create rather than
+                # failed. Overstates drift, never understates it. Held by
+                # `test_an_invalid_row_counts_as_a_create_under_preview` in
+                # `test_drift_comparison`.
+                disposition = (
+                    "ok"
+                    if preview
+                    else _validate_interface(interface, row, device, set(defaults))
+                )
                 if disposition != "ok":
                     # No outcome slot has been appended for this row yet, so the
                     # tail loop will not count it; count it here as the
@@ -1791,11 +1808,29 @@ def bulk_orm_apply_interface(
         outcome = ["unchanged"]
         row_outcomes.append(outcome)
         if changed_values:
-            _snapshot_once(existing)
-            for field, value in changed_values:
-                setattr(existing, field, value)
-            disposition = _validate_interface(
-                existing, row, device, {field for field, _ in changed_values}
+            if not preview:
+                # Skipped under preview because the snapshot exists solely to
+                # feed the branch diff of a write that never happens, and the
+                # mutation solely to stage that write. `changed_values` already
+                # decided the row differs.
+                #
+                # Honest scope, having tried to justify it more strongly and
+                # failed: this is NOT fixing a laundering bug like the one in
+                # `_ensure_fhrp_vip`. Duplicate rows for one interface are
+                # deduplicated upstream, so no second row ever reads the
+                # mutated object, and no test written here could distinguish
+                # the two behaviours. Nor is it measurable - 36 queries either
+                # way on the shapes benchmarked. It stands on being work a
+                # preview provably does not need, and nothing more.
+                _snapshot_once(existing)
+                for field, value in changed_values:
+                    setattr(existing, field, value)
+            disposition = (
+                "ok"
+                if preview
+                else _validate_interface(
+                    existing, row, device, {field for field, _ in changed_values}
+                )
             )
             if disposition != "ok":
                 # The outcome slot is already appended, so the tail loop counts


### PR DESCRIPTION
## Summary

**Stacked on #296.** Same treatment as #295, applied to the deployment's
largest compared model (357,274 rows) after #296 measured it.

`_validate_interface` runs `full_clean`, which a preview does not need. Skipped
on both branches. **Unlike #295 there is no sentinel** — the `Interface` is
still constructed and still flows into LAG resolution, because construction
turned out to be cheap.

| 16,000 rows | before | after |
| --- | --- | --- |
| first sync | 1.821 ms/row, 9,000 q, 29,139 ms | **0.092 ms/row, 36 q, 1,467 ms** |
| converged | 0.088 ms/row, 36 q | 0.079 ms/row, 36 q |

**~20× on a first sync** (357,274 rows: ~10.7 min → ~33 s); converged unchanged,
as expected — so this does nothing for the reporting deployment's steady state,
which measures ~21 s and needs nothing.

Negative control: restoring `_validate_interface` puts it back to 28,883 ms /
9,000 queries, so the win is attributable to that call and nothing else.

## It corrects a documented belief

`test_preview_primes_its_lookup_caches` stated that a create-path row *"is
instantiated, and NetBox charges two queries per instance"*, and that *"the only
way to avoid them is to stop routing the preview through the real apply"*.

**The middle step is wrong.** The charge came from `full_clean`, not
`Interface(**defaults)`. The preview still instantiates, still resolves, still
classifies through the same code — and the queries went flat anyway.

That module's canary asserted the create path costs *more queries* for more
rows, as proof the preview still went through the real apply. **That proxy is
now dead, and asserting a dead proxy would force the cost back to keep a test
green.** It is re-aimed at the property it was really protecting: every row is
still classified individually, checked on the counts an operator reads.

## Two of my own tests were worthless, and are gone

The update branch also skips `_snapshot_once` and the `setattr` loop. I first
justified that as preventing the `_ensure_fhrp_vip` laundering bug and wrote two
tests for it. A negative control showed **neither could fail** against the
behaviour it named — `refresh_from_db()` reloads from the database, so it can
never see an in-memory mutation, and duplicate rows turn out to be deduplicated
upstream so no second row reads the object anyway.

Both removed. The skip stands on being work a preview provably does not need,
and the comment now says exactly that and nothing stronger.

## Test plan

- [x] 5 contract tests incl. the pinned divergence; **481 green** with all of
      `test_sync` and `test_apply_engine`
- [x] pre-commit clean; `check_harness.py --base origin/main` passes

Refs #206

Claude-Session: https://claude.ai/code/session_012Qfd3hTSxZtmFHuzRJnZre