### PR TITLE
chore: accept netbox-branching 1.1.3 (2.9.1 candidate)

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -9,7 +9,7 @@ cryptography==50.0.0
 httpx==0.28.1
 netbox-cisco-aci==0.4.0
 netbox-dlm==0.9.1
-netboxlabs-netbox-branching==1.1.2
+netboxlabs-netbox-branching==1.1.3
 netbox-peering-manager==0.3.0
 netbox-routing==0.4.3
 netbox-validity==3.5.2

--- a/development/constraints-upgrade-from.txt
+++ b/development/constraints-upgrade-from.txt
@@ -3,7 +3,7 @@
 # The upgrade gate installs a previously released wheel, and a previous release
 # supports the runtime it shipped against — not the current one. Releases before
 # 2.6.7 pinned `netboxlabs-netbox-branching==1.1.1` exactly and capped NetBox at
-# 4.6.5, so applying the current `constraints.txt` (branching 1.1.2) to that
+# 4.6.5, so applying the current `constraints.txt` (branching 1.1.3) to that
 # install is unsatisfiable, not merely out of date. The gate failed closed on
 # exactly this for every available from-version.
 #

--- a/docs/03_Plans/active/2026-08-27-branching-1.1.3.md
+++ b/docs/03_Plans/active/2026-08-27-branching-1.1.3.md
@@ -1,0 +1,124 @@
+# Accept netbox-branching 1.1.3
+
+## Goal
+
+Move the validated branching pin from 1.1.2 to 1.1.3 as a 2.9.1 candidate, and
+record what that release does and does not buy.
+
+## Why
+
+1.1.3 is the current release and changes three files, two of which sit on paths
+this plugin exercises hard:
+
+- `ChangeDiff.save()` no longer resolves `self.object` - a GenericForeignKey,
+  several queries - unless `object_repr` is among the fields being saved. Merge
+  writes ChangeDiffs in bulk, so this is a real saving on a hot path.
+- `_update_conflicts()` changes `modified[k]` to `modified.get(k)` in three
+  places.
+- `signal_receivers.py` moves the global-change handler from a bulk `.update()`
+  to a per-diff loop, guards a debug log behind `isEnabledFor` (the
+  GenericForeignKey was resolved eagerly even with logging off), and imports
+  `DatabaseError` and `transaction`.
+
+**It does NOT unblock NetBox 4.7.** 1.1.3 declares `max_version = '4.6.99'`,
+identical to 1.1.2, so the 4.7 uplift stays blocked upstream exactly as
+measured for 2.8.4. That was the question this evaluation started from and the
+answer is no.
+
+## Constraints
+
+- Every pin site moves together. Two of them fail late and expensively:
+  `validate_installed_artifact.py` hard-fails on a version mismatch, and
+  `check_release_authorization.py` matches the literal string `Branching 1.1.3`
+  in the evidence prose - a miss there refuses the release AFTER the tag
+  exists, which spends a version number.
+- `development/constraints-upgrade-from.txt` must STAY at 1.1.1.
+  `UpgradeFromConstraintsTests` asserts the two constraint files differ only in
+  the branching pin, and the upgrade gate's from-side needs a pin the previous
+  release can satisfy.
+- No behaviour of ours changes. This is a dependency bump.
+
+## Touched Surfaces
+
+- `constraints.txt`
+- `scripts/validate_sbom.py`, `scripts/validate_installed_artifact.py`
+- `scripts/check_release_authorization.py`,
+  `scripts/tests/test_release_authorization.py`
+- `forward_netbox/tests/test_optional_plugin_versions.py`
+- two stale comments (`constraints-upgrade-from.txt`, `scripts/tests/test_tasks.py`)
+
+`pyproject.toml` already allows it (`>=1.1.1,<1.2.0`) and
+`validated_runtime.py` pins the SERIES (`"1.1"`), so neither moves - which is
+the point of pinning a series rather than a patch.
+
+## Approach
+
+Bump the seven sites, install 1.1.3 into the gate runtime, and run the suites
+that actually touch what changed rather than only the fast ones.
+
+### Nothing is retired, and one fix matters MORE now
+
+`_update_conflicts`'s `modified[k]` is exactly the line
+`2026-08-19-mixed-model-change-diffs.md` identified as where a deployment's
+`KeyError` was raised. It is tempting to read 1.1.3 as making that fix
+redundant. It is the opposite.
+
+Our fix is at the CAUSE: `_sync_branch_change_diffs` groups by each change's
+own `changed_object_type` instead of typing the whole batch from
+`object_changes[0]`, so a batch carrying two models can no longer file one
+model's changes against the other's diffs and write a diff whose `object_type`
+says IPAddress while its `original` holds a serialized Device.
+
+1.1.3 is at the SYMPTOM: `.get()` means indexing a corrupted diff no longer
+raises.
+
+So under 1.1.3 alone, that corruption would no longer crash - it would merge
+with silently wrong conflict data. The deployment's failure was diagnosable
+precisely because it crashed deterministically at plan item 51 of 90. Removing
+our fix would trade a loud, locatable failure for a quiet, wrong one. The
+`.get()` is a lost canary, not a replacement.
+
+## Validation
+
+Run against 1.1.3 installed in the release-gate runtime:
+
+- `invoke harness-test`: 334 tests OK.
+- Django, the branching-sensitive selection: 477 tests OK -
+  `test_mixed_model_change_diffs`, `test_bulk_merge`,
+  `test_merge_observability`, `test_sync`, `test_apply_engine`,
+  `test_optional_plugin_versions`, `test_runtime_dependency_check`.
+
+`test_mixed_model_change_diffs` and `test_bulk_merge` are the ones that matter:
+the signal-receiver rewrite is a hot merge path, and the first is the
+regression suite for the interaction described above.
+
+The full gate has NOT been run on this branch yet; it is a candidate, not a
+release.
+
+## Rollback
+
+Revert the seven sites and reinstall 1.1.2. No migration, no data change - the
+pin is the whole change.
+
+## Decision Log
+
+- **Take 1.1.3 despite it not unblocking 4.7.** The `ChangeDiff.save()` fix is
+  on a path merge hits hard, and staying a patch behind on a dependency this
+  central costs more than it saves.
+- **Retire nothing.** See above; the cause fix outlives the symptom fix, and
+  the symptom fix quietly removes the signal that made the cause findable.
+- **Leave `validated_runtime.py` alone.** It pins the series deliberately, so a
+  patch release must not require editing it. This bump is evidence that the
+  series pin works.
+
+## Open
+
+- `poetry.lock` still records 1.1.1 while `constraints.txt` now says 1.1.3 -
+  the documented "`poetry lock` alone does not move the lockfile" trap. Harmless
+  in practice because the Docker builds install under `--constraint`, but a bare
+  `poetry install` gets a version nothing validated. Worth a separate `poetry
+  update --lock netboxlabs-netbox-branching`.
+- Whether the `ChangeDiff.save()` saving is measurable on a real merge is
+  unmeasured. The `FORWARD_ADAPTER_SCALE` harness added this week measures the
+  comparison, not the merge.
+- NetBox 4.7 remains blocked on branching upstream.

--- a/forward_netbox/tests/test_optional_plugin_versions.py
+++ b/forward_netbox/tests/test_optional_plugin_versions.py
@@ -129,7 +129,7 @@ class FastBaselineRuntimeTupleTest(SimpleTestCase):
 
         tuple_ = {
             "netbox": "4.6.9",
-            "branching": "1.1.2",
+            "branching": "1.1.3",
             "forward_netbox": fast_baseline.forward_config.version,
             "optional_plugins": {
                 "netbox-cisco-aci": "0.4.0",

--- a/scripts/check_release_authorization.py
+++ b/scripts/check_release_authorization.py
@@ -67,7 +67,7 @@ EVIDENCE_BASE_RE = re.compile(
 EVIDENCE_REQUIRED_TEXT_PATTERNS = {
     "exact-runtime-artifact": (
         re.compile(r"\bNetBox\s+4\.6\.8\b", re.IGNORECASE),
-        re.compile(r"\bBranching\s+1\.1\.2\b", re.IGNORECASE),
+        re.compile(r"\bBranching\s+1\.1\.3\b", re.IGNORECASE),
         re.compile(r"\bPython\s+3\.14\b", re.IGNORECASE),
         re.compile(r"\bSBOM\b", re.IGNORECASE),
     ),

--- a/scripts/tests/test_release_authorization.py
+++ b/scripts/tests/test_release_authorization.py
@@ -26,7 +26,7 @@ class ReleaseAuthorizationTest(unittest.TestCase):
             "`rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate "
             "FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data "
             "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 "
-            "invoke artifact-test` passed: NetBox 4.6.8, Branching 1.1.2, "
+            "invoke artifact-test` passed: NetBox 4.6.8, Branching 1.1.3, "
             "Python 3.14, and SBOM validation; 0 errors."
         ),
         "scale-and-failure": (

--- a/scripts/tests/test_tasks.py
+++ b/scripts/tests/test_tasks.py
@@ -1363,7 +1363,7 @@ class UpgradeFromConstraintsTests(unittest.TestCase):
 
     The upgrade gate's from side needs its own constraints because releases
     before 2.6.7 pin `netboxlabs-netbox-branching==1.1.1` exactly, which the
-    current pin of 1.1.2 cannot satisfy. That is the only difference the
+    current pin of 1.1.3 cannot satisfy. That is the only difference the
     upgrade is meant to exercise; anything else drifting between the two sides
     would silently change what the gate compares.
     """

--- a/scripts/validate_installed_artifact.py
+++ b/scripts/validate_installed_artifact.py
@@ -35,8 +35,8 @@ def main():
         )
     if netbox_version != "4.6.8":
         raise SystemExit(f"NetBox {netbox_version} != required 4.6.8")
-    if branching_version != "1.1.2":
-        raise SystemExit(f"netbox-branching {branching_version} != required 1.1.2")
+    if branching_version != "1.1.3":
+        raise SystemExit(f"netbox-branching {branching_version} != required 1.1.3")
 
     print(
         json.dumps(

--- a/scripts/validate_sbom.py
+++ b/scripts/validate_sbom.py
@@ -16,7 +16,7 @@ REQUIRED_COMPONENTS = {
     "netbox-peering-manager": "0.3.0",
     "netbox-routing": "0.4.3",
     "netbox-validity": "3.5.2",
-    "netboxlabs-netbox-branching": "1.1.2",
+    "netboxlabs-netbox-branching": "1.1.3",
     "pyzipper": "0.4.0",
 }
 


### PR DESCRIPTION
## Summary

**Standalone version of #299, based on `main`** rather than on the eight-deep
#206 drift stack — so 2.9.1 can ship without any of that work. Same commit,
cherry-picked cleanly. Close whichever of the two you don't want.

Moves the validated branching pin 1.1.2 → 1.1.3 across all seven sites.

## It does NOT unblock NetBox 4.7

1.1.3 declares `max_version = '4.6.99'` — **identical to 1.1.2**. The uplift
stays blocked upstream exactly as measured for 2.8.4. That was the question this
started from; the answer is no.

## What it changes

- **`ChangeDiff.save()`** no longer resolves `self.object` (a
  GenericForeignKey, several queries) unless `object_repr` is being saved. Merge
  writes ChangeDiffs in bulk, so this is a real saving on a hot path.
- **`_update_conflicts()`** — `modified[k]` → `modified.get(k)`.
- **`signal_receivers.py`** — global-change handler moves from a bulk
  `.update()` to a per-diff loop; debug log guarded behind `isEnabledFor` (the
  GFK was resolved eagerly even with logging off).

## Nothing is retired — one of our fixes matters *more* now

`_update_conflicts`'s `modified[k]` is **exactly** the line
`2026-08-19-mixed-model-change-diffs.md` named as where a deployment's
`KeyError` fired, so 1.1.3 reads like it makes our 2.8.6 fix redundant. The
opposite is true:

- **Ours is at the cause** — `_sync_branch_change_diffs` groups by each change's
  own `changed_object_type`, so a two-model batch can no longer write a diff
  whose `object_type` says IPAddress while its `original` holds a Device.
- **1.1.3 is at the symptom** — `.get()` means indexing a corrupted diff no
  longer raises.

Under 1.1.3 alone that corruption would **merge with silently wrong conflict
data instead of crashing**. That failure was diagnosable precisely *because* it
crashed deterministically at plan item 51 of 90. The `.get()` is a lost canary,
not a replacement.

## The two pin sites that fail late

`validate_installed_artifact.py` hard-fails on a mismatch, and
`check_release_authorization.py` matches the **literal string** `Branching
1.1.3` in evidence prose — a miss there refuses the release *after* the tag
exists, spending a version number.

`pyproject.toml` and `validated_runtime.py` (series `"1.1"`) needed no edit,
which is the point of pinning a series. `constraints-upgrade-from.txt`
deliberately **stays at 1.1.1**.

## Test plan

- [x] `invoke harness-test`: **334 OK**
- [x] **477 Django tests OK** against 1.1.3 installed in the gate runtime
      (`mixed_model_change_diffs`, `bulk_merge`, `merge_observability`, `sync`,
      `apply_engine`, `optional_plugin_versions`, `runtime_dependency_check`)
- [x] pre-commit clean; `check_harness.py --base origin/main` passes
- [ ] Full gate not yet run — candidate, not a release

## Deliberately not included

`poetry.lock` still says 1.1.1. Running `poetry update --lock
netboxlabs-netbox-branching` moves it correctly, but it also backfills **37
packages that were never recorded** — `netbox-validity` and its entire
transitive subtree (netmiko, paramiko, scrapli…), missing since validity was
added in 2.9.0. That is 1,346 inserted lines and a pre-existing gap unrelated to
branching, so it goes in its own PR. Nothing consumes `poetry.lock` (no
Dockerfile, workflow, or script references it), which is why the drift was
invisible and why it is safe to fix separately.

Claude-Session: https://claude.ai/code/session_012Qfd3hTSxZtmFHuzRJnZre