### PR TITLE
release: prepare 2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Generated from the README compatibility table by `scripts/gen_changelog.py`. Do not edit by hand.
 
+## v2.9.1
+
+Release candidate; Accepts netbox-branching 1.1.3 and records the validated runtime in the lockfile.
+
 ## v2.9.0
 
 Feature: back up device configurations from Forward into a git data source for Validity golden-config checks, plus the runtime-validation refactor and health check it required.

--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ See the
 
 ## Release Compatibility
 
-The `2.9.0` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
+The `2.9.1` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
+| `v2.9.1` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Accepts netbox-branching 1.1.3 and records the validated runtime in the lockfile. |
 | `v2.9.0` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Feature: back up device configurations from Forward into a git data source for Validity golden-config checks, plus the runtime-validation refactor and health check it required. |
 | `v2.8.9` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.0`; Fix: a sync deletes a device only on the same quarantined evidence the operator prune requires, and never stages a delete the database will refuse. |
 | `v2.8.8` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.9`; Fix: the dependency preview runs again on deployments with optional plugins installed. |

--- a/docs/01_User_Guide/README.md
+++ b/docs/01_User_Guide/README.md
@@ -70,13 +70,14 @@ migrations, e.g. netbox-dlm `0.2.0+`; older builds need
 
 ## Release Compatibility
 
-The `2.9.0` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
+The `2.9.1` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
+| `v2.9.1` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Accepts netbox-branching 1.1.3 and records the validated runtime in the lockfile. |
 | `v2.9.0` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Feature: back up device configurations from Forward into a git data source for Validity golden-config checks, plus the runtime-validation refactor and health check it required. |
 | `v2.8.9` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.0`; Fix: a sync deletes a device only on the same quarantined evidence the operator prune requires, and never stages a delete the database will refuse. |
 | `v2.8.8` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.9`; Fix: the dependency preview runs again on deployments with optional plugins installed. |

--- a/docs/03_Plans/active/2026-08-27-release-2.9.1.md
+++ b/docs/03_Plans/active/2026-08-27-release-2.9.1.md
@@ -1,0 +1,110 @@
+# Release 2.9.1
+
+## Goal
+
+Ship the netbox-branching 1.1.3 uptake, and the lockfile correction that
+chasing it uncovered.
+
+## Why
+
+1.1.3 fixes three things, two on paths this plugin exercises hard:
+`ChangeDiff.save()` no longer resolves a GenericForeignKey for rows whose
+`object_repr` is not being written (merge writes ChangeDiffs in bulk);
+`_update_conflicts` stops indexing `modified` directly; and the global-change
+signal receiver stops resolving a GenericForeignKey for a debug message that is
+usually discarded.
+
+The evaluation began as "does 1.1.3 unblock NetBox 4.7". It does not - 1.1.3
+declares `max_version = '4.6.99'`, byte-identical to 1.1.2 - and that answer is
+recorded here so the question is not re-asked from scratch next time.
+
+Chasing the pin turned up the second change: `poetry.lock` had described a
+runtime from 2.6.7, and was missing `netbox-validity` and its entire transitive
+subtree - the same subtree the 2.9.0 preflight had to trace by hand when
+paramiko's `PYSEC-2026-2858` blocked the gate.
+
+## Constraints
+
+- A patch release. No behaviour of ours changes; both commits are dependency
+  bookkeeping.
+- `constraints.txt` stays the authority on what ships. The lockfile is being
+  made accurate, not made load-bearing.
+- Nothing is retired on the strength of 1.1.3. See below.
+
+## Touched Surfaces
+
+Landed across two pull requests:
+
+- `#300` chore: accept netbox-branching 1.1.3
+- `#302` chore: make poetry.lock record the runtime we actually validate
+
+This commit adds the version surfaces, the compatibility tables, and this plan.
+
+## Approach
+
+Seven pin sites move together for the branching bump. Two of them fail late and
+expensively and are worth naming for the next person:
+`validate_installed_artifact.py` hard-fails on a version mismatch, and
+`check_release_authorization.py` matches the literal string `Branching 1.1.3` in
+the evidence prose - a miss there refuses the release AFTER the tag exists,
+which spends a version number.
+
+`pyproject.toml` and `validated_runtime.py` needed no edit, because the latter
+pins the SERIES. This release is the evidence that the series pin does its job.
+
+### Nothing is retired, and one of our fixes matters more
+
+`_update_conflicts`'s `modified[k]` is exactly the line
+`2026-08-19-mixed-model-change-diffs.md` identified as where a deployment's
+`KeyError` was raised, so 1.1.3 reads like it makes our 2.8.6 fix redundant. It
+is the opposite. Ours is at the CAUSE: `_sync_branch_change_diffs` groups by
+each change's own `changed_object_type`, so a two-model batch can no longer
+write a diff whose `object_type` says IPAddress while its `original` holds a
+serialized Device. 1.1.3 is at the SYMPTOM: `.get()` means indexing a corrupted
+diff no longer raises.
+
+Under 1.1.3 alone that corruption would merge with silently wrong conflict data
+instead of crashing. That failure was diagnosable precisely because it crashed
+deterministically at plan item 51 of 90. The `.get()` removed the canary, not
+the fire.
+
+## Validation
+
+Recorded in the Release Authorization section below, bound to the evidence base
+commit: the full isolated gate and the exact-runtime artifact test, both on the
+final tree, both on NetBox 4.6.8 with branching 1.1.3.
+
+Before the release branch existed, 1.1.3 was installed into the gate runtime and
+the branching-sensitive suites run against it: `invoke harness-test` 334 OK,
+plus 477 Django tests across `test_mixed_model_change_diffs`, `test_bulk_merge`,
+`test_merge_observability`, `test_sync`, `test_apply_engine`,
+`test_optional_plugin_versions` and `test_runtime_dependency_check`.
+`test_mixed_model_change_diffs` and `test_bulk_merge` are the ones that matter:
+the signal-receiver rewrite is a hot merge path.
+
+## Rollback
+
+Revert both commits and reinstall 1.1.2. No migration and no data change - the
+pin is the whole change. A downgrade is an install of the prior wheel.
+
+## Decision Log
+
+- **Take 1.1.3 despite it not unblocking 4.7.** The `ChangeDiff.save()` fix is
+  on a path merge hits hard, and staying a patch behind on a dependency this
+  central costs more than it saves.
+- **Ship the lockfile correction in the same release.** It is bookkeeping with
+  no runtime effect, and holding it back would leave the file describing a
+  runtime three releases stale for no gain.
+- **Leave the `cryptography` lock divergence in place.** It is transitive from
+  NetBox and absent from `pyproject.toml`; forcing it would mean declaring a
+  dependency this package does not have to satisfy a file nothing reads.
+
+## Open
+
+- **Nothing consumes `poetry.lock`** - no Dockerfile, workflow or script. That
+  is why it drifted three releases unnoticed. Either the harness should enforce
+  it (`poetry check --lock`) or the file should go; accurate-today and
+  unenforced only resets the clock.
+- NetBox 4.7 remains blocked on netbox-branching upstream.
+- Whether the `ChangeDiff.save()` saving is measurable on a real merge is
+  unmeasured; this month's scale harness measures the comparison, not the merge.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,13 +8,14 @@ Forward 26.6 is the baseline for async NQE.
 
 ## Release Compatibility
 
-The `2.9.0` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
+The `2.9.1` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
+| `v2.9.1` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Accepts netbox-branching 1.1.3 and records the validated runtime in the lockfile. |
 | `v2.9.0` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Feature: back up device configurations from Forward into a git data source for Validity golden-config checks, plus the runtime-validation refactor and health check it required. |
 | `v2.8.9` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.0`; Fix: a sync deletes a device only on the same quarantined evidence the operator prune requires, and never stages a delete the database will refuse. |
 | `v2.8.8` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.8.9`; Fix: the dependency preview runs again on deployments with optional plugins installed. |

--- a/forward_netbox/__init__.py
+++ b/forward_netbox/__init__.py
@@ -5,7 +5,7 @@ class NetboxForwardConfig(PluginConfig):
     name = "forward_netbox"
     verbose_name = "Forward"
     description = "Sync Forward data into NetBox using built-in NQE queries."
-    version = "2.9.0"
+    version = "2.9.1"
     base_url = "forward"
     min_version = "4.6.5"
     max_version = "4.6.99"

--- a/forward_netbox/tests/test_runtime_dependency_check.py
+++ b/forward_netbox/tests/test_runtime_dependency_check.py
@@ -23,7 +23,7 @@ class RuntimeDependencyCheckTest(SimpleTestCase):
         self.assertIsNotNone(_resolved_branching_version())
 
     def test_plugin_config_version_matches_package_release(self):
-        self.assertEqual(NetboxForwardConfig.version, "2.9.0")
+        self.assertEqual(NetboxForwardConfig.version, "2.9.1")
 
     def test_exact_runtime_passes(self):
         _check_runtime_dependencies()

--- a/forward_netbox/utilities/fast_baseline.py
+++ b/forward_netbox/utilities/fast_baseline.py
@@ -201,7 +201,7 @@ def _runtime_decision():
     expected = {
         "netbox_series": VALIDATED_NETBOX_SERIES,
         "branching_series": VALIDATED_BRANCHING_SERIES,
-        "forward_netbox": "2.9.0",
+        "forward_netbox": "2.9.1",
         # Each optional distribution lists every version validated against this
         # engine, not a single pin. An exact pin meant a customer upgrading one
         # optional plugin silently lost the fast baseline — no error, just a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "forward-netbox"
-version = "2.9.0"
+version = "2.9.1"
 description = "NetBox plugin to sync Forward data into NetBox via built-in NQE queries"
 authors = ["Craig Johnson <craigjohnson@forwardnetworks.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Version surfaces, compatibility tables, and the release plan for 2.9.1.

Production changes landed in #300 (netbox-branching 1.1.3) and #302 (lockfile).
Both are dependency bookkeeping — no behaviour of ours changes.

Recorded in the plan so it is not re-asked from scratch:

- **1.1.3 does not unblock NetBox 4.7.** It declares `max_version = '4.6.99'`,
  byte-identical to 1.1.2.
- **Nothing of ours is retired on the strength of it.** Its `modified.get(k)`
  fixes at the *symptom* the same failure our 2.8.6 change fixed at the *cause*
  — so under 1.1.3 alone that corruption would merge with silently wrong
  conflict data instead of crashing.

## Test plan

- [x] `invoke harness-test`: 334 OK, and 477 Django tests against 1.1.3 in the
      gate runtime (incl. `test_mixed_model_change_diffs`, `test_bulk_merge`)
- [x] pre-commit clean; `check_harness.py --base origin/main` passes
- [ ] Full gate runs against the merged tree before authorization

Claude-Session: https://claude.ai/code/session_012Qfd3hTSxZtmFHuzRJnZre