### PR TITLE
release: authorize 2.9.1

### DIFF
--- a/docs/03_Plans/active/2026-08-27-release-2.9.1.md
+++ b/docs/03_Plans/active/2026-08-27-release-2.9.1.md
@@ -108,3 +108,40 @@ pin is the whole change. A downgrade is an install of the prior wheel.
 - NetBox 4.7 remains blocked on netbox-branching upstream.
 - Whether the `ChangeDiff.save()` saving is measurable on a real merge is
   unmeasured; this month's scale harness measures the comparison, not the merge.
+
+## Release Authorization
+
+- Evidence base commit: `bc8313a54e1f781425045a4db144f36fa4b89ab0`
+
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.9.0 invoke ci` passed on the final 2.9.1 tree with exit status 0: 334 harness tests OK, 70 scenario tests OK, 2311 Django tests OK with 4 skipped, 1 bulk-merge-retry-scale test OK, and 1 UI test OK covering 14 checks and 8 screenshots. The upgrade leg seeded under 2.9.0 on NetBox v4.6.5 and upgraded 2.9.0 -> 2.9.1 on NetBox v4.6.8, with the rows seeded under the previous release surviving.
+
+  The gated tree is the release tree apart from this authorization record, which
+  is Markdown in a single plan file and is appended after the gate by
+  construction.
+
+  This is the first gate run against netbox-branching 1.1.3. The suites that
+  exercise what 1.1.3 changed are inside that 2311: `test_mixed_model_change_diffs`
+  covers the ChangeDiff interaction its `_update_conflicts` change touches, and
+  `test_bulk_merge` covers the merge path its signal-receiver rewrite sits on.
+
+  `FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.9.0` supplies the upgrade source
+  because this host cannot reach the index to discover it; the upgrade,
+  migration and row-survival checks all still run in full against the built
+  wheel.
+
+  `FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1` records that the release-time
+  pattern feed is not on this host; the preflight prints that line as
+  `unverified`, and the release gate applies the superset feed and can still
+  refuse the tag. `check_sensitive_content.py --git-files --protected-history`
+  passes over tracked content and protected history against the widened local
+  feed.
+
+- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_HOST_PORT=8123 NETBOX_URL=http://127.0.0.1:8123 invoke artifact-test` passed with exit status 0 against the installed `forward_netbox-2.9.1-py3-none-any.whl` on NetBox 4.6.8, Branching 1.1.3, Python 3.14, with 7 authenticated menu routes returning 200, all plugin migrations applying cleanly with no drift, and a validated SBOM of 178 components.
+
+  The artifact's own report names Branching 1.1.3, which is the evidence that
+  the bump reached the installed wheel's runtime rather than only the
+  constraints file.
+
+The optional evidence ids are not recorded. The release owner's 2026-07-27
+proportionality decision applies; see
+`docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md`.


### PR DESCRIPTION
## Summary

Records the two required gate results on the final 2.9.1 tree, bound to
`bc8313a54e1f781425045a4db144f36fa4b89ab0` (the prepare commit) as the evidence
base.

**First release gated against netbox-branching 1.1.3.**

- `final-tree-full-gate`: exit 0 — 334 harness, 70 scenario, **2311 Django (4
  skipped)**, 1 bulk-merge-retry-scale, 1 UI test (14 checks, 8 screenshots).
  Upgrade leg 2.9.0 → 2.9.1 on NetBox 4.6.8, seeded rows survived.
- `exact-runtime-artifact`: exit 0 — installed
  `forward_netbox-2.9.1-py3-none-any.whl` on NetBox 4.6.8, **Branching 1.1.3**,
  Python 3.14; 7 authenticated menu routes returning 200, clean migrations, SBOM
  of 178 components.

The suites exercising what 1.1.3 changed sit inside that 2311:
`test_mixed_model_change_diffs` for the ChangeDiff interaction its
`_update_conflicts` change touches, and `test_bulk_merge` for the merge path its
signal-receiver rewrite sits on. The artifact report naming Branching 1.1.3 is
the evidence the bump reached the installed wheel's runtime, not just
`constraints.txt`.

## Test plan

- [x] `python3 scripts/check_release_authorization.py --version 2.9.1` passes
- [x] `check_harness.py --base origin/main` passes; pre-commit clean

Claude-Session: https://claude.ai/code/session_012Qfd3hTSxZtmFHuzRJnZre