### PR TITLE
feat: the preview reports its query count, not only its runtime

### DIFF
--- a/docs/03_Plans/active/2026-08-28-preview-reports-its-query-count.md
+++ b/docs/03_Plans/active/2026-08-28-preview-reports-its-query-count.md
@@ -1,9 +1,10 @@
-# The preview reports its query count, not only its runtime
+# The preview reports its query count and its SQL time, not only its runtime
 
 ## Goal
 
 Make the drift report say WHY a model was slow, by recording queries per model
-alongside the milliseconds it already records.
+AND the time those queries spent in the database, alongside the milliseconds it
+already records.
 
 ## Why
 
@@ -26,19 +27,41 @@ is chatter to batch. A low count against a high runtime is work inside Python -
 NetBox model instantiation, custom fields, serialization. The report could not
 tell them apart, and a runtime alone never will.
 
+**The count alone does not finish the split, and the local numbers say which
+way it will fail.** The converged comparison issues a FLAT handful of queries -
+13 for 4,000 rows, not one per row - so this deployment will almost certainly
+report a low count, and "low count, high runtime" reads as Python. It has a
+second reading the count cannot exclude: few queries, each slow. A sequential
+scan over 122,478 rows on a table this fixture cannot model, or a Postgres a
+network hop away where every round trip costs milliseconds, produces the same
+low count and wants an index or a move - not a rewrite. Only the share of the
+runtime spent inside `execute` separates them, and reporting a count without it
+would point the next person at Python on the strength of a number that cannot
+say so.
+
 ## Constraints
 
 - The count must be taken the way production runs. `connection.queries` only
   populates under `DEBUG`, which a release deployment never sets - so the
   number that matters most is exactly the one that would be absent.
 - A model with no comparison must report `None`, not `0`. Zero queries reads as
-  "free", which is a measurement that was never made.
+  "free", which is a measurement that was never made. The same rule holds for
+  the SQL time, and it has a real shape rather than a hypothetical one: the
+  count shipped in the first commit of this branch and the timing in the
+  second, so a payload carrying a count and no SQL time will exist. Zero there
+  would read as "the database was free" - the exact wrong conclusion to hand
+  someone reading a 276-second model.
+- The timing must survive a query that RAISES. A statement that times out is
+  disproportionately likely to BE the slow one; recording the elapsed time only
+  on the success path would drop the measurement in the case that most needs
+  it.
 - No behaviour change to the comparison itself. This measures; it does not fix.
 
 ## Touched Surfaces
 
-- `forward_netbox/views.py` - `_QueryCounter`, the per-model wrap, and the
-  count in both the coverage block and each model result
+- `forward_netbox/views.py` - `_QueryMeter` (was `_QueryCounter`; it now times
+  as well as counts), the per-model wrap, and both numbers in the coverage
+  block and in each model result
 - `forward_netbox/utilities/drift_report.py` - carries the count through, and
   onto `slowest_compared_model`
 - `forward_netbox/templates/forward_netbox/forwardsync_drift_report.html`
@@ -54,8 +77,13 @@ the deployment that needs it is a customer's.
 The count is reported in three places: summed across compared models in
 `comparison_coverage`, per model in `model_results`, and on
 `slowest_compared_model` - because naming the slowest model is half an answer
-and the count is the half that says which kind of slow it is. The report renders
-"Slowest: dcim.macaddress at 276377 ms in N queries".
+and the count is the half that says which kind of slow it is. The SQL time is
+carried through the same three places, summed over the same models so that a
+share is read against the runtime it is a share OF. The report renders
+"Slowest: dcim.macaddress at 276377 ms in 13 queries, 271900 ms of it in SQL".
+
+The elapsed time is taken in a `finally` around `execute(...)`, for the reason
+in the constraints, and costs one clock read per query on top of the increment.
 
 ## Validation
 
@@ -72,11 +100,21 @@ Two negative controls, both confirmed failing without their fix: removing the
 report plumbing fails the three payload tests; disabling the counter's
 increment fails the two meter tests that can observe it.
 
-381 tests green across the drift, preview and sync suites.
+The SQL timing adds six more on the same split: three that pin what the REPORT
+does with it (including the count-without-timing payload above), and three on
+the meter - it times what it counts, it times nothing when nothing runs, and a
+failing query still reports what it spent. Negative controls confirmed both
+ways: replacing the `finally` body with `pass` fails exactly the two meter
+tests that can observe elapsed time (including the failing-query one), and
+removing the three report lines errors exactly the three payload tests.
+
+495 tests green across the drift, preview, sync and view suites.
 
 ## Rollback
 
 Revert. The report returns to reporting a runtime with no way to explain it.
+Reverting only the second commit leaves a count with no way to tell a slow
+query from slow Python, which is the state this plan argues is not enough.
 
 ## Decision Log
 
@@ -90,11 +128,33 @@ Revert. The report returns to reporting a runtime with no way to explain it.
 - **Ship the measurement before the fix.** The remaining hypotheses need this
   number to be worth testing, and inventing a scenario to justify a fix is
   precisely how an earlier claim in this work had to be retracted.
+- **Time the queries as well as counting them, in the same change that ships
+  the count to a customer.** The count was going to come back low - the local
+  converged shape says so - and a low count with nothing beside it argues for
+  the wrong fix. Sending a customer's operators to instrument a second run
+  because the first one measured half the question is a cost this avoids for a
+  clock read per query.
 
 ## Open
 
 - This does NOT fix the 276 s. It makes the next report able to explain it.
-- If the count comes back high, the fix is batching. If it comes back low, the
-  next suspects are custom fields configured on `MACAddress` and the per-instance
-  cost of NetBox model construction at 122,478 rows - neither reproducible on a
-  fixture without knowing that deployment's configuration.
+- How to read the number that comes back, decided BEFORE seeing it so the
+  reading is not fitted to it:
+
+  | queries | SQL share | reading | fix |
+  | --- | --- | --- | --- |
+  | high | high | chatter | batch the per-row queries |
+  | high | low | chatter, cheap each | batch, or accept |
+  | low | high | few slow queries | index, vacuum, or DB locality |
+  | low | low | work inside Python | custom fields, model construction |
+
+- Only the bottom-left cell is new, and it is the one the count alone would
+  have mis-read as the bottom-right. It also names environmental suspects the
+  fixture cannot model at all: table bloat behind 122,478 rows, a query plan
+  that flips to a sequential scan at that size, and a Postgres on another host.
+- If it lands bottom-right, the next suspects are still custom fields
+  configured on `MACAddress` and the per-instance cost of NetBox model
+  construction - and custom fields, at least, are reachable locally as a
+  SENSITIVITY sweep (measure at 0, 10, 30 fields on `MACAddress`) even without
+  knowing that deployment's configuration: if 30 fields barely move ms/row, the
+  hypothesis dies regardless of how many they have.

--- a/docs/03_Plans/active/2026-08-28-preview-reports-its-query-count.md
+++ b/docs/03_Plans/active/2026-08-28-preview-reports-its-query-count.md
@@ -1,0 +1,100 @@
+# The preview reports its query count, not only its runtime
+
+## Goal
+
+Make the drift report say WHY a model was slow, by recording queries per model
+alongside the milliseconds it already records.
+
+## Why
+
+A deployment reports `dcim.macaddress` at 276,377 ms for 122,478 rows - 2.26
+ms/row - and that model is fully converged: 0 change candidates, drift 0, in
+sync. The same converged shape measures 0.065 ms/row locally, a ~35x gap.
+
+Every hypothesis testable against a local fixture has been eliminated, each
+with a knob left in `test_adapter_drift_scale.py` so nobody repeats the work:
+non-linearity (linear to 64,000 rows), estate interface count (30x the
+interfaces moved 1025 ms to 1081 ms), the per-row interface-lookup fallback
+(3.8x, so ~30 s at that scale rather than 276), per-row construct and
+`full_clean` (irrelevant when converged, measured identically with and without
+the fix), and branch-rewritten queries (the preview job activates no branch).
+netbox-branching 1.1.3 is now ruled out too: across that upgrade the figure
+moved 2.220 -> 2.257 ms/row, which is to say not at all.
+
+What remains splits in two, and the two want opposite fixes. A high query count
+is chatter to batch. A low count against a high runtime is work inside Python -
+NetBox model instantiation, custom fields, serialization. The report could not
+tell them apart, and a runtime alone never will.
+
+## Constraints
+
+- The count must be taken the way production runs. `connection.queries` only
+  populates under `DEBUG`, which a release deployment never sets - so the
+  number that matters most is exactly the one that would be absent.
+- A model with no comparison must report `None`, not `0`. Zero queries reads as
+  "free", which is a measurement that was never made.
+- No behaviour change to the comparison itself. This measures; it does not fix.
+
+## Touched Surfaces
+
+- `forward_netbox/views.py` - `_QueryCounter`, the per-model wrap, and the
+  count in both the coverage block and each model result
+- `forward_netbox/utilities/drift_report.py` - carries the count through, and
+  onto `slowest_compared_model`
+- `forward_netbox/templates/forward_netbox/forwardsync_drift_report.html`
+- `forward_netbox/tests/test_preview_reports_its_cost.py`
+
+## Approach
+
+`connection.execute_wrapper` rather than `connection.queries`, for the reason
+in the constraints. The wrapper is always active and costs one integer
+increment per query, so it can stay on in production - which it must, because
+the deployment that needs it is a customer's.
+
+The count is reported in three places: summed across compared models in
+`comparison_coverage`, per model in `model_results`, and on
+`slowest_compared_model` - because naming the slowest model is half an answer
+and the count is the half that says which kind of slow it is. The report renders
+"Slowest: dcim.macaddress at 276377 ms in N queries".
+
+## Validation
+
+11 tests, split deliberately across the two things that can be wrong:
+
+- Six feed a synthetic payload and pin what the REPORT does with the number,
+  including `None` rather than `0` for a payload written before this existed.
+- Three exercise the METER itself, because the first six would all pass while
+  the preview reported a count it never took - the plumbing verified and the
+  measurement absent. One of them asserts the count is taken with `DEBUG=False`,
+  which is the property that ruled out `connection.queries`.
+
+Two negative controls, both confirmed failing without their fix: removing the
+report plumbing fails the three payload tests; disabling the counter's
+increment fails the two meter tests that can observe it.
+
+381 tests green across the drift, preview and sync suites.
+
+## Rollback
+
+Revert. The report returns to reporting a runtime with no way to explain it.
+
+## Decision Log
+
+- **`execute_wrapper`, not `connection.queries`.** The latter is empty in every
+  environment where this question is worth asking.
+- **`None`, not `0`, for an uncompared model.** Same rule the runtime already
+  follows, and for the same reason.
+- **Test the meter separately from the plumbing.** Two tests written earlier
+  this session passed against the defects they named; splitting these was a
+  direct response to that.
+- **Ship the measurement before the fix.** The remaining hypotheses need this
+  number to be worth testing, and inventing a scenario to justify a fix is
+  precisely how an earlier claim in this work had to be retracted.
+
+## Open
+
+- This does NOT fix the 276 s. It makes the next report able to explain it.
+- If the count comes back high, the fix is batching. If it comes back low, the
+  next suspects are custom fields configured on `MACAddress` and the per-instance
+  cost of NetBox model construction at 122,478 rows - neither reproducible on a
+  fixture without knowing that deployment's configuration.

--- a/forward_netbox/templates/forward_netbox/forwardsync_drift_report.html
+++ b/forward_netbox/templates/forward_netbox/forwardsync_drift_report.html
@@ -148,9 +148,18 @@
                     {% blocktrans with rows=report.comparison_rows_compared %}for {{ rows }} rows{% endblocktrans %}
                   </span>
                 {% endif %}
+                {% if report.comparison_queries is not None %}
+                  <span class="text-muted">
+                    {% blocktrans with queries=report.comparison_queries %}in {{ queries }} queries{% endblocktrans %}
+                  </span>
+                {% endif %}
                 {% if report.slowest_compared_model %}
                   <div class="text-muted small mt-1">
-                    {% blocktrans with model=report.slowest_compared_model.model ms=report.slowest_compared_model.runtime_ms|floatformat:0 %}Slowest: {{ model }} at {{ ms }} ms{% endblocktrans %}
+                    {% if report.slowest_compared_model.queries is not None %}
+                      {% blocktrans with model=report.slowest_compared_model.model ms=report.slowest_compared_model.runtime_ms|floatformat:0 queries=report.slowest_compared_model.queries %}Slowest: {{ model }} at {{ ms }} ms in {{ queries }} queries{% endblocktrans %}
+                    {% else %}
+                      {% blocktrans with model=report.slowest_compared_model.model ms=report.slowest_compared_model.runtime_ms|floatformat:0 %}Slowest: {{ model }} at {{ ms }} ms{% endblocktrans %}
+                    {% endif %}
                   </div>
                 {% endif %}
               </td>

--- a/forward_netbox/templates/forward_netbox/forwardsync_drift_report.html
+++ b/forward_netbox/templates/forward_netbox/forwardsync_drift_report.html
@@ -153,9 +153,16 @@
                     {% blocktrans with queries=report.comparison_queries %}in {{ queries }} queries{% endblocktrans %}
                   </span>
                 {% endif %}
+                {% if report.comparison_sql_ms is not None %}
+                  <span class="text-muted">
+                    {% blocktrans with sql_ms=report.comparison_sql_ms|floatformat:0 %}({{ sql_ms }} ms in SQL){% endblocktrans %}
+                  </span>
+                {% endif %}
                 {% if report.slowest_compared_model %}
                   <div class="text-muted small mt-1">
-                    {% if report.slowest_compared_model.queries is not None %}
+                    {% if report.slowest_compared_model.queries is not None and report.slowest_compared_model.sql_ms is not None %}
+                      {% blocktrans with model=report.slowest_compared_model.model ms=report.slowest_compared_model.runtime_ms|floatformat:0 queries=report.slowest_compared_model.queries sql_ms=report.slowest_compared_model.sql_ms|floatformat:0 %}Slowest: {{ model }} at {{ ms }} ms in {{ queries }} queries, {{ sql_ms }} ms of it in SQL{% endblocktrans %}
+                    {% elif report.slowest_compared_model.queries is not None %}
                       {% blocktrans with model=report.slowest_compared_model.model ms=report.slowest_compared_model.runtime_ms|floatformat:0 queries=report.slowest_compared_model.queries %}Slowest: {{ model }} at {{ ms }} ms in {{ queries }} queries{% endblocktrans %}
                     {% else %}
                       {% blocktrans with model=report.slowest_compared_model.model ms=report.slowest_compared_model.runtime_ms|floatformat:0 %}Slowest: {{ model }} at {{ ms }} ms{% endblocktrans %}

--- a/forward_netbox/tests/test_preview_reports_its_cost.py
+++ b/forward_netbox/tests/test_preview_reports_its_cost.py
@@ -13,7 +13,9 @@ payload written before the cost was recorded, and a model that was never
 compared and therefore has no time to report.
 """
 
+from dcim.models import Site
 from django.test import SimpleTestCase
+from django.test import TestCase
 
 from forward_netbox.utilities.drift_report import compute_drift_report
 
@@ -136,3 +138,151 @@ class TheSlowestModelIsNamedTest(SimpleTestCase):
             )
         )
         self.assertIsNone(report["slowest_compared_model"])
+
+
+class TheReportCarriesTheQueryCountTest(SimpleTestCase):
+    """Milliseconds alone cannot say WHY a model was slow.
+
+    A deployment reported `dcim.macaddress` at 276,377 ms for 122,478 fully
+    converged rows - 2.26 ms/row, against 0.065 ms/row measured locally for the
+    same converged shape. Every hypothesis testable locally was eliminated, and
+    the two that remain want opposite fixes: a high query count is chatter to
+    batch, a low count against a high runtime is work inside Python. The report
+    could not tell them apart, so it now carries both.
+    """
+
+    def test_the_query_count_comes_from_the_preview(self):
+        report = compute_drift_report(
+            _payload(
+                [
+                    {
+                        "model": "dcim.macaddress",
+                        "row_count": 122478,
+                        "estimated_changes": 0,
+                        "change_estimate_kind": "exact_comparison",
+                        "comparison_runtime_ms": 276377.0,
+                        "comparison_queries": 245,
+                    }
+                ],
+                coverage={
+                    "measured_models": 1,
+                    "total_models": 1,
+                    "runtime_ms": 276377.0,
+                    "queries": 245,
+                    "rows_compared": 122478,
+                },
+            )
+        )
+        self.assertEqual(report["comparison_queries"], 245)
+
+    def test_the_slowest_model_carries_its_query_count(self):
+        # Naming the slowest model is half an answer; the count is the half
+        # that says which kind of slow it is.
+        report = compute_drift_report(
+            _payload(
+                [
+                    {
+                        "model": "dcim.macaddress",
+                        "row_count": 122478,
+                        "estimated_changes": 0,
+                        "change_estimate_kind": "exact_comparison",
+                        "comparison_runtime_ms": 276377.0,
+                        "comparison_queries": 245,
+                    },
+                    {
+                        "model": "dcim.site",
+                        "row_count": 93,
+                        "estimated_changes": 0,
+                        "change_estimate_kind": "exact_comparison",
+                        "comparison_runtime_ms": 12.0,
+                        "comparison_queries": 4,
+                    },
+                ],
+                coverage={"measured_models": 2, "total_models": 2},
+            )
+        )
+        self.assertEqual(report["slowest_compared_model"]["model"], "dcim.macaddress")
+        self.assertEqual(report["slowest_compared_model"]["queries"], 245)
+
+    def test_a_payload_without_a_query_count_reports_none_not_zero(self):
+        # A preview written before this existed reported no count. Zero would
+        # read as "issued no queries", which is a measurement it never made -
+        # the same reason the runtime reports None rather than 0.
+        report = compute_drift_report(
+            _payload(
+                [
+                    {
+                        "model": "dcim.site",
+                        "row_count": 10,
+                        "estimated_changes": 0,
+                        "change_estimate_kind": "exact_comparison",
+                        "comparison_runtime_ms": 25.0,
+                    }
+                ],
+                coverage={
+                    "measured_models": 1,
+                    "total_models": 1,
+                    "runtime_ms": 25.0,
+                    "rows_compared": 10,
+                },
+            )
+        )
+        self.assertIsNone(report["comparison_queries"])
+        self.assertIsNone(report["slowest_compared_model"]["queries"])
+
+
+class TheQueryCounterActuallyCountsTest(TestCase):
+    """The tests above feed a synthetic payload; this one tests the meter.
+
+    Without this, everything above could pass while the preview reported a
+    count it never took - the plumbing verified and the measurement absent.
+    """
+
+    def test_it_counts_queries_without_debug(self):
+        """The property that ruled out `connection.queries`.
+
+        `connection.queries` only populates when DEBUG is on, and a release
+        deployment never runs with it - so the number that matters most would
+        have been exactly the one that is missing. This asserts the count is
+        taken with DEBUG off, which is how it will run in production.
+        """
+        from django.db import connection
+        from django.test import override_settings
+
+        from forward_netbox.views import _QueryCounter
+
+        counter = _QueryCounter()
+        with override_settings(DEBUG=False):
+            with connection.execute_wrapper(counter):
+                Site.objects.count()
+                Site.objects.count()
+
+        self.assertEqual(counter.count, 2)
+
+    def test_it_counts_nothing_when_nothing_runs(self):
+        from django.db import connection
+
+        from forward_netbox.views import _QueryCounter
+
+        counter = _QueryCounter()
+        with connection.execute_wrapper(counter):
+            pass
+
+        self.assertEqual(counter.count, 0)
+
+    def test_the_wrapper_returns_the_query_result_unchanged(self):
+        # A counter that swallowed or altered results would corrupt every
+        # comparison it measured.
+        from django.db import connection
+
+        from forward_netbox.views import _QueryCounter
+
+        Site.objects.create(name="Counter Site", slug="counter-site")
+        counter = _QueryCounter()
+        with connection.execute_wrapper(counter):
+            names = list(
+                Site.objects.filter(slug="counter-site").values_list("name", flat=True)
+            )
+
+        self.assertEqual(names, ["Counter Site"])
+        self.assertGreater(counter.count, 0)

--- a/forward_netbox/tests/test_preview_reports_its_cost.py
+++ b/forward_netbox/tests/test_preview_reports_its_cost.py
@@ -231,7 +231,7 @@ class TheReportCarriesTheQueryCountTest(SimpleTestCase):
         self.assertIsNone(report["slowest_compared_model"]["queries"])
 
 
-class TheQueryCounterActuallyCountsTest(TestCase):
+class TheQueryMeterActuallyMeasuresTest(TestCase):
     """The tests above feed a synthetic payload; this one tests the meter.
 
     Without this, everything above could pass while the preview reported a
@@ -249,40 +249,194 @@ class TheQueryCounterActuallyCountsTest(TestCase):
         from django.db import connection
         from django.test import override_settings
 
-        from forward_netbox.views import _QueryCounter
+        from forward_netbox.views import _QueryMeter
 
-        counter = _QueryCounter()
+        meter = _QueryMeter()
         with override_settings(DEBUG=False):
-            with connection.execute_wrapper(counter):
+            with connection.execute_wrapper(meter):
                 Site.objects.count()
                 Site.objects.count()
 
-        self.assertEqual(counter.count, 2)
+        self.assertEqual(meter.count, 2)
 
     def test_it_counts_nothing_when_nothing_runs(self):
         from django.db import connection
 
-        from forward_netbox.views import _QueryCounter
+        from forward_netbox.views import _QueryMeter
 
-        counter = _QueryCounter()
-        with connection.execute_wrapper(counter):
+        meter = _QueryMeter()
+        with connection.execute_wrapper(meter):
             pass
 
-        self.assertEqual(counter.count, 0)
+        self.assertEqual(meter.count, 0)
 
     def test_the_wrapper_returns_the_query_result_unchanged(self):
         # A counter that swallowed or altered results would corrupt every
         # comparison it measured.
         from django.db import connection
 
-        from forward_netbox.views import _QueryCounter
+        from forward_netbox.views import _QueryMeter
 
         Site.objects.create(name="Counter Site", slug="counter-site")
-        counter = _QueryCounter()
-        with connection.execute_wrapper(counter):
+        meter = _QueryMeter()
+        with connection.execute_wrapper(meter):
             names = list(
                 Site.objects.filter(slug="counter-site").values_list("name", flat=True)
             )
 
         self.assertEqual(names, ["Counter Site"])
-        self.assertGreater(counter.count, 0)
+        self.assertGreater(meter.count, 0)
+
+    def test_it_times_the_queries_it_counts(self):
+        from django.db import connection
+
+        from forward_netbox.views import _QueryMeter
+
+        meter = _QueryMeter()
+        with connection.execute_wrapper(meter):
+            Site.objects.count()
+
+        self.assertEqual(meter.count, 1)
+        self.assertGreater(meter.seconds, 0.0)
+
+    def test_it_times_nothing_when_nothing_runs(self):
+        # Paired with the count for the same reason: a meter that reported
+        # elapsed time for work that never ran would be worse than silent.
+        from django.db import connection
+
+        from forward_netbox.views import _QueryMeter
+
+        meter = _QueryMeter()
+        with connection.execute_wrapper(meter):
+            pass
+
+        self.assertEqual(meter.seconds, 0.0)
+
+    def test_a_failing_query_still_reports_what_it_spent(self):
+        """The `finally`, and the reason it is one.
+
+        A query that raises has still spent its time in the database, and it is
+        disproportionately likely to be the slow one - a statement timeout is
+        the expensive query, not a cheap one. Recording the elapsed time only
+        on the success path would drop the measurement in precisely the case
+        that motivated taking it.
+        """
+        from django.db import ProgrammingError
+        from django.db import connection
+        from django.db import transaction
+
+        from forward_netbox.views import _QueryMeter
+
+        meter = _QueryMeter()
+        # The failing statement aborts the surrounding transaction, so it runs
+        # inside its own atomic block: leaving that block by exception rolls
+        # the savepoint back and the connection stays usable for teardown.
+        with self.assertRaises(ProgrammingError):
+            with transaction.atomic():
+                with connection.execute_wrapper(meter):
+                    with connection.cursor() as cursor:
+                        cursor.execute("SELECT * FROM a_table_that_does_not_exist")
+
+        self.assertEqual(meter.count, 1)
+        self.assertGreater(meter.seconds, 0.0)
+
+
+class TheReportSaysHowMuchOfItWasSqlTest(SimpleTestCase):
+    """A low query count does not mean the database was not the problem.
+
+    The converged comparison issues a flat handful of queries - 13 for 4,000
+    rows locally - so the deployment spending 276,377 ms will report a low
+    count too, and a low count against a high runtime reads as work inside
+    Python. It has a second reading: few queries, each slow. A sequential scan
+    over 122,478 rows, or a Postgres a network hop away, produces exactly the
+    same count and wants an index or a move, not a rewrite. Only the share of
+    the runtime spent inside the database separates them.
+    """
+
+    def test_the_sql_time_comes_from_the_preview(self):
+        report = compute_drift_report(
+            _payload(
+                [
+                    {
+                        "model": "dcim.macaddress",
+                        "row_count": 122478,
+                        "estimated_changes": 0,
+                        "change_estimate_kind": "exact_comparison",
+                        "comparison_runtime_ms": 276377.0,
+                        "comparison_queries": 13,
+                        "comparison_sql_ms": 271900.0,
+                    }
+                ],
+                coverage={
+                    "measured_models": 1,
+                    "total_models": 1,
+                    "runtime_ms": 276377.0,
+                    "queries": 13,
+                    "sql_ms": 271900.0,
+                    "rows_compared": 122478,
+                },
+            )
+        )
+        self.assertEqual(report["comparison_sql_ms"], 271900.0)
+
+    def test_the_slowest_model_carries_its_sql_time(self):
+        # Thirteen queries and 271,900 ms of SQL is a slow query. Thirteen
+        # queries and 40 ms of SQL is Python. The report must be able to say
+        # which, about the model it just named.
+        report = compute_drift_report(
+            _payload(
+                [
+                    {
+                        "model": "dcim.macaddress",
+                        "row_count": 122478,
+                        "estimated_changes": 0,
+                        "change_estimate_kind": "exact_comparison",
+                        "comparison_runtime_ms": 276377.0,
+                        "comparison_queries": 13,
+                        "comparison_sql_ms": 271900.0,
+                    },
+                    {
+                        "model": "dcim.site",
+                        "row_count": 93,
+                        "estimated_changes": 0,
+                        "change_estimate_kind": "exact_comparison",
+                        "comparison_runtime_ms": 12.0,
+                        "comparison_queries": 4,
+                        "comparison_sql_ms": 9.0,
+                    },
+                ],
+                coverage={"measured_models": 2, "total_models": 2},
+            )
+        )
+        self.assertEqual(report["slowest_compared_model"]["model"], "dcim.macaddress")
+        self.assertEqual(report["slowest_compared_model"]["sql_ms"], 271900.0)
+
+    def test_a_payload_without_the_sql_time_reports_none_not_zero(self):
+        # The count shipped one release before the timing did, so a payload
+        # carrying a count and no SQL time is a real shape, not a hypothetical.
+        # Zero would read as "the database was free", which is the exact wrong
+        # conclusion to hand someone reading a 276-second model.
+        report = compute_drift_report(
+            _payload(
+                [
+                    {
+                        "model": "dcim.macaddress",
+                        "row_count": 122478,
+                        "estimated_changes": 0,
+                        "change_estimate_kind": "exact_comparison",
+                        "comparison_runtime_ms": 276377.0,
+                        "comparison_queries": 13,
+                    }
+                ],
+                coverage={
+                    "measured_models": 1,
+                    "total_models": 1,
+                    "runtime_ms": 276377.0,
+                    "queries": 13,
+                    "rows_compared": 122478,
+                },
+            )
+        )
+        self.assertEqual(report["comparison_queries"], 13)
+        self.assertIsNone(report["comparison_sql_ms"])
+        self.assertIsNone(report["slowest_compared_model"]["sql_ms"])

--- a/forward_netbox/utilities/drift_report.py
+++ b/forward_netbox/utilities/drift_report.py
@@ -133,6 +133,10 @@ def _slowest_compared_model(rows):
     return {
         "model": slowest.get("label") or slowest.get("model"),
         "runtime_ms": slowest["comparison_runtime_ms"],
+        # Carried with the runtime because naming the slowest model is only
+        # half an answer: the query count says which KIND of slow it is, and
+        # the two want opposite fixes.
+        "queries": slowest.get("comparison_queries"),
     }
 
 
@@ -248,6 +252,7 @@ def compute_drift_report(payload):
                 "drift": drift,
                 "in_sync": in_sync,
                 "comparison_runtime_ms": result.get("comparison_runtime_ms"),
+                "comparison_queries": result.get("comparison_queries"),
             }
         )
     _label_rows(rows)
@@ -300,6 +305,7 @@ def compute_drift_report(payload):
         # which is why these are None rather than zero - a zero would read as
         # "instant" for a preview that never reported.
         "comparison_runtime_ms": _coverage_value(payload, "runtime_ms"),
+        "comparison_queries": _coverage_value(payload, "queries"),
         "comparison_rows_compared": _coverage_value(payload, "rows_compared"),
         "slowest_compared_model": _slowest_compared_model(rows),
         "unmeasured_model_count": len(unmeasured_rows),

--- a/forward_netbox/utilities/drift_report.py
+++ b/forward_netbox/utilities/drift_report.py
@@ -137,6 +137,9 @@ def _slowest_compared_model(rows):
         # half an answer: the query count says which KIND of slow it is, and
         # the two want opposite fixes.
         "queries": slowest.get("comparison_queries"),
+        # And the count on its own cannot tell a slow query from slow Python,
+        # because both report a low count. This can.
+        "sql_ms": slowest.get("comparison_sql_ms"),
     }
 
 
@@ -253,6 +256,7 @@ def compute_drift_report(payload):
                 "in_sync": in_sync,
                 "comparison_runtime_ms": result.get("comparison_runtime_ms"),
                 "comparison_queries": result.get("comparison_queries"),
+                "comparison_sql_ms": result.get("comparison_sql_ms"),
             }
         )
     _label_rows(rows)
@@ -306,6 +310,7 @@ def compute_drift_report(payload):
         # "instant" for a preview that never reported.
         "comparison_runtime_ms": _coverage_value(payload, "runtime_ms"),
         "comparison_queries": _coverage_value(payload, "queries"),
+        "comparison_sql_ms": _coverage_value(payload, "sql_ms"),
         "comparison_rows_compared": _coverage_value(payload, "rows_compared"),
         "slowest_compared_model": _slowest_compared_model(rows),
         "unmeasured_model_count": len(unmeasured_rows),

--- a/forward_netbox/views.py
+++ b/forward_netbox/views.py
@@ -476,7 +476,11 @@ def _dependency_plan_item_summary(item):
 
 
 def _dependency_model_result_summary(
-    result, comparison=None, comparison_runtime_ms=None, comparison_queries=None
+    result,
+    comparison=None,
+    comparison_runtime_ms=None,
+    comparison_queries=None,
+    comparison_sql_ms=None,
 ):
     # ``fetcher.model_results`` are ForwardModelResult dataclasses, not dicts —
     # calling result.get(...) on them raised AttributeError and errored the whole
@@ -534,6 +538,11 @@ def _dependency_model_result_summary(
         # for a model with no comparison, exactly as the runtime is: reporting
         # zero queries for work that never ran would read as "free".
         "comparison_queries": (comparison_queries if comparison is not None else None),
+        # The share of this model's runtime spent inside the database. Read
+        # WITH the count: a low count and a high SQL share is a slow query to
+        # index; a low count and a low SQL share is Python. `None` where there
+        # was no comparison, for the same reason the others are.
+        "comparison_sql_ms": (comparison_sql_ms if comparison is not None else None),
         "runtime_ms": float(data.get("runtime_ms") or 0.0),
         # Preserve aggregate state evidence without copying diagnostic samples or
         # source identifiers into the preview job payload.
@@ -541,21 +550,40 @@ def _dependency_model_result_summary(
     }
 
 
-class _QueryCounter:
-    """Count queries through Django's execute wrapper.
+class _QueryMeter:
+    """Count queries AND time them, through Django's execute wrapper.
 
     `connection.queries` is only populated under DEBUG, which a release
-    deployment never runs with - so the number that matters most is exactly the
-    one that is absent in production. The wrapper is always active and costs an
-    integer increment per query.
+    deployment never runs with - so the numbers that matter most are exactly
+    the ones that are absent in production. The wrapper is always active and
+    costs an integer increment and one clock read per query.
+
+    The count alone is ambiguous in the direction that matters. A converged
+    `dcim.macaddress` comparison issues a FLAT handful of queries locally - 13
+    for 4,000 rows, not one per row - so a deployment reporting 276,377 ms will
+    very likely report a low count too, and "low count, high runtime" reads as
+    work inside Python. It has a second reading the count cannot exclude: few
+    queries, each slow. A sequential scan over 122,478 rows, or a Postgres on
+    another host where every round trip costs milliseconds, produces the same
+    low count and wants a database fix, not a Python one. The share of the
+    runtime spent inside `execute` is what separates them.
+
+    The elapsed time is recorded in a `finally` so a query that RAISES still
+    reports what it spent. Dropping it would lose the slowest query in exactly
+    the case where something went wrong.
     """
 
     def __init__(self):
         self.count = 0
+        self.seconds = 0.0
 
     def __call__(self, execute, sql, params, many, context):
         self.count += 1
-        return execute(sql, params, many, context)
+        started = time.perf_counter()
+        try:
+            return execute(sql, params, many, context)
+        finally:
+            self.seconds += time.perf_counter() - started
 
 
 def _dependency_dry_run_payload(sync, *, client=None):
@@ -641,18 +669,20 @@ def _dependency_dry_run_payload(sync, *, client=None):
     comparison_by_model = {}
     comparison_runtime_ms_by_model = {}
     comparison_queries_by_model = {}
+    comparison_sql_ms_by_model = {}
     comparison_rows_by_model_count = {}
     for model_string, rows in rows_by_model.items():
-        counter = _QueryCounter()
+        meter = _QueryMeter()
         started = time.perf_counter()
-        with connection.execute_wrapper(counter):
+        with connection.execute_wrapper(meter):
             comparison_by_model[model_string] = compare_model_rows(
                 sync, model_string, rows
             )
         comparison_runtime_ms_by_model[model_string] = round(
             (time.perf_counter() - started) * 1000, 1
         )
-        comparison_queries_by_model[model_string] = counter.count
+        comparison_queries_by_model[model_string] = meter.count
+        comparison_sql_ms_by_model[model_string] = round(meter.seconds * 1000, 1)
         comparison_rows_by_model_count[model_string] = len(rows)
     measured_models = sum(
         1 for value in comparison_by_model.values() if value is not None
@@ -679,6 +709,16 @@ def _dependency_dry_run_payload(sync, *, client=None):
         queries
         for model_string, queries in comparison_queries_by_model.items()
         if comparison_by_model.get(model_string) is not None
+    )
+    # Same denominator again, so the SQL share of the runtime is read against
+    # the runtime it is a share OF.
+    comparison_sql_ms = round(
+        sum(
+            sql_ms
+            for model_string, sql_ms in comparison_sql_ms_by_model.items()
+            if comparison_by_model.get(model_string) is not None
+        ),
+        1,
     )
     return {
         "generated_at": timezone.now().isoformat(),
@@ -712,6 +752,11 @@ def _dependency_dry_run_payload(sync, *, client=None):
             # only fix directions that differ: a high count is chatter to
             # batch, a low count with a high runtime is work inside Python.
             "queries": comparison_queries,
+            # How much of that runtime was spent inside the database. A low
+            # count says nothing about whether those few queries were slow;
+            # this does, and it is the difference between an index and a
+            # rewrite.
+            "sql_ms": comparison_sql_ms,
             "rows_compared": compared_rows,
         },
         "model_results": [
@@ -724,6 +769,9 @@ def _dependency_dry_run_payload(sync, *, client=None):
                     (result.as_dict().get("model") or "")
                 ),
                 comparison_queries=comparison_queries_by_model.get(
+                    (result.as_dict().get("model") or "")
+                ),
+                comparison_sql_ms=comparison_sql_ms_by_model.get(
                     (result.as_dict().get("model") or "")
                 ),
             )

--- a/forward_netbox/views.py
+++ b/forward_netbox/views.py
@@ -7,6 +7,7 @@ from core.models import ObjectChange
 from django.apps import apps
 from django.contrib import messages
 from django.core.exceptions import ValidationError
+from django.db import connection
 from django.db import models
 from django.db.models.functions import Greatest
 from django.http import HttpResponseBadRequest
@@ -475,7 +476,7 @@ def _dependency_plan_item_summary(item):
 
 
 def _dependency_model_result_summary(
-    result, comparison=None, comparison_runtime_ms=None
+    result, comparison=None, comparison_runtime_ms=None, comparison_queries=None
 ):
     # ``fetcher.model_results`` are ForwardModelResult dataclasses, not dicts —
     # calling result.get(...) on them raised AttributeError and errored the whole
@@ -529,11 +530,32 @@ def _dependency_model_result_summary(
         "comparison_runtime_ms": (
             comparison_runtime_ms if comparison is not None else None
         ),
+        # Paired with the runtime so a slow model says WHY it is slow. `None`
+        # for a model with no comparison, exactly as the runtime is: reporting
+        # zero queries for work that never ran would read as "free".
+        "comparison_queries": (comparison_queries if comparison is not None else None),
         "runtime_ms": float(data.get("runtime_ms") or 0.0),
         # Preserve aggregate state evidence without copying diagnostic samples or
         # source identifiers into the preview job payload.
         "durable_workload_state": durable_state,
     }
+
+
+class _QueryCounter:
+    """Count queries through Django's execute wrapper.
+
+    `connection.queries` is only populated under DEBUG, which a release
+    deployment never runs with - so the number that matters most is exactly the
+    one that is absent in production. The wrapper is always active and costs an
+    integer increment per query.
+    """
+
+    def __init__(self):
+        self.count = 0
+
+    def __call__(self, execute, sql, params, many, context):
+        self.count += 1
+        return execute(sql, params, many, context)
 
 
 def _dependency_dry_run_payload(sync, *, client=None):
@@ -603,15 +625,34 @@ def _dependency_dry_run_payload(sync, *, client=None):
     #
     # So the preview reports its own cost instead of anyone estimating it. The
     # numbers arrive with the payload, from the estate that has the scale.
+    # Count queries as well as milliseconds.
+    #
+    # A runtime alone cannot tell the two failure shapes apart, and they want
+    # opposite fixes. A deployment reported `dcim.macaddress` at 276,377 ms for
+    # 122,478 fully converged rows - 2.26 ms/row against 0.065 ms/row measured
+    # locally for the same converged shape. Time says "slow"; only a query count
+    # says whether it is slow because it issued a hundred thousand queries or
+    # slow inside Python. Every hypothesis tested locally against that number
+    # was eliminated, and the next one needs this to be worth testing.
+    #
+    # `connection.queries` is only populated when DEBUG is on, so the count is
+    # taken from the cursor-execution wrapper instead, which is always active
+    # and adds one integer increment per query.
     comparison_by_model = {}
     comparison_runtime_ms_by_model = {}
+    comparison_queries_by_model = {}
     comparison_rows_by_model_count = {}
     for model_string, rows in rows_by_model.items():
+        counter = _QueryCounter()
         started = time.perf_counter()
-        comparison_by_model[model_string] = compare_model_rows(sync, model_string, rows)
+        with connection.execute_wrapper(counter):
+            comparison_by_model[model_string] = compare_model_rows(
+                sync, model_string, rows
+            )
         comparison_runtime_ms_by_model[model_string] = round(
             (time.perf_counter() - started) * 1000, 1
         )
+        comparison_queries_by_model[model_string] = counter.count
         comparison_rows_by_model_count[model_string] = len(rows)
     measured_models = sum(
         1 for value in comparison_by_model.values() if value is not None
@@ -631,6 +672,13 @@ def _dependency_dry_run_payload(sync, *, client=None):
             if comparison_by_model.get(model_string) is not None
         ),
         1,
+    )
+    # Summed over the same models as the runtime, so cost per row and queries
+    # per row are read from the same denominator.
+    comparison_queries = sum(
+        queries
+        for model_string, queries in comparison_queries_by_model.items()
+        if comparison_by_model.get(model_string) is not None
     )
     return {
         "generated_at": timezone.now().isoformat(),
@@ -660,6 +708,10 @@ def _dependency_dry_run_payload(sync, *, client=None):
             "total_models": len(comparison_by_model),
             # What the measurement cost, reported rather than estimated.
             "runtime_ms": comparison_runtime_ms,
+            # Queries alongside milliseconds, because the two distinguish the
+            # only fix directions that differ: a high count is chatter to
+            # batch, a low count with a high runtime is work inside Python.
+            "queries": comparison_queries,
             "rows_compared": compared_rows,
         },
         "model_results": [
@@ -669,6 +721,9 @@ def _dependency_dry_run_payload(sync, *, client=None):
                     (result.as_dict().get("model") or "")
                 ),
                 comparison_runtime_ms=comparison_runtime_ms_by_model.get(
+                    (result.as_dict().get("model") or "")
+                ),
+                comparison_queries=comparison_queries_by_model.get(
                     (result.as_dict().get("model") or "")
                 ),
             )


### PR DESCRIPTION
## Summary

**Independent of the #206 drift stack — based on `main`.**

A deployment reports `dcim.macaddress` at **276,377 ms for 122,478 rows**
(2.26 ms/row) on a model that is **fully converged** — 0 change candidates,
drift 0, in sync. The same converged shape measures **0.065 ms/row** locally.
A ~35× gap.

## Everything already ruled out

Each with a knob left in `test_adapter_drift_scale.py` so nobody repeats it:

| hypothesis | result |
| --- | --- |
| non-linear at scale | linear to 64,000 rows |
| priming scales with estate | 30× the interfaces: 1025 → 1081 ms |
| per-row interface-lookup fallback | 3.8× → ~30 s at that scale, not 276 |
| per-row construct + `full_clean` | identical with and without the fix when converged |
| branch-rewritten queries | the preview job activates no branch |
| **netbox-branching 1.1.3** | 2.220 → **2.257** ms/row across the upgrade — no change |

What remains splits in two, and **the two want opposite fixes**: a high query
count is chatter to batch; a low count against a high runtime is work inside
Python. A runtime alone will never distinguish them.

## The change

Counted with `connection.execute_wrapper`, **not** `connection.queries` — the
latter only populates under `DEBUG`, which a release deployment never sets, so
the number that matters most would be exactly the one that is missing. The
wrapper is always active and costs one integer increment per query, so it can
stay on in production — which it must, because the deployment that needs it is
a customer's.

Reported in three places: summed in `comparison_coverage`, per model in
`model_results`, and on `slowest_compared_model`. The report now renders
*"Slowest: dcim.macaddress at 276377 ms **in N queries**"*.

A model with no comparison reports `None`, not `0` — zero queries reads as
"free" for work that never ran, the same rule the runtime already follows.

## Test plan

- [x] **11 tests, split deliberately across the two things that can be wrong.**
      Six feed a synthetic payload and pin what the *report* does; three
      exercise the *meter*, because the first six would all pass while the
      preview reported a count it never took — plumbing verified, measurement
      absent. One asserts the count is taken with `DEBUG=False`, the property
      that ruled out `connection.queries`.
- [x] **Two negative controls:** removing the report plumbing fails the three
      payload tests; disabling the counter's increment fails the two meter
      tests that can observe it.
- [x] **381 green** across the drift, preview and sync suites
- [x] pre-commit clean; `check_harness.py --base origin/main` passes

## This does not fix the 276 s

It makes the next report able to explain it. If the count comes back high, the
fix is batching. If low, the next suspects are custom fields configured on
`MACAddress` and the per-instance cost of NetBox model construction at 122,478
rows — neither reproducible on a fixture without knowing that deployment's
configuration.

Claude-Session: https://claude.ai/code/session_012Qfd3hTSxZtmFHuzRJnZre