### PR TITLE
feat: measure drift for the peering models

### DIFF
--- a/docs/03_Plans/active/2026-09-01-adapter-model-drift-peering.md
+++ b/docs/03_Plans/active/2026-09-01-adapter-model-drift-peering.md
@@ -1,0 +1,146 @@
+# Measure drift for the peering models
+
+## Goal
+
+Slice seven of the adapter-only drift comparison: `netbox_routing.bgppeer`,
+`netbox_routing.bgpaddressfamily`, `netbox_routing.bgppeeraddressfamily` and
+`netbox_peering_manager.peeringsession`.
+
+## Why
+
+Unchanged. Every adapter-only model reports an upper bound, so `in_sync` stays
+unanswerable while any of the eight is uncompared. These were left until last
+because one Forward row means more persisted objects here than anywhere else.
+
+## Constraints
+
+- Reuse the apply's own resolution and comparisons.
+- Write nothing - and a single BGP peer row writes in six places.
+- A row the apply refuses must not read as drift.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/sync_routing_impl.py` - `preview` threaded through
+  the peer chain; the four apply functions classify
+- `forward_netbox/utilities/drift_comparison.py` - `_ensure_asn` and
+  `_coalesce_upsert` overrides, the routing chain delegations, the per-row
+  upsert record, `ForwardQueryError` in the row loop, the dispatch entries
+- `forward_netbox/tests/test_peering_drift_comparison.py` (new)
+
+## Approach
+
+### What one row writes
+
+A single `netbox_routing.bgppeer` row resolves - and the apply would persist -
+six objects:
+
+| object | reached via | shimmed by |
+| --- | --- | --- |
+| `ipam.ASN` x2 | `runner._ensure_asn` | new override (find-only) |
+| `ipam.RIR` | `_ensure_forward_observed_rir`, under `_ensure_asn` | same override, never reached |
+| `ipam.IPAddress` | `ensure_bgp_peer_ip` - **direct save** | `preview` argument |
+| `netbox_routing.BGPRouter` | `runner._upsert_values_from_defaults` | already overridden |
+| `netbox_routing.BGPScope` | `runner._coalesce_upsert` | new override |
+| `netbox_routing.BGPPeer` | `runner._upsert_values_from_defaults` | already overridden |
+
+Two of those were holes. `_ensure_asn` saves an `ASN` and calls
+`_ensure_forward_observed_rir`, which upserts a `RIR` - the same
+writes-behind-a-runner-call trap as `_ensure_vrf` and `_ensure_platform`, and
+equally invisible to a grep for ORM calls in this module. `_coalesce_upsert` is
+the THIRD upsert primitive: the model-string-carrying wrapper that resolves the
+conflict policy before delegating to `coalesce_update_or_create`. The preview
+overrode the delegate; the wrapper is defined separately on the runner and
+would have been inherited whole.
+
+`ensure_bgp_peer_ip` is the direct save, outside any `runner.` call - the same
+shape as the FHRP virtual IP and cables - so it takes a `preview` argument
+rather than a shim.
+
+### Why the verdict is not the leaf row
+
+`netbox_routing.bgprouter` and `netbox_routing.bgpscope` have contracts and
+coalesce fields but **no Forward query of their own** (`query_registry.py`
+registers six routing models; neither is among them). They exist only as
+parents built while applying a peer.
+
+So a router this run would rewrite is drift that NO model would report if the
+peer's verdict came from `last_upsert_would_change` alone, the way the flat DLM
+rows are classified. The peer would read `unchanged` while every run rewrote
+its router - a confident zero, which is the one failure mode here with a real
+consequence.
+
+Hence `preview_routing_outcome` takes the strongest outcome across every upsert
+the row performed, read from a per-row record the preview runner keeps
+(`upsert_outcomes`, cleared by `begin_row` in the shared row loop).
+`last_upsert_would_change` is untouched, so the flat paths that only ever
+upsert one object classify exactly as before.
+
+This is the same rule slice four applied to FHRP groups - "the row's verdict is
+the strongest of the three" - generalised from three hand-written cases to
+whatever the chain actually did.
+
+### Absent parents short-circuit
+
+Under preview the ASNs, the neighbour address, the router and the scope all
+resolve rather than create, so any of them can come back `None`. Building the
+peer's values against a missing parent is not merely pointless:
+
+- `ensure_bgp_router` reads `local_asn.asn` for the router name, so a `None`
+  ASN raises `AttributeError` - which no caller catches, so it would have
+  killed the whole comparison rather than classifying one row.
+- a scope coalesced on `router=None` matches whichever unrelated scope has no
+  router.
+
+So an absent parent returns `None` up the chain and the row is reported as a
+create, which is also the honest answer: a peer cannot already exist against a
+neighbour address NetBox does not have.
+
+### An absent VRF must not resolve to the global one
+
+Every coalesce set in these chains includes `vrf`. The real `_ensure_vrf`
+CREATES a missing VRF and coalesces inside it; the preview override resolves
+and returns `None` instead, which collides with the answer for a row that names
+no VRF at all.
+
+That collision is not cosmetic: a row whose VRF does not exist yet looked its
+scope up on `vrf=None` and matched the unrelated GLOBAL scope, so a peer the
+apply would create was reported as already present and unchanged. `routing_vrf`
+now returns a distinct `VRF_ABSENT` under preview and the callers report a
+create. The same fix covers the OSPF chain in slice eight, which shares this
+helper.
+
+### `ForwardQueryError` was escaping the row loop
+
+The routing paths are the first to raise `ForwardQueryError` during
+classification - an unparseable ASN, an empty `afi_safi`, an unsupported
+address family. It is **not** a subclass of `ForwardDataError`, so the shared
+row loop did not catch it, and one malformed row would have aborted the
+comparison for every other row in the batch.
+
+`apply_model_rows` catches it per row alongside `ForwardSearchError` and
+`ForwardSyncDataError` (`sync_reporting.py:589`), records an issue and
+continues. The loop now does the same and counts the row rejected, which is
+what the apply does with that row. This was a latent defect in the earlier
+slices, not one this slice introduced; no shipped adapter path raises it yet.
+
+## Testing
+
+`forward_netbox/tests/test_peering_drift_comparison.py`, 16 tests: the firewall
+(no ASN, RIR, address, router, scope or peer created; a drifted peer not
+rewritten), the classification (matching, absent, drifted), the absent-parent
+short-circuits, the parent-drift case no other model would report, and the
+rejection paths including one malformed row not taking the batch with it.
+
+The converged fixture is built from the apply's own `bgp_peer_name` and
+`bgp_peer_comments` rather than from literals, so it cannot quietly stop being
+converged when either format changes.
+
+## Limits
+
+- `netbox_routing.bgprouter` and `netbox_routing.bgpscope` are still not
+  models with counts of their own. They are reported through the peer that
+  builds them, which is where their drift is actionable.
+- Slice eight - the OSPF models - remains, and `in_sync` stays unanswerable
+  until it lands.
+- Two netbox-dlm sub-models (`inventoryitemsoftware`,
+  `inventoryitemroleplatform`) remain uncompared from slice six.

--- a/forward_netbox/tests/test_peering_drift_comparison.py
+++ b/forward_netbox/tests/test_peering_drift_comparison.py
@@ -1,0 +1,259 @@
+# Slice seven of the adapter-only drift comparison: the peering models -
+# `netbox_routing.bgppeer`, `bgpaddressfamily`, `bgppeeraddressfamily`, and
+# `netbox_peering_manager.peeringsession`.
+#
+# These were left until last because one Forward row means the most persisted
+# objects of any adapter model. A single BGP peer resolves - and the apply
+# would write - two ASNs, the neighbour IPAddress, a BGPRouter, a BGPScope and
+# the peer itself, and an unaudited path would write five of those six while
+# "measuring".
+#
+# Two of them are DIRECT saves that no `runner.` shim reaches: the neighbour
+# address inside `ensure_bgp_peer_ip`, and the ASN (plus the RIR beneath it)
+# inside `_ensure_asn`. The first is threaded with `preview`, the second is
+# overridden on the preview runner.
+#
+# `netbox_routing.bgprouter` and `netbox_routing.bgpscope` have NO Forward
+# query of their own - they exist only as parents built while applying a peer -
+# so a router this run would rewrite is drift that no model would report if the
+# peer's verdict looked only at the leaf row. That is what
+# `preview_routing_outcome` is for, and what the parent tests below pin.
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import Manufacturer
+from dcim.models import Site
+from django.test import TestCase
+from ipam.models import ASN
+from ipam.models import IPAddress
+from ipam.models import RIR
+
+from forward_netbox.utilities.drift_comparison import compare_model_rows
+from forward_netbox.utilities.sync_routing_impl import bgp_peer_comments
+from forward_netbox.utilities.sync_routing_impl import bgp_peer_name
+
+BGP_PEER = "netbox_routing.bgppeer"
+
+
+def _routing_models():
+    from forward_netbox.utilities.sync_primitives import optional_model
+
+    return (
+        optional_model("netbox_routing", "BGPRouter", BGP_PEER),
+        optional_model("netbox_routing", "BGPScope", BGP_PEER),
+        optional_model("netbox_routing", "BGPPeer", BGP_PEER),
+    )
+
+
+class PeeringPreviewTest(TestCase):
+    def setUp(self):
+        site = Site.objects.create(name="P Site", slug="p-site")
+        mfr = Manufacturer.objects.create(name="P Mfr", slug="p-mfr")
+        dtype = DeviceType.objects.create(manufacturer=mfr, model="P DT", slug="p-dt")
+        role = DeviceRole.objects.create(name="P Role", slug="p-role")
+        self.device = Device.objects.create(
+            name="bgp-dev", site=site, device_type=dtype, role=role, status="active"
+        )
+        self.rir = RIR.objects.create(name="P RIR", slug="p-rir")
+
+    def _row(self, **extra):
+        row = {
+            "device": "bgp-dev",
+            "local_asn": 65000,
+            "peer_asn": 65001,
+            "neighbor_address": "10.10.0.2",
+            "enabled": True,
+            "status": "active",
+            "peer_type": "EXTERNAL",
+        }
+        row.update(extra)
+        return row
+
+    def _asns(self):
+        local, _ = ASN.objects.get_or_create(asn=65000, defaults={"rir": self.rir})
+        remote, _ = ASN.objects.get_or_create(asn=65001, defaults={"rir": self.rir})
+        return local, remote
+
+    def _peer_ip(self):
+        return IPAddress.objects.create(address="10.10.0.2/32", status="active")
+
+    def _existing_peer(self, *, name=None, router_name=None):
+        """The whole chain a converged deployment already has."""
+        from django.contrib.contenttypes.models import ContentType
+
+        BGPRouter, BGPScope, BGPPeer = _routing_models()
+        local, remote = self._asns()
+        peer_ip = self._peer_ip()
+        router = BGPRouter.objects.create(
+            name=router_name or f"{self.device.name} AS65000",
+            assigned_object_type=ContentType.objects.get_for_model(Device),
+            assigned_object_id=self.device.pk,
+            asn=local,
+        )
+        scope = BGPScope.objects.create(router=router, vrf=None)
+        # Built from the apply's OWN renderers rather than from literals, so
+        # a converged fixture cannot quietly stop being converged when the
+        # comment or name format changes - the test would then be asserting
+        # against a shape the apply no longer writes.
+        peer = BGPPeer.objects.create(
+            scope=scope,
+            peer=peer_ip,
+            name=name or bgp_peer_name(self._row()),
+            remote_as=remote,
+            local_as=local,
+            enabled=True,
+            status="active",
+            description="",
+            comments=bgp_peer_comments(self._row()),
+        )
+        return router, scope, peer
+
+    # --- the firewall ------------------------------------------------------
+
+    def test_a_preview_creates_no_asn_address_router_scope_or_peer(self):
+        BGPRouter, BGPScope, BGPPeer = _routing_models()
+        before = (
+            ASN.objects.count(),
+            IPAddress.objects.count(),
+            RIR.objects.count(),
+            BGPRouter.objects.count(),
+            BGPScope.objects.count(),
+            BGPPeer.objects.count(),
+        )
+        compare_model_rows(None, BGP_PEER, [self._row()])
+        after = (
+            ASN.objects.count(),
+            IPAddress.objects.count(),
+            RIR.objects.count(),
+            BGPRouter.objects.count(),
+            BGPScope.objects.count(),
+            BGPPeer.objects.count(),
+        )
+        self.assertEqual(before, after)
+
+    def test_a_preview_does_not_rewrite_a_drifted_peer(self):
+        _, _, peer = self._existing_peer()
+        compare_model_rows(None, BGP_PEER, [self._row(description="new text")])
+        peer.refresh_from_db()
+        self.assertEqual(peer.description, "")
+
+    # --- the classification ------------------------------------------------
+
+    def test_a_fully_matching_row_is_unchanged(self):
+        self._existing_peer()
+        result = compare_model_rows(None, BGP_PEER, [self._row()])
+        self.assertEqual(result["unchanged"], 1)
+        self.assertEqual(result["creates"], 0)
+        self.assertEqual(result["updates"], 0)
+
+    def test_an_absent_peer_is_a_create(self):
+        result = compare_model_rows(None, BGP_PEER, [self._row()])
+        self.assertEqual(result["creates"], 1)
+
+    def test_a_drifted_peer_is_an_update(self):
+        self._existing_peer()
+        result = compare_model_rows(None, BGP_PEER, [self._row(description="changed")])
+        self.assertEqual(result["updates"], 1)
+        self.assertEqual(result["unchanged"], 0)
+
+    def test_an_absent_asn_is_a_create_not_a_crash(self):
+        """The router name reads `local_asn.asn`; a `None` there raises.
+
+        `AttributeError` is caught by no caller, so an absent ASN would have
+        killed the whole comparison rather than classifying one row.
+        """
+        result = compare_model_rows(None, BGP_PEER, [self._row()])
+        self.assertEqual(result["creates"], 1)
+        self.assertEqual(ASN.objects.count(), 0)
+
+    def test_an_absent_neighbour_address_is_a_create(self):
+        self._asns()
+        result = compare_model_rows(None, BGP_PEER, [self._row()])
+        self.assertEqual(result["creates"], 1)
+        self.assertEqual(IPAddress.objects.count(), 0)
+
+    def test_a_row_naming_an_absent_vrf_is_a_create_not_a_match_on_global(self):
+        """Every coalesce set includes `vrf`, so `None` must not stand in.
+
+        The apply CREATES a missing VRF and coalesces inside it. The preview
+        resolves instead, so an unresolved VRF left `vrf=None` on the lookup -
+        which matched the global scope built here, and reported a peer the
+        apply would create as already present and unchanged.
+        """
+        self._existing_peer()
+        result = compare_model_rows(None, BGP_PEER, [self._row(vrf="TENANT-A")])
+        self.assertEqual(result["creates"], 1)
+        self.assertEqual(result["unchanged"], 0)
+
+    def test_a_row_naming_an_existing_vrf_still_resolves(self):
+        from ipam.models import VRF
+
+        VRF.objects.create(name="TENANT-A")
+        result = compare_model_rows(None, BGP_PEER, [self._row(vrf="TENANT-A")])
+        self.assertEqual(result["creates"], 1)
+        self.assertEqual(VRF.objects.count(), 1)
+
+    # --- the parents no other model reports --------------------------------
+
+    def test_a_drifted_router_makes_an_otherwise_matching_peer_an_update(self):
+        """`netbox_routing.bgprouter` has no query, so this is its only report.
+
+        The peer row itself matches exactly. Only the router's name differs -
+        the apply would rewrite it, and if the verdict came from the leaf row
+        alone this would read `unchanged` while every run rewrote the router.
+        """
+        router, _, _ = self._existing_peer(router_name="stale name")
+        result = compare_model_rows(None, BGP_PEER, [self._row()])
+        self.assertEqual(result["updates"], 1)
+        self.assertEqual(result["unchanged"], 0)
+        router.refresh_from_db()
+        self.assertEqual(router.name, "stale name")
+
+    # --- rows the apply refuses -------------------------------------------
+
+    def test_an_unknown_device_is_rejected(self):
+        result = compare_model_rows(None, BGP_PEER, [self._row(device="nope")])
+        self.assertEqual(result["rejected"], 1)
+        self.assertEqual(result["creates"], 0)
+
+    def test_an_unparseable_asn_is_rejected_not_a_create(self):
+        """`ForwardQueryError` is not a `ForwardDataError`.
+
+        It was escaping the row loop entirely, so one malformed ASN would have
+        killed the comparison for every other row in the batch.
+        """
+        result = compare_model_rows(None, BGP_PEER, [self._row(local_asn="abc")])
+        self.assertEqual(result["rejected"], 1)
+        self.assertEqual(result["creates"], 0)
+
+    def test_one_malformed_row_does_not_lose_the_rest_of_the_batch(self):
+        self._existing_peer()
+        result = compare_model_rows(
+            None,
+            BGP_PEER,
+            [self._row(local_asn="abc"), self._row()],
+        )
+        self.assertEqual(result["rejected"], 1)
+        self.assertEqual(result["unchanged"], 1)
+
+    def test_a_sub_one_asn_is_rejected(self):
+        result = compare_model_rows(None, BGP_PEER, [self._row(local_asn=0)])
+        self.assertEqual(result["rejected"], 1)
+
+    def test_a_row_missing_its_device_key_is_rejected(self):
+        row = self._row()
+        del row["device"]
+        result = compare_model_rows(None, BGP_PEER, [row])
+        self.assertEqual(result["rejected"], 1)
+
+    # --- the model is actually registered ----------------------------------
+
+    def test_the_peering_models_report_a_measurement_not_an_upper_bound(self):
+        for model_string in (
+            "netbox_routing.bgppeer",
+            "netbox_routing.bgpaddressfamily",
+            "netbox_routing.bgppeeraddressfamily",
+            "netbox_peering_manager.peeringsession",
+        ):
+            with self.subTest(model_string=model_string):
+                self.assertIsNotNone(compare_model_rows(None, model_string, []))

--- a/forward_netbox/utilities/drift_comparison.py
+++ b/forward_netbox/utilities/drift_comparison.py
@@ -123,6 +123,24 @@ class PreviewRunner:
         # having run reports "no change" instead of raising - the adapter
         # comparison only reads it after an upsert it made itself.
         self.last_upsert_would_change = False
+        # Every upsert outcome recorded since `begin_row`, for the paths where
+        # one Forward row means several persisted objects and the last one is
+        # not the whole answer. The routing models need it: a `BGPRouter` or
+        # `BGPScope` this run would rewrite has no Forward query of its own, so
+        # if the peer's verdict ignored it, nothing would ever report it.
+        # `last_upsert_would_change` stays exactly as it was for the flat rows
+        # that only ever upsert one object.
+        self.upsert_outcomes = []
+
+    def begin_row(self):
+        """Start recording a new row's upserts. Called once per row."""
+        self.upsert_outcomes = []
+        self.last_upsert_would_change = False
+
+    def _record_upsert_outcome(self, *, created, changed):
+        self.upsert_outcomes.append(
+            "creates" if created else ("updates" if changed else "unchanged")
+        )
 
     def _record_issue(self, *args, **kwargs):
         # Deliberately signature-agnostic. Callers pass different keyword sets
@@ -400,6 +418,7 @@ class PreviewRunner:
             # caller; `would_change` is not the question for a row that is not
             # there at all.
             self.last_upsert_would_change = False
+            self._record_upsert_outcome(created=True, changed=False)
             return None, True
         self.last_upsert_would_change = any(
             not _model_field_value_matches(model, obj, field, value)
@@ -407,6 +426,9 @@ class PreviewRunner:
                 model._meta.label_lower,
                 values,
             ).items()
+        )
+        self._record_upsert_outcome(
+            created=False, changed=self.last_upsert_would_change
         )
         return obj, False
 
@@ -448,6 +470,7 @@ class PreviewRunner:
                 break
         if obj is None:
             self.last_upsert_would_change = False
+            self._record_upsert_outcome(created=True, changed=False)
             if return_change:
                 return None, True, True
             return None, True
@@ -460,9 +483,118 @@ class PreviewRunner:
             ).items()
         )
         self.last_upsert_would_change = changed
+        self._record_upsert_outcome(created=False, changed=changed)
         if return_change:
             return obj, False, changed
         return obj, False
+
+    @property
+    def FORWARD_BGP_ADDRESS_FAMILY_ALIASES(self):
+        """The apply's own alias table, not a copy.
+
+        `normalize_bgp_address_family` reads it off the runner to fold Forward's
+        AFI/SAFI spellings onto NetBox's choices. A second copy here would drift
+        from the real one and classify a peer address family as a create under a
+        name the apply never writes.
+        """
+        from .sync import ForwardSyncRunner
+
+        return ForwardSyncRunner.FORWARD_BGP_ADDRESS_FAMILY_ALIASES
+
+    def _ensure_asn(self, asn_value):
+        """Find the ASN, never create it - nor the RIR beneath it.
+
+        The real one saves an `ASN` and calls `_ensure_forward_observed_rir`,
+        which upserts a `RIR`. Both are reached from inside the BGP peer
+        classification, so inheriting either would write while measuring - the
+        same trap as `_ensure_vrf` and `_ensure_platform`.
+
+        The validation is kept because the apply rejects those rows too: an
+        unparseable or sub-1 ASN raises there, is recorded per row and skipped,
+        so a preview that quietly returned `None` would classify a row the apply
+        refuses as a create.
+        """
+        from ipam.models import ASN
+
+        from ..exceptions import ForwardQueryError
+
+        try:
+            asn_number = int(asn_value)
+        except (TypeError, ValueError) as exc:
+            raise ForwardQueryError(f"Invalid BGP ASN value `{asn_value}`.") from exc
+        if asn_number < 1:
+            raise ForwardQueryError(
+                f"Invalid BGP ASN value `{asn_value}`; ASNs must be greater "
+                "than or equal to 1."
+            )
+        existing = self._get_unique_or_raise(ASN, {"asn": asn_number})
+        if existing is not None:
+            self._asn_by_number_cache[existing.asn] = existing
+        return existing
+
+    def _coalesce_upsert(
+        self,
+        model_string,
+        model,
+        *,
+        coalesce_lookups,
+        create_values,
+        update_values=None,
+        return_change=False,
+        create_instance_attrs=None,
+    ):
+        """The third upsert primitive, read-only.
+
+        `ensure_bgp_scope` calls this one - the model-string-carrying wrapper
+        that resolves the conflict policy before delegating to
+        `coalesce_update_or_create`. The preview overrides the delegate, but
+        the real `coalesce_upsert` would still have been inherited and written,
+        because it is defined on the runner rather than reached through one of
+        the two methods already shimmed. A hole exactly where a caller was
+        explicit about the model it was writing.
+        """
+        return self._coalesce_update_or_create(
+            model,
+            coalesce_lookups=coalesce_lookups,
+            create_values=create_values,
+            update_values=update_values,
+            conflict_policy=self._conflict_policy(model_string),
+            return_change=return_change,
+            create_instance_attrs=create_instance_attrs,
+        )
+
+    # --- routing chains, resolved with preview threaded through -------------
+    #
+    # Each delegates to the same impl function the real runner does, with
+    # `preview=True`. The threading exists for the writes that are NOT behind a
+    # `runner.` call and so cannot be shimmed: `ensure_bgp_peer_ip` saves an
+    # `IPAddress` directly, the same shape as the FHRP virtual IP.
+
+    def _ensure_netbox_routing_bgppeer(self, row):
+        from .sync_routing_impl import ensure_netbox_routing_bgppeer
+
+        return ensure_netbox_routing_bgppeer(self, row, preview=True)
+
+    def _ensure_bgp_address_family(self, row):
+        from .sync_routing_impl import ensure_bgp_address_family
+
+        return ensure_bgp_address_family(self, row, preview=True)
+
+    def _ensure_bgp_peer_address_family(self, row):
+        from .sync_routing_impl import ensure_bgp_peer_address_family
+
+        return ensure_bgp_peer_address_family(self, row, preview=True)
+
+    def _ensure_peering_relationship(self, row):
+        """No `preview` argument, and that is the audit result, not an omission.
+
+        Every write in this chain is the one `_upsert_values_from_defaults`
+        below it, which is already shimmed, so the impl function is read-only
+        under this runner as written.
+        """
+        from .sync_routing_impl import ensure_peering_relationship
+
+        return ensure_peering_relationship(self, row)
 
     def _lookup_module_bay(self, device, module_bay_name):
         from .sync_primitives import lookup_module_bay
@@ -575,21 +707,36 @@ def _compare_adapter_rows(runner, rows, apply_row, *, uncomparable_outcomes=()):
     next run would resolve.
     """
     from ..exceptions import ForwardDependencySkipError
+    from ..exceptions import ForwardQueryError
     from ..exceptions import ForwardSearchError
     from ..exceptions import ForwardSyncDataError
 
     counts = {"creates": 0, "updates": 0, "unchanged": 0, "rejected": 0}
     for row in rows:
+        # One row, one record of what it would write. The paths where a row
+        # means several objects read the whole record back; the flat ones do
+        # not, and are unaffected.
+        runner.begin_row()
         try:
             outcome = apply_row(runner, row, preview=True)
         except (
             ForwardDependencySkipError,
+            ForwardQueryError,
             ForwardSearchError,
             ForwardSyncDataError,
         ):
             # An unusable row is a defect in the row, not a difference between
             # the two systems, so it is counted apart from drift rather than
             # inflating it.
+            #
+            # `ForwardQueryError` joined this list with the routing models,
+            # which are the first to raise it during classification - an
+            # unparseable ASN, an empty `afi_safi`, an unsupported address
+            # family. It is NOT a subclass of `ForwardDataError`, so it was
+            # escaping this loop and would have killed the whole comparison
+            # rather than the row. `apply_model_rows` catches it per row
+            # alongside the other three and continues, so counting it rejected
+            # is what the apply does with the same row.
             counts["rejected"] += 1
             continue
         except (KeyError, ValueError):
@@ -668,6 +815,45 @@ def _dlm_comparisons():
     }
 
 
+def _compare_netbox_routing_peering(model_string, apply_function):
+    """Build a comparison for one netbox-routing peering sub-model."""
+
+    def compare(runner, rows):
+        return _compare_adapter_rows(runner, rows, apply_function)
+
+    compare.__name__ = f"_compare_{model_string.replace('.', '_')}"
+    return compare
+
+
+def _peering_comparisons():
+    """The four peering models, which share one classification.
+
+    All four funnel into `ensure_netbox_routing_bgppeer` or the address-family
+    pair beneath it, and every write in those chains is either behind a
+    `runner.` call the preview overrides or behind the `preview` argument
+    threaded through `sync_routing_impl`. So they classify identically and
+    share one builder rather than four that could drift apart.
+
+    `netbox_peering_manager.peeringsession` belongs here rather than with its
+    own plugin: it has no chain of its own, only the BGP peer beneath it.
+    """
+    from .sync_routing_impl import apply_netbox_peering_manager_peeringsession
+    from .sync_routing_impl import apply_netbox_routing_bgpaddressfamily
+    from .sync_routing_impl import apply_netbox_routing_bgppeer
+    from .sync_routing_impl import apply_netbox_routing_bgppeeraddressfamily
+
+    return {
+        "netbox_routing.bgppeer": apply_netbox_routing_bgppeer,
+        "netbox_routing.bgpaddressfamily": apply_netbox_routing_bgpaddressfamily,
+        "netbox_routing.bgppeeraddressfamily": (
+            apply_netbox_routing_bgppeeraddressfamily
+        ),
+        "netbox_peering_manager.peeringsession": (
+            apply_netbox_peering_manager_peeringsession
+        ),
+    }
+
+
 def _compare_dcim_module(runner, rows):
     from .sync_inventory_module import apply_dcim_module
 
@@ -732,6 +918,15 @@ def _register_dlm_comparisons():
         )
 
 
+# netbox-routing is registered lazily for the same reason netbox-dlm is.
+def _register_peering_comparisons():
+    for model_string, apply_function in _peering_comparisons().items():
+        _ADAPTER_COMPARISONS.setdefault(
+            model_string,
+            _compare_netbox_routing_peering(model_string, apply_function),
+        )
+
+
 def compare_model_rows(sync, model_string, rows):
     """Return ``{"creates", "updates", "unchanged", "rejected"}`` or ``None``.
 
@@ -786,6 +981,11 @@ def compare_model_rows(sync, model_string, rows):
         _ADAPTER_COMPARISONS
     ):
         _register_dlm_comparisons()
+    if (
+        model_string.startswith("netbox_routing.")
+        or model_string.startswith("netbox_peering_manager.")
+    ) and model_string not in _ADAPTER_COMPARISONS:
+        _register_peering_comparisons()
     adapter_comparison = _ADAPTER_COMPARISONS.get(model_string)
     if adapter_comparison is not None:
         return adapter_comparison(runner, rows)

--- a/forward_netbox/utilities/sync_routing_impl.py
+++ b/forward_netbox/utilities/sync_routing_impl.py
@@ -124,16 +124,55 @@ def delete_netbox_routing_ospfinterface(runner, row):
     return runner._delete_by_coalesce(OSPFInterface, [{"interface": interface}])
 
 
-def apply_netbox_routing_bgppeer(runner, row):
-    return runner._ensure_netbox_routing_bgppeer(row)
+def preview_routing_outcome(runner, obj):
+    """Classify one routing row from what the shimmed upserts reported.
+
+    A routing row is not one object. A single BGP peer resolves - and the apply
+    would write - up to five: two ASNs, the neighbour `IPAddress`, a
+    `BGPRouter`, a `BGPScope`, and the peer itself. `netbox_routing.bgprouter`
+    and `netbox_routing.bgpscope` have no Forward query of their own; they exist
+    only as parents built while applying a peer. So a router this run would
+    rewrite is drift that NO model would report if this function looked only at
+    the leaf row, and the peer model would read `unchanged` while every run
+    rewrote 360 routers - the confident zero this feature exists to prevent.
+
+    Hence the verdict is the strongest outcome across every upsert the row
+    performed, taken from the preview runner's own record of them, rather than
+    from `last_upsert_would_change` alone the way the flat DLM rows are
+    classified.
+
+    ``obj is None`` means a parent was absent, so the leaf cannot already
+    exist: the row is a create.
+    """
+    if obj is None:
+        return "creates"
+    outcomes = getattr(runner, "upsert_outcomes", ())
+    if "creates" in outcomes:
+        return "creates"
+    if "updates" in outcomes:
+        return "updates"
+    return "unchanged"
 
 
-def apply_netbox_routing_bgpaddressfamily(runner, row):
-    return runner._ensure_bgp_address_family(row)
+def apply_netbox_routing_bgppeer(runner, row, *, preview=False):
+    peer = runner._ensure_netbox_routing_bgppeer(row)
+    if preview:
+        return preview_routing_outcome(runner, peer)
+    return peer
 
 
-def apply_netbox_routing_bgppeeraddressfamily(runner, row):
-    return runner._ensure_bgp_peer_address_family(row)
+def apply_netbox_routing_bgpaddressfamily(runner, row, *, preview=False):
+    address_family = runner._ensure_bgp_address_family(row)
+    if preview:
+        return preview_routing_outcome(runner, address_family)
+    return address_family
+
+
+def apply_netbox_routing_bgppeeraddressfamily(runner, row, *, preview=False):
+    peer_address_family = runner._ensure_bgp_peer_address_family(row)
+    if preview:
+        return preview_routing_outcome(runner, peer_address_family)
+    return peer_address_family
 
 
 def apply_netbox_routing_ospfinstance(runner, row):
@@ -148,13 +187,24 @@ def apply_netbox_routing_ospfinterface(runner, row):
     return runner._ensure_ospf_interface(row)
 
 
-def apply_netbox_peering_manager_peeringsession(runner, row):
+def apply_netbox_peering_manager_peeringsession(runner, row, *, preview=False):
+    """Bind the session to its peer, or - with ``preview`` - classify only.
+
+    Every write in this path is behind a ``runner.`` call the preview overrides,
+    including `_ensure_peering_relationship`, which upserts a `Relationship`.
+    The one thing it needs of its own is the guard below: the session coalesces
+    on `bgp_peer` alone, so an absent peer would look the session up on
+    ``{"bgp_peer": None}`` and match whichever unrelated session has no peer.
+    """
     PeeringSession = runner._optional_model(
         "netbox_peering_manager",
         "PeeringSession",
         "netbox_peering_manager.peeringsession",
     )
     bgp_peer = runner._ensure_netbox_routing_bgppeer(row)
+    if preview and bgp_peer is None:
+        # The peer is absent, so its session cannot already exist either.
+        return "creates"
     values = runner._model_field_values(
         PeeringSession,
         {
@@ -163,22 +213,43 @@ def apply_netbox_peering_manager_peeringsession(runner, row):
             "service_reference": row.get("service_reference") or "",
         },
     )
-    runner._upsert_values_from_defaults(
+    session, _ = runner._upsert_values_from_defaults(
         "netbox_peering_manager.peeringsession",
         PeeringSession,
         values=values,
         coalesce_sets=[("bgp_peer",)],
     )
+    if preview:
+        return preview_routing_outcome(runner, session)
 
 
-def bgp_vrf(runner, row):
-    return routing_vrf(runner, row)
+#: Returned by `routing_vrf` under preview when the row NAMES a VRF that NetBox
+#: does not have. Distinct from `None`, which means the row names no VRF at all
+#: and the object genuinely belongs in the global table.
+VRF_ABSENT = object()
 
 
-def routing_vrf(runner, row):
+def bgp_vrf(runner, row, *, preview=False):
+    return routing_vrf(runner, row, preview=preview)
+
+
+def routing_vrf(runner, row, *, preview=False):
+    """Resolve the row's VRF; under preview, distinguish absent from global.
+
+    The real `_ensure_vrf` CREATES a missing VRF. The preview runner's override
+    resolves and returns `None` instead, which collides with the answer for a
+    row that names no VRF at all - and the collision is not cosmetic. Every
+    coalesce set below includes `vrf`, so a row whose VRF does not exist yet
+    would look its object up on `vrf=None` and match the unrelated GLOBAL one:
+    an OSPF instance or BGP scope that the apply would create would be reported
+    as already present and unchanged.
+
+    That is the confident-zero failure this feature exists to prevent, so the
+    two answers are kept apart and the callers report a create.
+    """
     if not row.get("vrf"):
         return None
-    return runner._ensure_vrf(
+    vrf = runner._ensure_vrf(
         {
             "name": row["vrf"],
             "rd": None,
@@ -187,6 +258,9 @@ def routing_vrf(runner, row):
         },
         update_existing=False,
     )
+    if preview and vrf is None:
+        return VRF_ABSENT
+    return vrf
 
 
 def lookup_device_for_routing(runner, row, model_string, object_label):
@@ -232,13 +306,26 @@ def lookup_ipaddress_by_host(runner, *, address, vrf):
     return runner._get_unique_or_raise(IPAddress, lookup)
 
 
-def ensure_bgp_peer_ip(runner, row, vrf):
+def ensure_bgp_peer_ip(runner, row, vrf, *, preview=False):
+    """Find the neighbour address, and - under ``preview`` - never create it.
+
+    This save is DIRECT: it is not reached through any ``runner.`` call, so the
+    preview runner's firewall does not see it. Same shape as the FHRP virtual
+    IP and as cables, and the reason this path needs a ``preview`` argument
+    rather than another shim.
+
+    Returning ``None`` under preview says the address is absent. The caller
+    treats that as a create for the whole row, which is the honest answer: a
+    peer cannot already exist against a neighbour address NetBox does not have.
+    """
     from ipam.models import IPAddress
 
     neighbor_address = row["neighbor_address"]
     existing = lookup_ipaddress_by_host(runner, address=neighbor_address, vrf=vrf)
     if existing is not None:
         return existing
+    if preview:
+        return None
     ip_obj = IPAddress(
         address=host_address(neighbor_address),
         vrf=vrf,
@@ -344,17 +431,37 @@ def bgp_peer_address_family_comments(row):
     return "\n".join(lines)
 
 
-def bgp_peer_values(runner, row):
+def bgp_peer_values(runner, row, *, preview=False):
+    """Resolve everything a peer hangs off, or ``None`` if a parent is absent.
+
+    Under ``preview`` the ASNs and the neighbour address resolve rather than
+    create, so any of them can come back ``None``. Building the peer's values
+    against a missing parent would be worse than useless: ``ensure_bgp_router``
+    reads ``local_asn.asn`` for the router name and would raise
+    ``AttributeError``, which no caller catches, and a scope coalesced on
+    ``router=None`` would match some unrelated row. So an absent parent short-
+    circuits to ``None`` and the caller reports the row as a create.
+    """
     device = lookup_device_for_routing(
         runner, row, "netbox_routing.bgppeer", "BGP peer"
     )
 
-    vrf = bgp_vrf(runner, row)
+    vrf = bgp_vrf(runner, row, preview=preview)
+    if vrf is VRF_ABSENT:
+        # The peer's VRF does not exist yet, so neither can anything coalesced
+        # inside it. Resolving on `vrf=None` would match the global scope.
+        return None
     local_asn = runner._ensure_asn(row["local_asn"])
     remote_asn = runner._ensure_asn(row["peer_asn"])
-    peer_ip = ensure_bgp_peer_ip(runner, row, vrf)
+    peer_ip = ensure_bgp_peer_ip(runner, row, vrf, preview=preview)
+    if preview and (local_asn is None or remote_asn is None or peer_ip is None):
+        return None
     router = ensure_bgp_router(runner, row, device, local_asn)
+    if preview and router is None:
+        return None
     scope = ensure_bgp_scope(runner, row, router, vrf)
+    if preview and scope is None:
+        return None
     status = row.get("status") or ("active" if row.get("enabled") else "offline")
     if status not in {"active", "planned", "offline", "failed"}:
         status = "active" if row.get("enabled") else "offline"
@@ -371,11 +478,15 @@ def bgp_peer_values(runner, row):
     }
 
 
-def ensure_netbox_routing_bgppeer(runner, row):
+def ensure_netbox_routing_bgppeer(runner, row, *, preview=False):
     BGPPeer = runner._optional_model(
         "netbox_routing", "BGPPeer", "netbox_routing.bgppeer"
     )
-    values = runner._model_field_values(BGPPeer, bgp_peer_values(runner, row))
+    peer_values = bgp_peer_values(runner, row, preview=preview)
+    if peer_values is None:
+        # Preview only, and only when a parent is absent - see `bgp_peer_values`.
+        return None
+    values = runner._model_field_values(BGPPeer, peer_values)
     peer, _ = runner._upsert_values_from_defaults(
         "netbox_routing.bgppeer",
         BGPPeer,
@@ -395,21 +506,33 @@ def normalize_bgp_address_family(afi_safi, *, aliases):
     return aliases.get(value, value)
 
 
-def ensure_bgp_scope_for_row(runner, row, model_string):
+def ensure_bgp_scope_for_row(runner, row, model_string, *, preview=False):
     device = lookup_device_for_routing(runner, row, model_string, "BGP scope")
-    vrf = bgp_vrf(runner, row)
+    vrf = bgp_vrf(runner, row, preview=preview)
+    if vrf is VRF_ABSENT:
+        return None
     local_asn = runner._ensure_asn(row["local_asn"])
+    if preview and local_asn is None:
+        # The router name is built from `local_asn.asn`; an absent ASN means
+        # no router, so no scope, so the row is a create.
+        return None
     router = ensure_bgp_router(runner, row, device, local_asn)
+    if preview and router is None:
+        return None
     return ensure_bgp_scope(runner, row, router, vrf)
 
 
-def ensure_bgp_address_family(runner, row):
+def ensure_bgp_address_family(runner, row, *, preview=False):
     BGPAddressFamily = runner._optional_model(
         "netbox_routing",
         "BGPAddressFamily",
         "netbox_routing.bgpaddressfamily",
     )
-    scope = ensure_bgp_scope_for_row(runner, row, "netbox_routing.bgpaddressfamily")
+    scope = ensure_bgp_scope_for_row(
+        runner, row, "netbox_routing.bgpaddressfamily", preview=preview
+    )
+    if preview and scope is None:
+        return None
     address_family = normalize_bgp_address_family(
         row.get("afi_safi"), aliases=runner.FORWARD_BGP_ADDRESS_FAMILY_ALIASES
     )
@@ -462,14 +585,18 @@ def resolve_bgp_address_family_for_delete(runner, row):
     )
 
 
-def ensure_bgp_peer_address_family(runner, row):
+def ensure_bgp_peer_address_family(runner, row, *, preview=False):
     BGPPeerAddressFamily = runner._optional_model(
         "netbox_routing",
         "BGPPeerAddressFamily",
         "netbox_routing.bgppeeraddressfamily",
     )
-    bgp_peer = ensure_netbox_routing_bgppeer(runner, row)
-    address_family = ensure_bgp_address_family(runner, row)
+    bgp_peer = ensure_netbox_routing_bgppeer(runner, row, preview=preview)
+    if preview and bgp_peer is None:
+        return None
+    address_family = ensure_bgp_address_family(runner, row, preview=preview)
+    if preview and address_family is None:
+        return None
     values = runner._model_field_values(
         BGPPeerAddressFamily,
         {


### PR DESCRIPTION
Slice seven of eight toward #206's remaining scope: `netbox_routing.bgppeer`, `bgpaddressfamily`, `bgppeeraddressfamily`, and `netbox_peering_manager.peeringsession`.

Left until last with slice eight because one Forward row writes more here than anywhere else. A single BGP peer resolves — and the apply persists — six objects:

| object | reached via | shimmed by |
| --- | --- | --- |
| `ipam.ASN` ×2 | `runner._ensure_asn` | new override (find-only) |
| `ipam.RIR` | under `_ensure_asn` | same override, never reached |
| `ipam.IPAddress` | `ensure_bgp_peer_ip` — **direct save** | `preview` argument |
| `BGPRouter` | `_upsert_values_from_defaults` | already overridden |
| `BGPScope` | `runner._coalesce_upsert` | new override |
| `BGPPeer` | `_upsert_values_from_defaults` | already overridden |

Two were firewall holes. `_ensure_asn` saves an ASN and calls `_ensure_forward_observed_rir`, which upserts a RIR — the writes-behind-a-runner-call trap, invisible to a grep of this module for ORM calls. `_coalesce_upsert` is the **third** upsert primitive: the model-string-carrying wrapper that resolves conflict policy before delegating to the one already overridden, defined separately on the runner and so inherited whole.

## The verdict is not the leaf row

`netbox_routing.bgprouter` and `bgpscope` have contracts but **no Forward query of their own** — they exist only as parents built while applying a peer. So a router this run would rewrite is drift that NO model would report if the peer classified from `last_upsert_would_change` alone: the peer would read `unchanged` while every run rewrote its router.

The preview runner now records every upsert a row performs and the verdict is the strongest of them — slice four's "strongest of the three" generalised from three hand-written cases to whatever the chain actually did. `last_upsert_would_change` is untouched, so the flat paths classify exactly as before.

## Two defects found

**An absent VRF resolved to the global one.** Every coalesce set includes `vrf`. The real `_ensure_vrf` creates a missing VRF; the preview override returns `None`, which collided with "this row names no VRF". A peer in a not-yet-existing VRF looked its scope up on `vrf=None` and matched the unrelated global scope — reported as unchanged, a confident zero. Now a distinct `VRF_ABSENT`.

**`ForwardQueryError` was escaping the shared row loop.** It is not a `ForwardDataError`, and the routing paths are the first to raise it during classification, so one malformed row would have aborted the batch. `apply_model_rows` catches it per row and continues; the loop now does the same. Latent in the earlier slices, not introduced here.

## Testing

16 new tests; 122 adjacent drift/routing tests green; harness 334 green; full suite 2438 green on the finished stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)