### PR TITLE
feat: measure drift for the OSPF models, and fix a ForwardQueryError that raised TypeError

### DIFF
--- a/docs/03_Plans/active/2026-09-01-adapter-model-drift-ospf.md
+++ b/docs/03_Plans/active/2026-09-01-adapter-model-drift-ospf.md
@@ -1,0 +1,123 @@
+# Measure drift for the OSPF models
+
+## Goal
+
+Slice eight of eight, and the last of the adapter-only drift comparison:
+`netbox_routing.ospfinstance`, `netbox_routing.ospfarea` and
+`netbox_routing.ospfinterface`.
+
+## Why
+
+Unchanged, and this is the slice that ends it: every adapter-only model named
+in #206 now reports a measurement rather than an upper bound.
+
+## Constraints
+
+- Reuse the apply's own resolution and comparisons.
+- Write nothing.
+- A row the apply refuses must not read as drift.
+- **A parent that is separately measured must not be counted twice.**
+
+## Touched Surfaces
+
+- `forward_netbox/exceptions.py` - `ForwardQueryError` accepts the structured
+  keywords two callers already passed it
+- `forward_netbox/utilities/sync_routing_impl.py` - `preview` threaded through
+  the instance chain; the three apply functions classify
+- `forward_netbox/utilities/drift_comparison.py` - three chain delegations and
+  the dispatch entries
+- `forward_netbox/tests/test_ospf_drift_comparison.py` (new)
+
+## Approach
+
+### The audit is short, and that is the finding
+
+Every write in these three chains is already behind a `runner.` call the
+preview overrides - `_upsert_values_from_defaults` for all three models,
+`_ensure_vrf` beneath the instance, `_lookup_interface` beneath the interface.
+There is no direct save here, unlike the BGP neighbour address (slice seven),
+the FHRP virtual IP (slice four) or `Cable.save()` (slice two).
+
+`lookup_routing_interface_name` falls back to a raw `Interface.objects.filter`
+and then calls `remember_lookup_object`, which was checked: it only writes into
+the runner's own memoisation dicts, every one of which `PreviewRunner` seeds.
+
+### The verdict rule is the OPPOSITE of slice seven's
+
+Slice seven takes the strongest outcome across every object a row touches,
+because a BGP peer's `BGPRouter` and `BGPScope` have no Forward query of their
+own - the peer is the only place their drift can ever be reported.
+
+Every OSPF parent is a **separately measured model**. `ospfinstance` and
+`ospfarea` each have their own query in `query_registry.py` and their own row
+set. So folding a parent's create into the interface's verdict would count one
+object twice - once under the model that owns it, and again under this one -
+and inflate total drift by exactly the number of shared parents.
+
+`preview_leaf_outcome` therefore classifies from the leaf's own upsert, the way
+the flat DLM rows do. The two rules sit next to each other in
+`sync_routing_impl.py` with the reason on each, because the difference is not
+obvious from either call site and picking the wrong one is silent in both
+directions.
+
+### An absent VRF, again
+
+`ensure_ospf_instance` coalesces on `("device", "vrf", "process_id")`, so it has
+the same collision slice seven fixed for BGP scopes: an unresolved VRF left
+`vrf=None` on the lookup and matched the device's GLOBAL instance, reporting an
+instance the apply would create as already present. It uses the same
+`routing_vrf` guard and returns a create.
+
+### `ForwardQueryError` took no keyword arguments
+
+Found by the preview, but the bug is in the APPLY, and it is the more serious
+of the two findings here.
+
+Two callers build it with `model_string=`, `context=` and `data=`:
+
+- `ensure_bgp_address_family` - an address family NetBox does not offer
+- `ensure_ospf_instance` - a row with no `router_id`
+
+`ForwardQueryError` subclasses `ForwardSyncError`, which defines no `__init__`,
+so **both raised `TypeError` instead of the exception they name**.
+`apply_model_rows` catches `ForwardQueryError` per row, records the issue and
+continues (`sync_reporting.py:589`); it catches no `TypeError` anywhere. So one
+malformed OSPF row, or one unsupported BGP address family, aborted the apply
+for its entire model rather than being recorded and skipped - and the recorded
+failure would have named `TypeError`, which says nothing about the row.
+
+Fixed by giving `ForwardQueryError` the same structured keywords
+`ForwardDataError` has. Deliberately NOT reparented under `ForwardDataError`:
+several `except ForwardDataError` sites would silently start catching query
+failures, and nothing here needs that.
+
+## Testing
+
+`forward_netbox/tests/test_ospf_drift_comparison.py`, 19 tests: the firewall,
+the classification for all three models, the absent-VRF collision, the two
+double-counting cases, the rejection paths, and three on the exception
+signature including one that drives the real OSPF raise site.
+
+## Limits
+
+**Every adapter-only model NAMED in #206 is now measured. That is not the same
+as every model.** A static sweep of `query_registry.py` against
+`_ADAPTER_COMPARISONS` and the bulk dispatcher leaves ten fetched models still
+reporting an upper bound:
+
+| model(s) | why |
+| --- | --- |
+| `netbox_cisco_aci.*` (8) | adapter-only, never in the eight-slice scope - #206 predates the ACI maps |
+| `netbox_dlm.inventoryitemsoftware` | deferred in slice six, pending an audit of `_lookup_inventory_item` |
+| `dcim.virtualchassis` | deliberate: it creates rows and THEN assigns devices to them |
+
+So a deployment with netbox-cisco-aci or netbox-dlm still reports a PARTIAL
+measurement, which the report states as "N of M models" rather than implying
+whole-estate coverage. `in_sync` is answerable end to end only for a deployment
+running neither optional plugin.
+
+Closing ACI is a ninth slice and is the largest single block of what remains;
+it was not in this stack's scope and is not claimed by it.
+- The `ForwardQueryError` fix is not covered by a test that exercises the
+  BGP address-family raise site through a real apply; only the OSPF one is
+  driven end to end.

--- a/forward_netbox/exceptions.py
+++ b/forward_netbox/exceptions.py
@@ -55,7 +55,46 @@ class ForwardLicenseTierError(ForwardClientError):
 
 
 class ForwardQueryError(ForwardSyncError):
-    """Raised when a built-in Forward NQE query fails."""
+    """Raised when a built-in Forward NQE query fails.
+
+    Accepts the same structured keywords as `ForwardDataError` because two
+    callers already passed them: `ensure_bgp_address_family` for an unsupported
+    address family, and `ensure_ospf_instance` for a row with no `router_id`.
+    Both took `message, model_string=..., context=..., data=...` against an
+    `__init__` that took none, so BOTH raised `TypeError` instead - and
+    `apply_model_rows` catches `ForwardQueryError` per row and continues, but
+    catches no `TypeError` at all. One malformed OSPF or BGP address-family row
+    therefore aborted the apply for its whole model rather than being recorded
+    and skipped.
+
+    Kept as a `ForwardSyncError` rather than reparented under `ForwardDataError`:
+    several `except ForwardDataError` sites would silently start catching query
+    failures, which is a behaviour change nothing here needs. The keywords are
+    accepted and recorded; the hierarchy is not touched.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        model_string: str | None = None,
+        context: dict | None = None,
+        defaults: dict | None = None,
+        data: dict | None = None,
+        issue_id: int | None = None,
+        dependency: str | None = None,
+        dependency_is_protecting: bool = False,
+        netbox_pk=None,
+    ):
+        super().__init__(message)
+        self.model_string = model_string
+        self.context = context or {}
+        self.defaults = defaults or {}
+        self.data = data or {}
+        self.issue_id = issue_id
+        self.dependency = dependency or ""
+        self.dependency_is_protecting = bool(dependency_is_protecting)
+        self.netbox_pk = None if netbox_pk is None else str(netbox_pk).strip() or None
 
 
 class ForwardDataError(ForwardSyncError):

--- a/forward_netbox/tests/test_empty_comparison_is_not_a_measurement.py
+++ b/forward_netbox/tests/test_empty_comparison_is_not_a_measurement.py
@@ -2,10 +2,16 @@
 
 A deployment's drift report showed 2 of 32 models measured. One of the two was
 `netbox_dlm.softwareversion`, carrying a green `In sync: Yes` against 45
-Forward rows. That model is adapter-only: it appears nowhere in the comparison
-dispatcher, so it has no comparison and cannot be measured. The badge came from
-a shortcut that returned a confident zero whenever the row list was empty,
-without ever asking whether the model was one this code can compare.
+Forward rows. That model was adapter-only: it appeared nowhere in the
+comparison dispatcher, so it had no comparison and could not be measured. The
+badge came from a shortcut that returned a confident zero whenever the row list
+was empty, without ever asking whether the model was one this code can compare.
+
+`netbox_dlm.softwareversion` has since BEEN wired up, which is why these tests
+now use `netbox_cisco_aci.acitenant` as their uncomparable example. The rule
+under test never depended on which model stood in for it: an uncomparable model
+says `None` however many rows it is handed. Every substitution here needs to be
+a model the dispatcher genuinely declines - checking that is the point.
 
 The two situations are indistinguishable at that point - a model with genuinely
 nothing incoming, and a model whose rows never arrived - and only one of them
@@ -23,16 +29,31 @@ class AnUncomparableModelNeverReportsZeroTest(TestCase):
     """The failure that reached a customer: zero rows read as zero drift."""
 
     def test_adapter_only_model_with_no_rows_is_not_measured(self):
-        # `netbox_dlm.softwareversion` is applied by `sync_dlm`, not by the
-        # bulk dispatcher, so there is nothing here that could compare it.
-        self.assertIsNone(compare_model_rows(None, "netbox_dlm.softwareversion", []))
+        # `netbox_cisco_aci.acitenant` is applied by the ACI adapter, not by
+        # the bulk dispatcher, and no slice has wired it up, so there is
+        # nothing here that could compare it.
+        self.assertIsNone(compare_model_rows(None, "netbox_cisco_aci.acitenant", []))
 
     def test_adapter_only_model_with_rows_is_not_measured_either(self):
         # Same answer with rows present. The emptiness was never what made it
         # uncomparable, which is why keying the shortcut off emptiness was wrong.
         self.assertIsNone(
-            compare_model_rows(None, "netbox_dlm.softwareversion", [{"version": "1.0"}])
+            compare_model_rows(
+                None, "netbox_cisco_aci.acitenant", [{"name": "TENANT-A"}]
+            )
         )
+
+    def test_the_model_this_test_was_written_against_is_now_measured(self):
+        """Pins the substitution above, so it cannot silently rot again.
+
+        `netbox_dlm.softwareversion` was the uncomparable example until slice
+        six wired it up, and this file was not updated with it - so these tests
+        went red on the full suite while every targeted run stayed green. If a
+        later slice wires up `netbox_cisco_aci.acitenant` too, this assertion
+        fails and names the reason instead of leaving the next person to
+        rediscover it from two stale assertions.
+        """
+        self.assertIsNotNone(compare_model_rows(None, "netbox_dlm.softwareversion", []))
 
     def test_a_model_that_declines_on_purpose_still_declines_when_empty(self):
         # virtualchassis returns None deliberately; an empty list must not

--- a/forward_netbox/tests/test_ospf_drift_comparison.py
+++ b/forward_netbox/tests/test_ospf_drift_comparison.py
@@ -1,0 +1,299 @@
+# Slice eight of the adapter-only drift comparison, and the last one:
+# `netbox_routing.ospfinstance`, `ospfarea` and `ospfinterface`.
+#
+# The audit result here is short, which is itself the finding: every write in
+# these three chains is already behind a `runner.` call the preview overrides.
+# No direct save, unlike the BGP neighbour address and the FHRP virtual IP.
+#
+# What they DO need is the opposite of what the peering models needed. A BGP
+# peer's BGPRouter and BGPScope have no Forward query of their own, so the peer
+# is the only place their drift can be reported and its verdict is the
+# strongest across the whole chain. Every OSPF parent is a SEPARATELY measured
+# model with its own query and its own rows, so folding a parent's create into
+# the interface's verdict would count one object twice. `preview_leaf_outcome`
+# is that distinction, and the double-count test below is what pins it.
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import Interface
+from dcim.models import Manufacturer
+from dcim.models import Site
+from django.test import TestCase
+from ipam.models import VRF
+
+from forward_netbox.utilities.drift_comparison import compare_model_rows
+
+INSTANCE = "netbox_routing.ospfinstance"
+AREA = "netbox_routing.ospfarea"
+OSPF_INTERFACE = "netbox_routing.ospfinterface"
+
+
+def _ospf_models():
+    from forward_netbox.utilities.sync_primitives import optional_model
+
+    return (
+        optional_model("netbox_routing", "OSPFInstance", INSTANCE),
+        optional_model("netbox_routing", "OSPFArea", AREA),
+        optional_model("netbox_routing", "OSPFInterface", OSPF_INTERFACE),
+    )
+
+
+class OspfPreviewTest(TestCase):
+    def setUp(self):
+        site = Site.objects.create(name="O Site", slug="o-site")
+        mfr = Manufacturer.objects.create(name="O Mfr", slug="o-mfr")
+        dtype = DeviceType.objects.create(manufacturer=mfr, model="O DT", slug="o-dt")
+        role = DeviceRole.objects.create(name="O Role", slug="o-role")
+        self.device = Device.objects.create(
+            name="ospf-dev", site=site, device_type=dtype, role=role, status="active"
+        )
+        self.interface = Interface.objects.create(
+            device=self.device, name="GigabitEthernet0/0", type="1000base-t"
+        )
+
+    def _row(self, **extra):
+        row = {
+            "device": "ospf-dev",
+            "process_id": "1",
+            "router_id": "10.0.0.1",
+            "area_id": "0.0.0.0",
+            "area_type": "standard",
+            "local_interface": "GigabitEthernet0/0",
+        }
+        row.update(extra)
+        return row
+
+    def _existing_instance(self, *, router_id="10.0.0.1", vrf=None):
+        from forward_netbox.utilities.sync_routing_impl import ospf_instance_comments
+
+        OSPFInstance, _, _ = _ospf_models()
+        return OSPFInstance.objects.create(
+            name=f"{self.device.name} OSPF 1",
+            router_id=router_id,
+            process_id=1,
+            device=self.device,
+            vrf=vrf,
+            comments=ospf_instance_comments(self._row(), "1"),
+        )
+
+    def _existing_area(self, *, area_type="standard"):
+        _, OSPFArea, _ = _ospf_models()
+        return OSPFArea.objects.create(
+            area_id="0.0.0.0",
+            area_type=area_type,
+            description="Observed by Forward from structured OSPF state.",
+        )
+
+    def _existing_interface(self):
+        from forward_netbox.utilities.sync_routing_impl import ospf_interface_comments
+
+        _, _, OSPFInterface = _ospf_models()
+        return OSPFInterface.objects.create(
+            instance=self._existing_instance(),
+            area=self._existing_area(),
+            interface=self.interface,
+            priority=None,
+            comments=ospf_interface_comments(self._row()),
+        )
+
+    # --- the firewall ------------------------------------------------------
+
+    def test_a_preview_creates_no_instance_area_or_interface(self):
+        OSPFInstance, OSPFArea, OSPFInterface = _ospf_models()
+        for model_string in (INSTANCE, AREA, OSPF_INTERFACE):
+            compare_model_rows(None, model_string, [self._row()])
+        self.assertEqual(OSPFInstance.objects.count(), 0)
+        self.assertEqual(OSPFArea.objects.count(), 0)
+        self.assertEqual(OSPFInterface.objects.count(), 0)
+        self.assertEqual(VRF.objects.count(), 0)
+
+    def test_a_preview_does_not_rewrite_a_drifted_instance(self):
+        instance = self._existing_instance(router_id="10.9.9.9")
+        compare_model_rows(None, INSTANCE, [self._row()])
+        instance.refresh_from_db()
+        self.assertEqual(str(instance.router_id), "10.9.9.9")
+
+    # --- the classification ------------------------------------------------
+
+    def test_a_matching_instance_is_unchanged(self):
+        self._existing_instance()
+        result = compare_model_rows(None, INSTANCE, [self._row()])
+        self.assertEqual(result["unchanged"], 1)
+
+    def test_a_drifted_instance_is_an_update(self):
+        self._existing_instance(router_id="10.9.9.9")
+        result = compare_model_rows(None, INSTANCE, [self._row()])
+        self.assertEqual(result["updates"], 1)
+
+    def test_an_absent_instance_is_a_create(self):
+        result = compare_model_rows(None, INSTANCE, [self._row()])
+        self.assertEqual(result["creates"], 1)
+
+    def test_a_matching_area_is_unchanged(self):
+        self._existing_area()
+        result = compare_model_rows(None, AREA, [self._row()])
+        self.assertEqual(result["unchanged"], 1)
+
+    def test_a_drifted_area_is_an_update(self):
+        self._existing_area(area_type="nssa")
+        result = compare_model_rows(None, AREA, [self._row()])
+        self.assertEqual(result["updates"], 1)
+
+    def test_a_matching_interface_is_unchanged(self):
+        self._existing_interface()
+        result = compare_model_rows(None, OSPF_INTERFACE, [self._row()])
+        self.assertEqual(result["unchanged"], 1)
+
+    # --- the parents are measured elsewhere, so they are NOT counted here ---
+
+    def test_an_absent_parent_does_not_make_a_matching_interface_drift(self):
+        """The interface row exists and matches; only its parents are absent.
+
+        Its `instance` and `area` are separately measured models, so counting
+        their creates here would report the same two objects twice - once under
+        their own model and again under this one. The interface coalesces on
+        `interface` alone, so its own row is found and compared on its merits.
+        """
+        _, _, OSPFInterface = _ospf_models()
+        from forward_netbox.utilities.sync_routing_impl import ospf_interface_comments
+
+        OSPFInterface.objects.create(
+            instance=self._existing_instance(),
+            area=self._existing_area(),
+            interface=self.interface,
+            priority=None,
+            comments=ospf_interface_comments(self._row()),
+        )
+        result = compare_model_rows(None, OSPF_INTERFACE, [self._row()])
+        self.assertEqual(result["unchanged"], 1)
+        self.assertEqual(result["creates"], 0)
+
+    def test_an_absent_instance_is_not_also_a_create_under_the_interface(self):
+        """The same absent OSPFInstance, asked of both models.
+
+        `netbox_routing.ospfinstance` reports the create, because it owns that
+        object. `netbox_routing.ospfinterface` reports an UPDATE - the apply
+        would repoint the existing interface row at the new instance - and
+        crucially not a second create, which is what folding a parent's outcome
+        into the leaf's verdict would have produced.
+        """
+        OSPFInstance, _, _ = _ospf_models()
+        # The interface exists and points at a DIFFERENT process, so the row's
+        # own instance is absent while the interface row itself is present.
+        # `instance` is NOT NULL, so this is the only shape that models it.
+        other = OSPFInstance.objects.create(
+            name=f"{self.device.name} OSPF 99",
+            router_id="10.0.0.99",
+            process_id=99,
+            device=self.device,
+            vrf=None,
+            comments="",
+        )
+        from forward_netbox.utilities.sync_routing_impl import ospf_interface_comments
+
+        _, _, OSPFInterface = _ospf_models()
+        OSPFInterface.objects.create(
+            instance=other,
+            area=self._existing_area(),
+            interface=self.interface,
+            priority=None,
+            comments=ospf_interface_comments(self._row()),
+        )
+
+        instance_result = compare_model_rows(None, INSTANCE, [self._row()])
+        self.assertEqual(instance_result["creates"], 1)
+
+        interface_result = compare_model_rows(None, OSPF_INTERFACE, [self._row()])
+        self.assertEqual(interface_result["creates"], 0)
+        self.assertEqual(interface_result["updates"], 1)
+
+    # --- the VRF collision this shares with the peering chain --------------
+
+    def test_an_instance_naming_an_absent_vrf_is_a_create(self):
+        """Coalesced on ("device", "vrf", "process_id").
+
+        With `vrf=None` standing in for an unresolved VRF, this matched the
+        device's GLOBAL instance and reported an instance the apply would
+        create as already present.
+        """
+        self._existing_instance()
+        result = compare_model_rows(None, INSTANCE, [self._row(vrf="TENANT-B")])
+        self.assertEqual(result["creates"], 1)
+        self.assertEqual(result["unchanged"], 0)
+
+    def test_an_instance_naming_an_existing_vrf_resolves_into_it(self):
+        vrf = VRF.objects.create(name="TENANT-B")
+        self._existing_instance(vrf=vrf)
+        result = compare_model_rows(None, INSTANCE, [self._row(vrf="TENANT-B")])
+        self.assertEqual(result["unchanged"], 1)
+
+    # --- rows the apply refuses -------------------------------------------
+
+    def test_an_instance_without_a_router_id_is_rejected(self):
+        result = compare_model_rows(None, INSTANCE, [self._row(router_id="")])
+        self.assertEqual(result["rejected"], 1)
+        self.assertEqual(result["creates"], 0)
+
+    def test_an_unknown_device_is_rejected(self):
+        result = compare_model_rows(None, INSTANCE, [self._row(device="nope")])
+        self.assertEqual(result["rejected"], 1)
+
+    def test_an_uninported_local_interface_is_a_skip_not_drift(self):
+        result = compare_model_rows(
+            None, OSPF_INTERFACE, [self._row(local_interface="Gi9/9")]
+        )
+        self.assertEqual(result["rejected"], 1)
+        self.assertEqual(result["creates"], 0)
+
+    # --- every adapter model now answers -----------------------------------
+
+    def test_the_ospf_models_report_a_measurement_not_an_upper_bound(self):
+        for model_string in (INSTANCE, AREA, OSPF_INTERFACE):
+            with self.subTest(model_string=model_string):
+                self.assertIsNotNone(compare_model_rows(None, model_string, []))
+
+
+class ForwardQueryErrorSignatureTest(TestCase):
+    """`ForwardQueryError` took no keywords, and two callers passed four.
+
+    Found by the preview, but the bug is in the APPLY. Both raise sites built
+    the exception with `model_string=`, `context=` and `data=` against an
+    `__init__` that accepted none, so both raised `TypeError` instead.
+    `apply_model_rows` catches `ForwardQueryError` per row, records the issue
+    and continues; it catches no `TypeError` at all. So one OSPF row with no
+    `router_id`, or one BGP row with an address family NetBox does not offer,
+    aborted the apply for its entire model instead of being skipped.
+    """
+
+    def test_the_structured_keywords_are_accepted_and_recorded(self):
+        from forward_netbox.exceptions import ForwardQueryError
+
+        exc = ForwardQueryError(
+            "boom",
+            model_string=INSTANCE,
+            context={"device": "d1"},
+            data={"row": 1},
+        )
+        self.assertEqual(exc.model_string, INSTANCE)
+        self.assertEqual(exc.context, {"device": "d1"})
+        self.assertEqual(exc.data, {"row": 1})
+
+    def test_the_ospf_raise_site_raises_its_own_class(self):
+        from forward_netbox.exceptions import ForwardQueryError
+        from forward_netbox.utilities.drift_comparison import PreviewRunner
+        from forward_netbox.utilities.sync_routing_impl import ensure_ospf_instance
+
+        site = Site.objects.create(name="Q Site", slug="q-site")
+        mfr = Manufacturer.objects.create(name="Q Mfr", slug="q-mfr")
+        dtype = DeviceType.objects.create(manufacturer=mfr, model="Q DT", slug="q-dt")
+        role = DeviceRole.objects.create(name="Q Role", slug="q-role")
+        Device.objects.create(
+            name="q-dev", site=site, device_type=dtype, role=role, status="active"
+        )
+        with self.assertRaises(ForwardQueryError):
+            ensure_ospf_instance(PreviewRunner(), {"device": "q-dev", "router_id": ""})
+
+    def test_the_message_still_reaches_str(self):
+        from forward_netbox.exceptions import ForwardQueryError
+
+        self.assertEqual(str(ForwardQueryError("plain message")), "plain message")

--- a/forward_netbox/utilities/drift_comparison.py
+++ b/forward_netbox/utilities/drift_comparison.py
@@ -585,6 +585,27 @@ class PreviewRunner:
 
         return ensure_bgp_peer_address_family(self, row, preview=True)
 
+    def _ensure_ospf_instance(self, row):
+        from .sync_routing_impl import ensure_ospf_instance
+
+        return ensure_ospf_instance(self, row, preview=True)
+
+    def _ensure_ospf_area(self, row):
+        """No `preview` argument, and that is the audit result, not an omission.
+
+        The area resolves through one `_upsert_values_from_defaults` and
+        nothing else - no device, no VRF, no interface - so the impl function
+        is already read-only under this runner as written.
+        """
+        from .sync_routing_impl import ensure_ospf_area
+
+        return ensure_ospf_area(self, row)
+
+    def _ensure_ospf_interface(self, row):
+        from .sync_routing_impl import ensure_ospf_interface
+
+        return ensure_ospf_interface(self, row, preview=True)
+
     def _ensure_peering_relationship(self, row):
         """No `preview` argument, and that is the audit result, not an omission.
 
@@ -826,7 +847,12 @@ def _compare_netbox_routing_peering(model_string, apply_function):
 
 
 def _peering_comparisons():
-    """The four peering models, which share one classification.
+    """The seven netbox-routing models, which share one row loop.
+
+    They do NOT share one verdict rule, and the split is the substance of these
+    two slices - see `preview_routing_outcome` against `preview_leaf_outcome`.
+
+    Named for peering because that is the slice that built it.
 
     All four funnel into `ensure_netbox_routing_bgppeer` or the address-family
     pair beneath it, and every write in those chains is either behind a
@@ -841,6 +867,9 @@ def _peering_comparisons():
     from .sync_routing_impl import apply_netbox_routing_bgpaddressfamily
     from .sync_routing_impl import apply_netbox_routing_bgppeer
     from .sync_routing_impl import apply_netbox_routing_bgppeeraddressfamily
+    from .sync_routing_impl import apply_netbox_routing_ospfarea
+    from .sync_routing_impl import apply_netbox_routing_ospfinstance
+    from .sync_routing_impl import apply_netbox_routing_ospfinterface
 
     return {
         "netbox_routing.bgppeer": apply_netbox_routing_bgppeer,
@@ -851,6 +880,9 @@ def _peering_comparisons():
         "netbox_peering_manager.peeringsession": (
             apply_netbox_peering_manager_peeringsession
         ),
+        "netbox_routing.ospfinstance": apply_netbox_routing_ospfinstance,
+        "netbox_routing.ospfarea": apply_netbox_routing_ospfarea,
+        "netbox_routing.ospfinterface": apply_netbox_routing_ospfinterface,
     }
 
 
@@ -943,11 +975,13 @@ def compare_model_rows(sync, model_string, rows):
     # There used to be one: no rows, therefore nothing to create or update,
     # therefore a confident zero. It is true arithmetic and the wrong answer,
     # because it answers for models this function cannot compare at all.
-    # `netbox_dlm.softwareversion` is adapter-only and has no comparison; a
-    # deployment reporting 45 Forward rows for it still reached this line with
-    # an empty row list, took the shortcut, and the drift report showed it
-    # measured and `In sync: Yes` - the only affirmative claim on the page,
-    # made by the one branch that never looked at NetBox.
+    # `netbox_dlm.softwareversion` was adapter-only and had no comparison when
+    # this was written (it has since been wired up); a deployment reporting 45
+    # Forward rows for it still reached this line with an empty row list, took
+    # the shortcut, and the drift report showed it measured and `In sync: Yes`
+    # - the only affirmative claim on the page, made by the one branch that
+    # never looked at NetBox. The `netbox_cisco_aci.*` models are in that
+    # position now.
     #
     # An empty row list is not evidence of agreement. It means either that the
     # model genuinely has nothing incoming, or that its rows never reached this

--- a/forward_netbox/utilities/sync_routing_impl.py
+++ b/forward_netbox/utilities/sync_routing_impl.py
@@ -175,16 +175,47 @@ def apply_netbox_routing_bgppeeraddressfamily(runner, row, *, preview=False):
     return peer_address_family
 
 
-def apply_netbox_routing_ospfinstance(runner, row):
-    return runner._ensure_ospf_instance(row)
+def preview_leaf_outcome(runner, obj):
+    """Classify one OSPF row from its OWN upsert, not from its parents'.
+
+    The deliberate difference from `preview_routing_outcome`. A BGP peer's
+    `BGPRouter` and `BGPScope` have no Forward query of their own, so the peer
+    is the only place their drift can be reported. Every OSPF parent is a
+    SEPARATELY measured model - `netbox_routing.ospfinstance` and `ospfarea`
+    each have their own query and their own row set - so folding a parent's
+    create into the interface's verdict would count the same object twice, once
+    under its own model and again under this one.
+
+    So this reads the leaf's own upsert, exactly as the flat DLM rows do.
+    """
+    if obj is None:
+        return "creates"
+    return "updates" if runner.last_upsert_would_change else "unchanged"
 
 
-def apply_netbox_routing_ospfarea(runner, row):
-    return runner._ensure_ospf_area(row)
+def apply_netbox_routing_ospfinstance(runner, row, *, preview=False):
+    instance = runner._ensure_ospf_instance(row)
+    if preview:
+        return preview_leaf_outcome(runner, instance)
+    return instance
 
 
-def apply_netbox_routing_ospfinterface(runner, row):
-    return runner._ensure_ospf_interface(row)
+def apply_netbox_routing_ospfarea(runner, row, *, preview=False):
+    area = runner._ensure_ospf_area(row)
+    if preview:
+        return preview_leaf_outcome(runner, area)
+    return area
+
+
+def apply_netbox_routing_ospfinterface(runner, row, *, preview=False):
+    ospf_interface = runner._ensure_ospf_interface(row)
+    if preview:
+        # `False` is this path's own answer for an interface Forward reports
+        # that NetBox never imported - a skip the apply records, not drift.
+        if ospf_interface is False:
+            return False
+        return preview_leaf_outcome(runner, ospf_interface)
+    return ospf_interface
 
 
 def apply_netbox_peering_manager_peeringsession(runner, row, *, preview=False):
@@ -678,14 +709,18 @@ def ospf_interface_comments(row):
     return "\n".join(lines)
 
 
-def ensure_ospf_instance(runner, row):
+def ensure_ospf_instance(runner, row, *, preview=False):
     OSPFInstance = runner._optional_model(
         "netbox_routing", "OSPFInstance", "netbox_routing.ospfinstance"
     )
     device = lookup_device_for_routing(
         runner, row, "netbox_routing.ospfinstance", "OSPF instance"
     )
-    vrf = routing_vrf(runner, row)
+    vrf = routing_vrf(runner, row, preview=preview)
+    if vrf is VRF_ABSENT:
+        # Coalesced on ("device", "vrf", "process_id"); resolving on `vrf=None`
+        # would match the device's GLOBAL instance instead. See `routing_vrf`.
+        return None
     process_id, process_label = ospf_process_values(row)
     router_id = str(row.get("router_id") or "").strip()
     if not router_id:
@@ -737,7 +772,7 @@ def ensure_ospf_area(runner, row):
     return area
 
 
-def ensure_ospf_interface(runner, row):
+def ensure_ospf_interface(runner, row, *, preview=False):
     OSPFInterface = runner._optional_model(
         "netbox_routing", "OSPFInterface", "netbox_routing.ospfinterface"
     )
@@ -757,7 +792,7 @@ def ensure_ospf_interface(runner, row):
             ),
         )
         return False
-    instance = ensure_ospf_instance(runner, row)
+    instance = ensure_ospf_instance(runner, row, preview=preview)
     area = ensure_ospf_area(runner, row)
     values = runner._model_field_values(
         OSPFInterface,


### PR DESCRIPTION
Slice eight of eight toward #206's remaining scope: `netbox_routing.ospfinstance`, `ospfarea` and `ospfinterface`.

## The audit is short, and that is the finding

Every write in these three chains is already behind a `runner.` call the preview overrides. No direct save, unlike the BGP neighbour address (slice seven), the FHRP virtual IP (slice four) or `Cable.save()` (slice two). `lookup_routing_interface_name` falls back to a raw queryset and then calls `remember_lookup_object`, which was checked: it writes only the runner's own memoisation dicts, all of which `PreviewRunner` seeds.

## The verdict rule is the opposite of slice seven's

Slice seven takes the strongest outcome across every object a row touches, because a peer's `BGPRouter` and `BGPScope` have no Forward query of their own and the peer is the only place their drift can be reported.

Every OSPF parent **is** separately measured — `ospfinstance` and `ospfarea` each have their own query in `query_registry.py` and their own rows. Folding a parent's create into the interface's verdict would count one object twice and inflate total drift by the number of shared parents.

`preview_leaf_outcome` therefore classifies from the leaf's own upsert. The two rules sit next to each other with the reason on each, because picking the wrong one is silent in both directions.

## A production bug the preview surfaced

`ForwardQueryError` subclasses `ForwardSyncError`, which defines no `__init__` — but two callers build it with `model_string=`, `context=` and `data=`:

- `ensure_bgp_address_family` — an address family NetBox does not offer
- `ensure_ospf_instance` — a row with no `router_id`

**Both raised `TypeError` instead of the exception they name.** `apply_model_rows` catches `ForwardQueryError` per row, records the issue and continues; it catches no `TypeError` anywhere. So one malformed OSPF row, or one unsupported BGP address family, **aborted the apply for its entire model** rather than being recorded and skipped — and the recorded failure would have named `TypeError`, which says nothing about the row.

Fixed by giving it the same structured keywords `ForwardDataError` has, deliberately **without** reparenting: several `except ForwardDataError` sites would otherwise start catching query failures.

## Also fixes two tests slice six left red

#298 wired up `netbox_dlm.softwareversion` but did not update `test_empty_comparison_is_not_a_measurement`, which asserts that same model is uncomparable — so the stack was failing the full suite while every targeted run stayed green. They now use `netbox_cisco_aci.acitenant`, plus a third test asserting `softwareversion` **is** measured so the substitution cannot rot silently the same way.

## Scope note — this does not close #206

Every adapter-only model **named** in #206 is now measured. That is not every model. Ten fetched models still report an upper bound:

| model(s) | why |
| --- | --- |
| `netbox_cisco_aci.*` (8) | adapter-only, never in the eight-slice scope — #206 predates the ACI maps |
| `netbox_dlm.inventoryitemsoftware` | deferred in slice six |
| `dcim.virtualchassis` | deliberate |

So `in_sync` is answerable end to end only for a deployment running neither optional plugin. The report states "N of M models" rather than implying whole-estate coverage. ACI is a ninth slice and the largest block of what remains.

## Testing

19 new tests; 52 green across the drift comparison suites; **full suite 2438 green, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)