### PR TITLE
feat: make the uncovered-device bucket enumerable

### DIFF
--- a/docs/03_Plans/active/2026-09-01-uncovered-device-tag.md
+++ b/docs/03_Plans/active/2026-09-01-uncovered-device-tag.md
@@ -1,0 +1,143 @@
+# The `forward-uncovered` device tag
+
+## Goal
+
+Make the "carry no include tag" bucket enumerable. An operator seeing a count
+there must be able to list the devices behind it, the same way the other two
+scope-reconciliation buckets already can be listed.
+
+## Why
+
+A customer reported 552 devices under "carry no include tag" while "out of
+scope (orphans)" read 0, and asked which devices they were. Nothing could
+answer him:
+
+- The panel showed a count and, on the actionable half, a badge linking to
+  `/dcim/devices/?tag_id__n=&q=`. Both parameters are empty, so NetBox ignores
+  them and the link opens the unfiltered device list.
+- `owned_untagged_sample` and `unclaimed_sample` were computed and returned in
+  the payload, and then never rendered. Every other bucket on the page renders
+  its sample; this one did not.
+- The CLI audit is not a fallback: it prints the same payload, so it is capped
+  at the same `SAMPLE_LIMIT = 25`.
+
+The count is also the one that grows, which is why it was the count being
+asked about. A device disabled in Forward vanishes from `network.devices` and
+from the REST inventory alike, so it drops out of the tag-scope result; since
+the absence quarantine landed in 2.8.0 it is deliberately kept rather than
+pruned. It therefore accumulates here, permanently, and part of the growth the
+customer is seeing is the 2.8.0 fix working as designed.
+
+Orphans staying at 0 while this climbs is not a contradiction. An orphan is a
+device this sync PREVIOUSLY CLAIMED and no longer sees, and a claim is released
+on the first run that observes the absence. A device this sync created but never
+held a scope claim for was never an orphan of it.
+
+## Approach
+
+The other two buckets are answerable for exactly one reason: a maintained tag
+is applied to them, so `?tag=forward-backfilled` lists every member. The gap is
+that the third bucket has no such tag, and the empty href is the symptom rather
+than the defect. So close it the same way instead of a new way.
+
+`forward-uncovered` is maintained by `tag_backfilled_devices()` alongside the
+other two, from `report["_owned_untagged"]`.
+
+Deliberately NOT applied to the `unclaimed` half. A device this sync never
+created is not this sync's to label. That is enforced rather than trusted: an
+unclaimed device holds no `ForwardDeviceIdentity`, so it resolves as `missing`
+and is skipped by the claim machinery on its own.
+
+## Touched Surfaces
+
+- `forward_netbox/models.py` - `UNCOVERED` on BOTH `ClaimType` enums
+  (`ForwardDeviceTagClaim` and `ForwardManagedDeviceTag`).
+- `forward_netbox/utilities/ownership.py` - `STATUS_CLAIM_TYPES` and
+  `_NEGATIVE_STATUS_CLAIM_TYPES`, replacing three inline literal pairs.
+- `forward_netbox/utilities/scope_reconciliation.py` - the tag constants, the
+  `_owned_untagged` name set, and the third `_apply_maintained_device_tag` call.
+- `forward_netbox/utilities/tag_contracts.py` - reserve the new slug.
+- `forward_netbox/views.py` + the scope-reconciliation template - the working
+  link and the two sample cards.
+
+No migration. Django 6.0 does not treat a `choices` change as schema state;
+`makemigrations --check` exits 0 against these edits.
+
+## Constraints
+
+- The tag says a device is not covered BY THIS SYNC. It must never be published
+  as a deployment-wide verdict, so it carries the same cross-sync subtraction
+  `out_of_scope` does.
+- It is not a delete gate. Nothing prunes on this tag, and the absence
+  quarantine remains the only thing that authorizes a deletion.
+- `Tag.description` is 200 characters, and the write raises rather than
+  truncating.
+
+## Validation
+
+- `forward_netbox/tests/test_uncovered_device_tag.py` - 13 tests: what the tag
+  is for, the not-an-orphan shape the customer actually has, both directions of
+  idempotency, the unclaimed exclusion, the backfilled non-overlap, the
+  cross-sync subtraction, and the four contracts a fourth status tag would have
+  to satisfy.
+- Adjacent suites: `test_ownership`, `test_scope_module_ui`,
+  `test_device_scope_reconciliation_audit_command`, `test_ownership_migration`,
+  `test_reserved_status_tag_adoption`, `test_ownership_conflict_reason`,
+  `test_health`.
+- Full Django suite.
+
+## Rollback
+
+Revert. The tag stops being maintained and any assignments it left behind are
+inert - no other code reads it, and the panel counts are computed from the
+Forward result, not from the tag.
+
+## Decision Log
+
+- **A tag, not a filter parameter.** The badge could have carried an explicit
+  `?id=` list, but at 552 devices that is a 5 KB URL that goes stale the moment
+  the next reconciliation runs. The tag is recomputed by the same job that
+  computes the count, so the link and the number can never disagree.
+
+- **`owned_untagged` only.** Tagging the whole bucket would have matched the
+  552 the customer quoted, which is superficially what he asked for. It would
+  also have this sync asserting something about devices another source owns.
+  The split already exists precisely because the two halves need different
+  treatment; collapsing it to make one number match would undo that.
+
+- **The claim types are named, not derived.** `_NEGATIVE_STATUS_CLAIM_TYPES` is
+  an explicit tuple rather than "every status type except backfilled". Getting
+  the membership wrong is silent in both directions - a missing type means the
+  tag is never applied, an extra one means it lands on devices that are fine -
+  so the set is spelled out and pinned by a test.
+
+- **Both `ClaimType` enums.** There are two, on two models, and only one of them
+  is the claim table. Adding to one and not the other leaves the managed-tag
+  registry unable to represent the tag it is asked to materialize. A test now
+  pins them equal.
+
+- **Resolving these names can retire a stale identity binding, and that is
+  correct.** `reconcile_source_device_tag_claims` resolves by device NAME, and
+  an owned-untagged device may hold an identity under a different Forward key -
+  the rename case. The retirement only fires when the bound key is absent from
+  `live_source_keys`, i.e. when Forward no longer reports that name anywhere. A
+  device merely renamed in NetBox while Forward still reports the old key is
+  held instead, because the key is still live. So the new call site cannot
+  retire a binding that is still in use; it can only finish a retirement the
+  rename path already intended.
+
+- **No health signal in this change.** "It keeps growing" is the customer's
+  actual complaint, and `_out_of_scope_summary` shows how a trend signal on this
+  count would be built. It is a separate change: this one makes the bucket
+  answerable, and a warning about a number nobody could enumerate would have
+  been the wrong order to do it in.
+
+## Limits
+
+- The `unclaimed` half stays un-enumerable beyond its 25-name sample. That is
+  intentional - it is not this sync's data - but it means an operator whose
+  count is mostly unclaimed still cannot list it from this page.
+- The tag reflects the most recent reconciliation run, not live Forward state.
+  A device re-enabled in Forward keeps the tag until the next run.
+- Nothing back-fills the tag onto devices whose absence predates this change
+  until the next reconciliation runs.

--- a/forward_netbox/jobs.py
+++ b/forward_netbox/jobs.py
@@ -1033,7 +1033,9 @@ def _run_forward_config_backup_work(job, *args, **kwargs):
 
 
 def _reconcile_forward_device_scope_tags_work(job, *args, **kwargs):
-    """Background sync of the ``forward-backfilled`` tag for a sync.
+    """Background sync of the maintained device status tags for a sync.
+
+    ``forward-backfilled``, ``forward-out-of-scope`` and ``forward-uncovered``.
 
     Runs as a job because it issues a live Forward scope query and may tag/untag
     many devices (with change-logging signals), which can exceed an HTTP gateway

--- a/forward_netbox/models.py
+++ b/forward_netbox/models.py
@@ -1356,6 +1356,7 @@ class ForwardManagedDeviceTag(ForwardPluginModelDocsMixin, models.Model):
         SCOPE = "scope", _("Managed scope")
         BACKFILLED = "backfilled", _("Backfilled status")
         OUT_OF_SCOPE = "out_of_scope", _("Out-of-scope status")
+        UNCOVERED = "uncovered", _("Uncovered status")
 
     tag = models.ForeignKey(
         "extras.Tag",
@@ -1530,6 +1531,7 @@ class ForwardDeviceTagClaim(
         SCOPE = "scope", _("Managed scope")
         BACKFILLED = "backfilled", _("Backfilled status")
         OUT_OF_SCOPE = "out_of_scope", _("Out-of-scope status")
+        UNCOVERED = "uncovered", _("Uncovered status")
 
     sync = models.ForeignKey(
         ForwardSync,

--- a/forward_netbox/templates/forward_netbox/forwardsync_scope_reconciliation.html
+++ b/forward_netbox/templates/forward_netbox/forwardsync_scope_reconciliation.html
@@ -104,7 +104,7 @@
             <td>
               {{ payload.unmanaged.untagged_total }}
               {% if payload.unmanaged.owned_untagged %}
-                <a href="{% url 'dcim:device_list' %}?tag_id__n=&amp;q=" class="badge text-bg-warning text-decoration-none">{% blocktrans with count=payload.unmanaged.owned_untagged %}{{ count }} created by this sync{% endblocktrans %}</a>
+                <a href="{{ uncovered_tag_url }}" class="badge text-bg-warning text-decoration-none">{% blocktrans with count=payload.unmanaged.owned_untagged %}{{ count }} created by this sync{% endblocktrans %}</a>
               {% endif %}
               {% if payload.unmanaged.unclaimed %}
                 <span class="badge text-bg-secondary">{% blocktrans with count=payload.unmanaged.unclaimed %}{{ count }} not claimed by this sync{% endblocktrans %}</span>
@@ -373,4 +373,45 @@
     </div>
   </div>
 </div>
+{% if payload.unmanaged.untagged_total %}
+<div class="row mt-3">
+  <div class="col col-md-6">
+    <div class="card">
+      <h5 class="card-header">{% trans "Uncovered, Created by This Sync" %}</h5>
+      <div class="card-body">
+        {% if payload.unmanaged.owned_untagged_sample %}
+          <p class="text-muted mt-0">{% trans "This sync created these devices, and the current Forward result no longer covers them. A device disabled in Forward looks exactly like this, so they are kept, not pruned — which is why this count grows. Use the tag to list all of them, not just this sample." %}</p>
+          <p><a href="{{ uncovered_tag_url }}" class="btn btn-sm btn-outline-warning"><i class="mdi mdi-tag-outline" aria-hidden="true"></i>&nbsp;{% blocktrans with count=payload.unmanaged.owned_untagged %}List all {{ count }}{% endblocktrans %}</a></p>
+          <ul class="mb-0">
+            {% for name in payload.unmanaged.owned_untagged_sample %}<li><code>{{ name }}</code></li>{% endfor %}
+          </ul>
+          {% if payload.unmanaged.owned_untagged > payload.unmanaged.owned_untagged_sample|length %}
+            <p class="text-muted mt-2 mb-0">{% blocktrans with shown=payload.unmanaged.owned_untagged_sample|length total=payload.unmanaged.owned_untagged %}Showing {{ shown }} of {{ total }}.{% endblocktrans %}</p>
+          {% endif %}
+        {% else %}
+          <p class="text-muted mb-0">{% trans "Every device this sync created is covered by the current Forward result." %}</p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  <div class="col col-md-6">
+    <div class="card">
+      <h5 class="card-header">{% trans "Uncovered, Not Claimed by This Sync" %}</h5>
+      <div class="card-body">
+        {% if payload.unmanaged.unclaimed_sample %}
+          <p class="text-muted mt-0">{% trans "Devices this sync never created: another source, an operator, or an old SNMP endpoint import. Listed so the count above can be accounted for — this sync makes no claim about them, tags none of them, and never prunes them." %}</p>
+          <ul class="mb-0">
+            {% for name in payload.unmanaged.unclaimed_sample %}<li><code>{{ name }}</code></li>{% endfor %}
+          </ul>
+          {% if payload.unmanaged.unclaimed > payload.unmanaged.unclaimed_sample|length %}
+            <p class="text-muted mt-2 mb-0">{% blocktrans with shown=payload.unmanaged.unclaimed_sample|length total=payload.unmanaged.unclaimed %}Showing {{ shown }} of {{ total }}.{% endblocktrans %}</p>
+          {% endif %}
+        {% else %}
+          <p class="text-muted mb-0">{% trans "Every uncovered device was created by this sync." %}</p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}
 {% endblock content %}

--- a/forward_netbox/tests/test_uncovered_device_tag.py
+++ b/forward_netbox/tests/test_uncovered_device_tag.py
@@ -1,0 +1,422 @@
+"""The ``forward-uncovered`` tag: the bucket an operator could not enumerate.
+
+A customer reported 552 devices under "carry no include tag" while orphans read
+0, and asked which ones they were. Nothing could answer him. The panel showed a
+count and a 25-name sample, the CLI audit prints that same truncated sample, and
+the one badge that looked like a filter linked to `?tag_id__n=&q=` - both
+parameters empty, so it opened the unfiltered device list.
+
+The other two buckets have always been answerable, and for one reason: a
+maintained tag is applied to them, so `?tag=forward-backfilled` lists every one.
+This tag closes the gap the same way rather than a new way.
+
+Only the `owned_untagged` half is tagged. The `unclaimed` half is another
+source's or an operator's, and a device this sync never created is not this
+sync's to label.
+"""
+
+from unittest.mock import Mock
+from unittest.mock import patch
+from uuid import uuid4
+
+from core.choices import JobStatusChoices
+from core.models import Job
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import Manufacturer
+from dcim.models import Site
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.test import Client
+from django.test import TestCase
+from django.urls import reverse
+
+from forward_netbox.choices import ForwardSyncStatusChoices
+from forward_netbox.models import ForwardDeviceIdentity
+from forward_netbox.models import ForwardIngestion
+from forward_netbox.models import ForwardSource
+from forward_netbox.models import ForwardSync
+from forward_netbox.utilities.scope_reconciliation import tag_backfilled_devices
+from forward_netbox.utilities.scope_reconciliation import UNCOVERED_TAG_SLUG
+
+
+class UncoveredDeviceTagTest(TestCase):
+    def setUp(self):
+        self.source = ForwardSource.objects.create(
+            name="unc-src",
+            type="saas",
+            url="https://fwd.app",
+            status="ready",
+            parameters={
+                "username": "u@example.com",
+                "password": "p",
+                "verify": True,
+                "network_id": "net-1",
+                "device_tag_include_tags": ["Prod_Core"],
+                "device_tag_include_match": "any",
+            },
+        )
+        self.sync = ForwardSync.objects.create(
+            name="unc-sync",
+            source=self.source,
+            status=ForwardSyncStatusChoices.COMPLETED,
+            parameters={"snapshot_id": "latestProcessed"},
+        )
+        self.ingestion = ForwardIngestion.objects.create(
+            sync=self.sync,
+            snapshot_id="snap-1",
+            baseline_ready=True,
+        )
+        mfr = Manufacturer.objects.create(name="MfrN", slug="mfr-n")
+        self.dt = DeviceType.objects.create(manufacturer=mfr, model="dt-n", slug="dt-n")
+        self.role = DeviceRole.objects.create(name="RoleN", slug="role-n")
+        self.site = Site.objects.create(name="SiteN", slug="site-n")
+
+    def _device(self, name):
+        return Device.objects.create(
+            name=name, device_type=self.dt, role=self.role, site=self.site
+        )
+
+    def _own(self, device, *, sync=None, key=None):
+        """Record that a sync created this device, without claiming scope.
+
+        Deliberately not via `reconcile_sync_scope_tag_claims`: that also writes
+        a scope claim, which would make the device an ORPHAN once it left the
+        result. The shape being reproduced here is the customer's - orphans 0,
+        uncovered large - and it needs ownership without a surviving claim.
+        """
+        return ForwardDeviceIdentity.objects.create(
+            sync=sync or self.sync,
+            source_device_key=key or device.name,
+            device=device,
+            ingestion_id=self.ingestion.pk,
+            snapshot_id="snap-1",
+        )
+
+    def _run(self, rows):
+        fwd_client = Mock()
+        fwd_client.run_nqe_query = Mock(return_value=rows)
+        with (
+            patch.object(ForwardSource, "get_client", return_value=fwd_client),
+            patch.object(ForwardSync, "resolve_snapshot_id", return_value="snap-1"),
+        ):
+            return tag_backfilled_devices(self.sync)
+
+    def _tagged(self, slug):
+        return set(
+            Device.objects.filter(tags__slug=slug).values_list("name", flat=True)
+        )
+
+    # --- what the tag is for ------------------------------------------------
+
+    def test_a_device_this_sync_created_and_no_longer_covers_is_tagged(self):
+        self._device("dev-covered")
+        self._own(self._device("dev-gone"))
+
+        result = self._run([{"name": "dev-covered", "completed": True}])
+
+        self.assertEqual(self._tagged(UNCOVERED_TAG_SLUG), {"dev-gone"})
+        self.assertEqual(result["total_uncovered"], 1)
+
+    def test_it_is_applied_even_though_the_device_is_not_an_orphan(self):
+        """The customer's exact shape, and the whole reason this tag exists.
+
+        An orphan is a device this sync PREVIOUSLY CLAIMED and no longer sees.
+        A device it created but never held a scope claim for is not an orphan of
+        it, so `forward-out-of-scope` reads zero - and before this tag there was
+        nothing else to filter on.
+        """
+        self._device("dev-covered")
+        self._own(self._device("dev-gone"))
+
+        self._run([{"name": "dev-covered", "completed": True}])
+
+        self.assertEqual(self._tagged("forward-out-of-scope"), set())
+        self.assertEqual(self._tagged(UNCOVERED_TAG_SLUG), {"dev-gone"})
+
+    def test_a_device_this_sync_never_created_is_not_tagged(self):
+        self._device("dev-covered")
+        self._device("someone-elses")
+
+        self._run([{"name": "dev-covered", "completed": True}])
+
+        self.assertEqual(self._tagged(UNCOVERED_TAG_SLUG), set())
+
+    def test_a_covered_device_is_not_tagged(self):
+        self._own(self._device("dev-covered"))
+
+        self._run([{"name": "dev-covered", "completed": True}])
+
+        self.assertEqual(self._tagged(UNCOVERED_TAG_SLUG), set())
+
+    def test_the_tag_is_removed_when_the_device_returns_to_the_result(self):
+        """A device disabled in Forward is the common case, and it comes back.
+
+        The tag has to follow the bucket in both directions or it becomes a
+        permanent mark on devices that are fine - the failure mode the count it
+        replaces already had.
+        """
+        self._device("dev-covered")
+        self._own(self._device("dev-gone"))
+
+        self._run([{"name": "dev-covered", "completed": True}])
+        self.assertEqual(self._tagged(UNCOVERED_TAG_SLUG), {"dev-gone"})
+
+        result = self._run(
+            [
+                {"name": "dev-covered", "completed": True},
+                {"name": "dev-gone", "completed": True},
+            ]
+        )
+
+        self.assertEqual(self._tagged(UNCOVERED_TAG_SLUG), set())
+        self.assertEqual(result["total_uncovered"], 0)
+
+    def test_a_backfilled_device_is_not_uncovered(self):
+        """Backfilled is the opposite assertion and must not overlap.
+
+        `forward-backfilled` says the device IS in scope but was not freshly
+        collected. It is still in the tag-scope result, so it is covered.
+        """
+        self._own(self._device("dev-backfilled"))
+
+        self._run([{"name": "dev-backfilled", "completed": False}])
+
+        self.assertEqual(self._tagged("forward-backfilled"), {"dev-backfilled"})
+        self.assertEqual(self._tagged(UNCOVERED_TAG_SLUG), set())
+
+    # --- the cross-sync rule ------------------------------------------------
+
+    def test_a_device_another_sync_still_scopes_is_not_desired(self):
+        """A per-sync absence must never be published as a global verdict.
+
+        `uncovered` is a negative status tag, so it carries the same rule as
+        `out_of_scope`: subtract every positive scope claim, whoever holds it.
+        Without this the tag lands on devices another source is actively
+        managing, and says something false about them.
+        """
+        from forward_netbox.models import ForwardDeviceTagClaim
+        from forward_netbox.utilities.ownership import _desired_tag_device_ids
+        from forward_netbox.utilities.scope_reconciliation import (
+            UNCOVERED_TAG_NAME,
+        )
+        from extras.models import Tag
+
+        device = self._device("dev-shared")
+        other_source = ForwardSource.objects.create(
+            name="other-src",
+            type="saas",
+            url="https://fwd.app",
+            status="ready",
+            parameters={**self.source.parameters},
+        )
+        other_sync = ForwardSync.objects.create(
+            name="other-sync",
+            source=other_source,
+            parameters={"snapshot_id": "latestProcessed"},
+        )
+        uncovered_tag = Tag.objects.create(
+            slug=UNCOVERED_TAG_SLUG, name=UNCOVERED_TAG_NAME
+        )
+        scope_tag = Tag.objects.create(slug="prod-core", name="Prod_Core")
+        ForwardDeviceTagClaim.objects.create(
+            sync=self.sync,
+            device=device,
+            tag=uncovered_tag,
+            claim_type="uncovered",
+            ingestion_id=self.ingestion.pk,
+            snapshot_id="snap-1",
+        )
+
+        self.assertEqual(
+            _desired_tag_device_ids(uncovered_tag.pk, "uncovered"), {device.pk}
+        )
+
+        other_ingestion = ForwardIngestion.objects.create(
+            sync=other_sync, snapshot_id="snap-1", baseline_ready=True
+        )
+        ForwardDeviceTagClaim.objects.create(
+            sync=other_sync,
+            device=device,
+            tag=scope_tag,
+            claim_type="scope",
+            ingestion_id=other_ingestion.pk,
+            snapshot_id="snap-1",
+        )
+
+        self.assertEqual(_desired_tag_device_ids(uncovered_tag.pk, "uncovered"), set())
+
+
+class MaintainedStatusTagContractTest(TestCase):
+    """Pins the lists a fourth status tag would have to be added to.
+
+    Each of these was a literal pair spelled inline, and a claim type missing
+    from any one of them fails silently: the claims accumulate correctly and the
+    tag is simply never applied to anything.
+    """
+
+    def test_status_claim_types_cover_every_non_scope_claim_type(self):
+        from forward_netbox.models import ForwardDeviceTagClaim
+        from forward_netbox.utilities.ownership import STATUS_CLAIM_TYPES
+
+        self.assertEqual(
+            set(STATUS_CLAIM_TYPES),
+            {
+                value
+                for value, _label in ForwardDeviceTagClaim.ClaimType.choices
+                if value != "scope"
+            },
+        )
+
+    def test_both_claim_type_enums_agree(self):
+        from forward_netbox.models import ForwardDeviceTagClaim
+        from forward_netbox.models import ForwardManagedDeviceTag
+
+        self.assertEqual(
+            set(ForwardDeviceTagClaim.ClaimType.values),
+            set(ForwardManagedDeviceTag.ClaimType.values),
+        )
+
+    def test_every_maintained_tag_description_fits_the_column(self):
+        """`Tag.description` is 200 characters and the write is not truncated.
+
+        A longer one raises `DataError` at tag-creation time, which is the FIRST
+        run on a deployment that has never had this bucket - so the failure
+        lands on a customer, not here. Caught exactly this way.
+        """
+        from extras.models import Tag
+        from forward_netbox.utilities.scope_reconciliation import (
+            BACKFILLED_TAG_DESCRIPTION,
+        )
+        from forward_netbox.utilities.scope_reconciliation import (
+            OUT_OF_SCOPE_TAG_DESCRIPTION,
+        )
+        from forward_netbox.utilities.scope_reconciliation import (
+            UNCOVERED_TAG_DESCRIPTION,
+        )
+
+        limit = Tag._meta.get_field("description").max_length
+        for description in (
+            BACKFILLED_TAG_DESCRIPTION,
+            OUT_OF_SCOPE_TAG_DESCRIPTION,
+            UNCOVERED_TAG_DESCRIPTION,
+        ):
+            self.assertLessEqual(len(description), limit, description)
+
+    def test_every_maintained_status_slug_is_reserved(self):
+        """An include tag normalizing onto a status slug is refused up front.
+
+        The managed-tag registry allows a slug exactly one claim type, so the
+        collision would otherwise surface as an `OwnershipConflictError` on
+        every run, with no remedy but renaming the tag in Forward.
+        """
+        from forward_netbox.utilities.scope_reconciliation import BACKFILLED_TAG_SLUG
+        from forward_netbox.utilities.scope_reconciliation import OUT_OF_SCOPE_TAG_SLUG
+        from forward_netbox.utilities.tag_contracts import RESERVED_STATUS_TAG_SLUGS
+
+        self.assertEqual(
+            RESERVED_STATUS_TAG_SLUGS,
+            frozenset({BACKFILLED_TAG_SLUG, OUT_OF_SCOPE_TAG_SLUG, UNCOVERED_TAG_SLUG}),
+        )
+
+
+class UncoveredPanelTest(TestCase):
+    """The panel defects the tag was added to fix."""
+
+    def setUp(self):
+        self.source = ForwardSource.objects.create(
+            name="panel-src",
+            type="saas",
+            url="https://fwd.app",
+            status="ready",
+            parameters={
+                "username": "u@example.com",
+                "password": "p",
+                "verify": True,
+                "network_id": "net-1",
+                "device_tag_include_tags": ["Prod_Core"],
+                "device_tag_include_match": "any",
+            },
+        )
+        self.sync = ForwardSync.objects.create(
+            name="panel-sync",
+            source=self.source,
+            status=ForwardSyncStatusChoices.COMPLETED,
+            parameters={"snapshot_id": "latestProcessed"},
+        )
+        self.ingestion = ForwardIngestion.objects.create(
+            sync=self.sync, snapshot_id="snap-1", baseline_ready=True
+        )
+        mfr = Manufacturer.objects.create(name="MfrP", slug="mfr-p")
+        self.dt = DeviceType.objects.create(manufacturer=mfr, model="dt-p", slug="dt-p")
+        self.role = DeviceRole.objects.create(name="RoleP", slug="role-p")
+        self.site = Site.objects.create(name="SiteP", slug="site-p")
+
+    def _render(self):
+        device = Device.objects.create(
+            name="dev-uncovered", device_type=self.dt, role=self.role, site=self.site
+        )
+        ForwardDeviceIdentity.objects.create(
+            sync=self.sync,
+            source_device_key="dev-uncovered",
+            device=device,
+            ingestion_id=self.ingestion.pk,
+            snapshot_id="snap-1",
+        )
+        Device.objects.create(
+            name="dev-unclaimed", device_type=self.dt, role=self.role, site=self.site
+        )
+        fwd_client = Mock()
+        fwd_client.run_nqe_query = Mock(return_value=[])
+        user = get_user_model().objects.create_user(username="admin-unc", password="x")
+        user.is_superuser = True
+        user.is_staff = True
+        user.save()
+        client = Client()
+        client.force_login(user)
+        with (
+            patch.object(ForwardSource, "get_client", return_value=fwd_client),
+            patch.object(ForwardSync, "resolve_snapshot_id", return_value="snap-1"),
+        ):
+            from forward_netbox.jobs import _scope_reconciliation_work
+
+            job = Job.objects.create(
+                object_type=ContentType.objects.get_for_model(ForwardSync),
+                object_id=self.sync.pk,
+                name=f"{self.sync.name} - scope reconciliation",
+                status=JobStatusChoices.STATUS_COMPLETED,
+                job_id=uuid4(),
+            )
+            _scope_reconciliation_work(job)
+            return client.get(
+                reverse(
+                    "plugins:forward_netbox:forwardsync_scope_reconciliation",
+                    kwargs={"pk": self.sync.pk},
+                )
+            )
+
+    def test_the_badge_links_to_a_real_filter(self):
+        """THE defect. The href had both parameters empty.
+
+        `?tag_id__n=&q=` is not a filter - NetBox ignores empty values - so the
+        one actionable badge on the panel opened the full device list.
+        """
+        response = self._render()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f"?tag={UNCOVERED_TAG_SLUG}")
+        self.assertNotContains(response, "tag_id__n=&amp;q=")
+
+    def test_the_sample_names_are_rendered(self):
+        """They were computed and returned, and then never displayed.
+
+        Every other bucket on this page renders its sample. This one did not,
+        so the split was two bare numbers with no way to see behind them.
+        """
+        response = self._render()
+
+        self.assertContains(response, "dev-uncovered")
+        self.assertContains(response, "dev-unclaimed")
+        self.assertContains(response, "Uncovered, Created by This Sync")
+        self.assertContains(response, "Uncovered, Not Claimed by This Sync")

--- a/forward_netbox/utilities/ownership.py
+++ b/forward_netbox/utilities/ownership.py
@@ -18,6 +18,27 @@ from .tag_contracts import validate_scope_tag_names
 OWNERSHIP_ADVISORY_LOCK_ID = 0x4657444F574E
 DEVICE_IDENTITY_CANDIDATES_KEY = "device_identity_candidates"
 
+# Every claim type materialized under the STATUS_TAGS domain.
+#
+# This was spelled inline as a literal pair, which is why adding a third status
+# tag is a change to this module at all: a claim type absent from the list is
+# never materialized, so its claims accumulate correctly and its tag is simply
+# never applied to anything - a failure with no error and no symptom except the
+# tag being empty. One name, used everywhere the set is needed.
+#
+# Plain strings rather than the `ClaimType` members: this is module scope, and
+# importing models here would make `utilities.ownership` unimportable before the
+# app registry is ready. The values are pinned to the enum by a test.
+STATUS_CLAIM_TYPES = ("backfilled", "out_of_scope", "uncovered")
+
+# The status tags that assert a device is NOT covered, as opposed to
+# `backfilled`, which asserts a device IS in scope but was not freshly
+# collected. Only the negative ones are cross-sync claims: see
+# `_desired_tag_device_ids` for why they subtract every positive scope claim,
+# and `finalize_device_tag_domain` for why they need a second materialization
+# pass once both domains are ready.
+_NEGATIVE_STATUS_CLAIM_TYPES = ("out_of_scope", "uncovered")
+
 
 class OwnershipConflictError(RuntimeError):
     """Raised after durable claims expose incompatible desired relationships."""
@@ -724,7 +745,18 @@ def _desired_tag_device_ids(
         claim_type=claim_type,
     ).exclude(sync_id__in=excluded_sync_ids)
     desired_ids = set(claims.values_list("device_id", flat=True))
-    if claim_type == ForwardDeviceTagClaim.ClaimType.OUT_OF_SCOPE:
+    # Both negative status tags assert an ABSENCE, and an absence is only ever
+    # true of one sync's result. A device this sync does not cover may be
+    # squarely in another sync's scope, and tagging it there would publish a
+    # contradiction: `forward-out-of-scope` and `forward-uncovered` would sit on
+    # a device that some other source is actively managing. Subtracting every
+    # positive scope claim is what keeps a per-sync observation from reading as
+    # a deployment-wide verdict.
+    #
+    # `uncovered` is here for the same reason `out_of_scope` is, and it is
+    # listed explicitly rather than derived, because getting this wrong is
+    # silent: the tag simply appears on devices that are fine.
+    if claim_type in _NEGATIVE_STATUS_CLAIM_TYPES:
         positively_scoped_ids = set(
             ForwardDeviceTagClaim.objects.filter(claim_type="scope")
             .exclude(sync_id__in=excluded_sync_ids)
@@ -1133,7 +1165,7 @@ def finalize_device_tag_domain(
     claim_types = (
         ["scope"]
         if domain == ForwardOwnershipReconciliation.Domain.SCOPE_TAGS
-        else ["backfilled", "out_of_scope"]
+        else list(STATUS_CLAIM_TYPES)
     )
     managed_tags = ForwardManagedDeviceTag.objects.filter(claim_type__in=claim_types)
     if tag_ids is not None:
@@ -1194,7 +1226,7 @@ def finalize_device_tag_domain(
         and _domain_is_ready(ForwardOwnershipReconciliation.Domain.STATUS_TAGS)
     ):
         for managed_tag in ForwardManagedDeviceTag.objects.filter(
-            claim_type="out_of_scope"
+            claim_type__in=_NEGATIVE_STATUS_CLAIM_TYPES
         ).select_related("tag"):
             result = _materialize_managed_tag(managed_tag, force_current=True)
             added += result["assignments_added"]

--- a/forward_netbox/utilities/scope_reconciliation.py
+++ b/forward_netbox/utilities/scope_reconciliation.py
@@ -90,6 +90,29 @@ OUT_OF_SCOPE_TAG_DESCRIPTION = (
     "Forward sync scope reconciliation."
 )
 
+# NetBox tag applied to devices this sync CREATED that the current Forward
+# result no longer covers - the `owned_untagged` half of "carry no include tag".
+#
+# It exists because that bucket is the only one an operator could not enumerate.
+# The panel showed a count and a 25-name sample, and the count is the one that
+# grows: a device disabled in Forward drops out of the tag-scope result, and
+# since the absence quarantine it is deliberately kept rather than pruned, so it
+# lands here and stays. A customer reading 552 had no way, in the UI or on a
+# shell, to list them - the CLI audit prints the same truncated sample.
+#
+# Deliberately NOT applied to the `unclaimed` half. A device this sync never
+# created is not this sync's to label, and the claim machinery enforces that on
+# its own: an unclaimed device has no `ForwardDeviceIdentity`, so it resolves as
+# `missing` and is skipped.
+UNCOVERED_TAG_SLUG = "forward-uncovered"
+UNCOVERED_TAG_NAME = "Forward Uncovered"
+UNCOVERED_TAG_COLOR = "ff9800"
+UNCOVERED_TAG_DESCRIPTION = (
+    "Created by this sync but absent from the current Forward tag-scope "
+    "result. Not an orphan, and never pruned on this tag alone. Maintained by "
+    "the Forward sync scope reconciliation."
+)
+
 
 # How long an absence must persist before the prune is allowed to believe it.
 #
@@ -405,7 +428,7 @@ def compute_scope_reconciliation(sync, *, snapshot_id=None) -> dict:
         device_id for device_id, name in previously_managed if name in out_of_scope
     ]
 
-    unmanaged = _unmanaged_device_summary(sync, tagged_names)
+    unmanaged, owned_untagged_names = _unmanaged_device_summary(sync, tagged_names)
 
     absence = _classify_out_of_scope_absence(
         out_of_scope,
@@ -498,6 +521,7 @@ def compute_scope_reconciliation(sync, *, snapshot_id=None) -> dict:
         "_device_tagged_names": device_tagged_names,
         "_forward_site_slugs": forward_site_slugs,
         "_out_of_scope": out_of_scope,
+        "_owned_untagged": owned_untagged_names,
         "_out_of_scope_pks": out_of_scope_pks,
         "_present_backfilled": present_backfilled,
         "_matched_include_tags_by_name": present_scope_tags_by_name,
@@ -525,6 +549,11 @@ def _unmanaged_device_summary(sync, tagged_names):
     Deliberately read-only, local, and free: no Forward call, no deletion, and
     no inference about which of the two an operator should care about. The
     counts and the filters are the product; the judgement stays with them.
+
+    Returns ``(summary, owned_names)``. The summary is JSON-safe and carries
+    only counts and truncated samples; the full owned name set is handed back
+    separately because it is what the ``forward-uncovered`` tag is maintained
+    from, and it must not reach a persisted diagnostic.
     """
     from ..models import ForwardDeviceIdentity
 
@@ -540,7 +569,7 @@ def _unmanaged_device_summary(sync, tagged_names):
             "unclaimed": 0,
             "owned_untagged_sample": [],
             "unclaimed_sample": [],
-        }
+        }, set()
     owned_ids = set(
         ForwardDeviceIdentity.objects.filter(
             sync=sync,
@@ -557,7 +586,7 @@ def _unmanaged_device_summary(sync, tagged_names):
         "unclaimed": len(unclaimed),
         "owned_untagged_sample": owned[:SAMPLE_LIMIT],
         "unclaimed_sample": unclaimed[:SAMPLE_LIMIT],
-    }
+    }, set(owned)
 
 
 def _classify_out_of_scope_absence(
@@ -1107,15 +1136,21 @@ def tag_backfilled_devices(
     snapshot_id=None,
     ingestion_id=None,
 ) -> dict:
-    """Maintain the ``forward-backfilled`` and ``forward-out-of-scope`` device tags.
+    """Maintain the three maintained device status tags.
 
     ``forward-backfilled`` marks devices that are tagged-in-scope but were not
     freshly collected in the latest snapshot (kept on purpose).
     ``forward-out-of-scope`` marks NetBox devices that match none of the sync's
-    included Forward tags (the removable orphans). Both are idempotent — after
-    running, each tag's device set exactly matches the current bucket, so operators
-    can filter ``/dcim/devices/?tag=forward-backfilled`` or
-    ``?tag=forward-out-of-scope``.
+    included Forward tags AND were previously claimed by it (the removable
+    orphans). ``forward-uncovered`` marks devices this sync created that the
+    current result no longer covers, whether or not a claim survives - the
+    bucket the panel counts as "created by this sync" under "carry no include
+    tag", and the one that grows.
+
+    All three are idempotent — after running, each tag's device set exactly
+    matches the current bucket, so operators can filter
+    ``/dcim/devices/?tag=forward-backfilled``, ``?tag=forward-out-of-scope`` or
+    ``?tag=forward-uncovered``.
     """
     if report is None:
         report = compute_scope_reconciliation(sync, snapshot_id=snapshot_id)
@@ -1155,6 +1190,24 @@ def tag_backfilled_devices(
             color=OUT_OF_SCOPE_TAG_COLOR,
             description=OUT_OF_SCOPE_TAG_DESCRIPTION,
             claim_type="out_of_scope",
+            generation=generation["generation"],
+            snapshot_id=generation["snapshot_id"],
+            mark_domain=False,
+            materialize=False,
+            live_source_keys=live_source_keys,
+        )
+        # `owned_untagged`, not the whole "carry no include tag" bucket: the
+        # unclaimed half is another source's or an operator's, and this sync has
+        # no standing to label it. That is enforced rather than trusted - an
+        # unclaimed device has no identity row, so it resolves as `missing`.
+        uncovered = _apply_maintained_device_tag(
+            sync,
+            report["_owned_untagged"],
+            slug=UNCOVERED_TAG_SLUG,
+            name=UNCOVERED_TAG_NAME,
+            color=UNCOVERED_TAG_COLOR,
+            description=UNCOVERED_TAG_DESCRIPTION,
+            claim_type="uncovered",
             generation=generation["generation"],
             snapshot_id=generation["snapshot_id"],
             mark_domain=False,
@@ -1233,6 +1286,16 @@ def tag_backfilled_devices(
         "out_of_scope_claims_added": out_of_scope["claims_added"],
         "out_of_scope_claims_released": out_of_scope["claims_released"],
         "total_out_of_scope": out_of_scope["total"],
+        "uncovered_tag_slug": UNCOVERED_TAG_SLUG,
+        "uncovered_tagged": status_materialized["by_claim_type"]
+        .get("uncovered", {})
+        .get("assignments_added", 0),
+        "uncovered_untagged": status_materialized["by_claim_type"]
+        .get("uncovered", {})
+        .get("assignments_removed", 0),
+        "uncovered_claims_added": uncovered["claims_added"],
+        "uncovered_claims_released": uncovered["claims_released"],
+        "total_uncovered": uncovered["total"],
         "scope_claims_released": managed_scope_cleanup["claims_released"],
         "out_of_scope_scope_tags_removed": managed_scope_cleanup["assignments_removed"],
         "scope_claims_added": managed_scope_cleanup["claims_added"],

--- a/forward_netbox/utilities/tag_contracts.py
+++ b/forward_netbox/utilities/tag_contracts.py
@@ -2,10 +2,20 @@ from django.core.exceptions import ValidationError
 from django.utils.text import slugify
 
 
+# Every slug the plugin maintains as a status tag. An include tag that
+# normalizes onto one of these is refused at configuration time, because the
+# managed-tag registry allows a slug exactly one claim type: the collision would
+# otherwise surface much later as an `OwnershipConflictError` on every run, with
+# no remedy short of renaming the Forward tag.
+#
+# Kept in lockstep with `scope_reconciliation`'s three `*_TAG_SLUG` constants;
+# a test pins them equal so a fourth status tag cannot be added without being
+# reserved here too.
 RESERVED_STATUS_TAG_SLUGS = frozenset(
     {
         "forward-backfilled",
         "forward-out-of-scope",
+        "forward-uncovered",
     }
 )
 

--- a/forward_netbox/views.py
+++ b/forward_netbox/views.py
@@ -1354,8 +1354,11 @@ class ForwardSyncScopeReconciliationView(BaseObjectView):
         report_job = _latest_scope_reconciliation_job(sync)
         payload, generated_at, report_error = _scope_reconciliation_payload(report_job)
         from .utilities.scope_reconciliation import BACKFILLED_TAG_SLUG
+        from .utilities.scope_reconciliation import UNCOVERED_TAG_SLUG
 
-        backfilled_tag_url = f"{reverse('dcim:device_list')}?tag={BACKFILLED_TAG_SLUG}"
+        device_list_url = reverse("dcim:device_list")
+        backfilled_tag_url = f"{device_list_url}?tag={BACKFILLED_TAG_SLUG}"
+        uncovered_tag_url = f"{device_list_url}?tag={UNCOVERED_TAG_SLUG}"
         return render(
             request,
             self.template_name,
@@ -1373,6 +1376,7 @@ class ForwardSyncScopeReconciliationView(BaseObjectView):
                     include_samples=True
                 ),
                 "backfilled_tag_url": backfilled_tag_url,
+                "uncovered_tag_url": uncovered_tag_url,
                 "tag_backfilled_url": reverse(
                     "plugins:forward_netbox:forwardsync_tag_backfilled",
                     kwargs={"pk": sync.pk},


### PR DESCRIPTION
## The report

A customer sees 552 devices under **"carry no include tag"** while **"out of scope (orphans)"** reads 0, and asked which devices they are. Nothing could answer him.

Backfilled (49) and uncovered (552) are different populations and neither contradicts the other — backfilled means Forward *has* the device but could not collect it, and those are in scope and kept. But the number he is actually looking at was the one with no way to inspect it.

## Why it could not be answered

The other two buckets are answerable for exactly one reason: a maintained tag is applied to them, so `?tag=forward-backfilled` lists every member. The third bucket has no such tag.

- The badge that looked like a filter linked to `/dcim/devices/?tag_id__n=&q=`. Both parameters are empty, so NetBox ignores them and it opens the **unfiltered** device list. The empty href was the symptom; the missing tag was the defect.
- `owned_untagged_sample` / `unclaimed_sample` were computed and returned in the payload, then **never rendered** — every other bucket on the page renders its sample.
- The CLI is not a fallback: `forward_device_scope_reconciliation_audit` prints the same payload, so it caps at the same `SAMPLE_LIMIT = 25`.

## What this does

Maintains `forward-uncovered` alongside the other two status tags, from `report["_owned_untagged"]`, and renders both sample cards.

**Only the `owned_untagged` half is tagged.** Tagging the whole 552 would have matched the number he quoted, and would also have this sync asserting something about devices another source owns. That is enforced rather than trusted: an unclaimed device holds no `ForwardDeviceIdentity`, so it resolves as `missing` and is skipped.

## Four sites moved together — three fail silently

| Site | Failure mode if missed |
|---|---|
| **Both** `ClaimType` enums (`ForwardDeviceTagClaim`, `ForwardManagedDeviceTag`) | registry cannot represent the tag it is asked to materialize |
| `finalize_device_tag_domain` status claim types | claims accumulate correctly, tag is **never applied**, no error |
| `_desired_tag_device_ids` positive-scope subtraction | tag lands on devices another sync actively manages |
| `RESERVED_STATUS_TAG_SLUGS` | `OwnershipConflictError` every run, forever, no remedy but renaming the Forward tag |

The last two were inline literal pairs; they are now `STATUS_CLAIM_TYPES` and `_NEGATIVE_STATUS_CLAIM_TYPES`, pinned to the enum by a test.

## No migration

Django 6.0 does not treat a `choices` change as schema state. `makemigrations --check` exits 0 against these edits.

## Bug caught in review

The tag description was 249 characters; `Tag.description` is 200 and **raises rather than truncating**. It raises at tag-*creation* time — the first run on any deployment that has this bucket — so it would have landed on a customer. Shortened, and a test now pins all three descriptions under the column width.

## Validation

- `test_uncovered_device_tag.py` — 13 tests: the not-an-orphan shape the customer actually has, both directions of idempotency, the unclaimed exclusion, backfilled non-overlap, the cross-sync subtraction, and the four contracts a fourth status tag would have to satisfy.
- Adjacent suites (156): `test_ownership`, `test_scope_module_ui`, `test_device_scope_reconciliation_audit_command`, `test_ownership_migration`, `test_reserved_status_tag_adoption`, `test_ownership_conflict_reason`, `test_health`.
- **Full suite: `Ran 2324 tests` / `OK (skipped=4)` / `EXIT=0`.**
- `pre-commit`, `invoke harness-check`, `invoke harness-test` (334) all pass.

## Limits

- This makes the growth **inspectable**, it does not stop it. A device disabled in Forward drops out of the tag-scope result and, since 2.8.0, is quarantined rather than pruned — so it accumulates here by design.
- The `unclaimed` half stays un-enumerable beyond its 25-name sample. Intentional (it is not this sync's data), but an operator whose count is mostly unclaimed still cannot list it here.
- The tag reflects the last reconciliation run, not live Forward state, and nothing back-fills it onto existing absences until the next run.
- No health/trend signal for this count. "It keeps growing" is the customer's actual complaint and `_out_of_scope_summary` shows how that would be built — deliberately a separate change, since warning about a number nobody could enumerate would be the wrong order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa