### PR TITLE
chore: a release is one invocation, with no hand steps after the tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,11 @@ dmypy.json
 # Local-only sensitive content denylist
 .sensitive-patterns.local.txt
 
+# What `scripts/release.py` verify ran, and its gate logs: the source the
+# authorization is rendered from. Names this host's port and log paths.
+.release-evidence.json
+.release-evidence-logs/
+
 # Browser harness artifacts
 node_modules/
 playwright-report/

--- a/docs/03_Plans/active/2026-08-18-no-dev0-on-main.md
+++ b/docs/03_Plans/active/2026-08-18-no-dev0-on-main.md
@@ -68,8 +68,11 @@ Revert. `main` returns to advertising a version that does not exist.
 
 ## Open
 
-- The `.dev0` contradiction itself. Either `--open-next` goes, or the rule
-  does, and neither should be decided as a side effect of a release.
+- ~~The `.dev0` contradiction itself.~~ **Decided 2026-09-02, in
+  `2026-09-02-release-tooling.md`:** the rule stays and `--open-next` is gone.
+  `main` carries the released version; a dev marker offered source installs a
+  version that was never gated, tagged or published, and the window it
+  described is minutes wide and now crossed by `--auto-finish` in one run.
 - The bridge commit that carried these edits is no longer documentation-only,
   which makes it unusable as `PRIOR_POST_RELEASE_DOC_COMMIT`. Reverting the
   content here does not fix that: the verifier diffs the release tag against

--- a/docs/03_Plans/active/2026-09-02-release-tooling.md
+++ b/docs/03_Plans/active/2026-09-02-release-tooling.md
@@ -1,0 +1,134 @@
+# Release tooling for 2.9.2: one invocation, no hand steps
+
+## Goal
+
+A release is one `scripts/release.py <version> --summary ... --write --publish
+--auto-finish` invocation that ends with the tag published, the bridge merged
+and the anchor advanced - and every step it takes is also a flag, so a failure
+names where to resume.
+
+## Why
+
+Every release since 2.7.13 has needed hand work after the tag, and every one
+of them has recorded the same open items:
+
+- The `.dev0` contradiction, undecided in six plans.
+- `--finish` committing `release: promote` on the release branch before the
+  tag, which the harness refuses by construction (the anchor must name the
+  release the table calls current, and cannot move until the bridge exists,
+  which cannot exist until the tag does) - and a second copy of that commit
+  stranded on local `main`.
+- The bridge SHA, the anchor constants and the table promotion all edited by
+  hand, from a printed instruction.
+- The Release Authorization section typed from memory, including the test
+  counts.
+- The sensitive-content pre-tag review covering one of the four surfaces the
+  gate reads.
+- `requirements-release.txt` audited by nothing; `poetry.lock` read by nothing.
+- `ui-validation` evidence required naming two variables the Playwright task
+  never reads.
+- The installed-route probe covering menu lists only.
+
+Three items the survey listed as open were already closed on `main` and are
+recorded here so they are not re-opened: `_github_json`'s bounded retry and
+keep-alive connection, skipped preflight checks printing `skipped`, and the
+release command refusing to report a published release as failed.
+
+## Constraints
+
+- `verify_release_provenance.py` is the trusted scanner and is not edited by
+  this change; `release.py` mirrors its documentation-path rule rather than
+  importing it.
+- Nothing here changes what the gate runs. `verify` runs the same `invoke ci`
+  and `invoke artifact-test`; it now also keeps their output.
+- The authorization checker is not relaxed to accept the rendered section.
+  The renderer is tested against the checker's own predicate.
+- No Django suite: `invoke harness-test` covers all of it.
+
+## Touched Surfaces
+
+- `scripts/release.py` - `stage_open_next` and `--open-next` removed;
+  `stage_verify` records evidence (`.release-evidence.json`, gitignored) with
+  logged gate output; `promote_release_tables` is a file edit; `stage_finish`
+  on the production branch no longer promotes; `stage_authorize`,
+  `stage_anchor`, `stage_finish_unattended`; `stage_post_release` opens its
+  pull request and cleans up on failure; `--authorize`, `--post-release`,
+  `--anchor` flags.
+- `scripts/check_release_authorization.py` - `ui-validation` accepts what the
+  task reads (`FORWARD_NETBOX_PLAYWRIGHT_HOST_PORT`, optional).
+- `scripts/check_release_preflight.py` - audits `requirements-release.txt`
+  alongside `constraints.txt`; `check_lockfile_consistency` (`poetry check
+  --lock`).
+- `scripts/check_release_lineage.py` - runs the sensitive gate over tree,
+  protected history, ref names and tag names, and reports which.
+- `scripts/validate_installed_routes.py` - every registered pk-scoped route,
+  enumerated from the resolver.
+- `.gitignore`, `docs/03_Plans/technical-debt.md`, `active/README.md`,
+  `2026-08-18-no-dev0-on-main.md`.
+
+## Approach
+
+The decision first: `main` carries the released version, and the marker
+machinery is deleted rather than left as a trap. Then promotion moves to where
+the harness can accept it - the anchor commit, which `stage_anchor` now
+generates from the tag: it derives the bridge (first first-parent commit after
+the tag, checked documentation-only), advances both constants, promotes the
+tables, regenerates the changelog, writes its own plan file, and opens the pull
+request.
+
+`stage_verify` tees the two gate commands to log files and records what ran:
+the exact `rtk env ... invoke` forms the checker parses, exit statuses, the
+`Ran N tests` lines, the runtime versions the tree declares. `stage_authorize`
+renders the Release Authorization section from that record after the
+production pull request merges - when the evidence base commit is knowable -
+and commits it on the evidence branch.
+
+`stage_finish_unattended` sequences the existing single-step functions and
+waits for each pull request to merge between them. The bound on the wait
+exists so an unattended run ends with an instruction instead of a hang.
+
+## Validation
+
+- `invoke harness-test`: 375 tests OK (was 334), including: the promotion
+  helper is gone and `--finish` on the production branch commits nothing; the
+  rendered authorization satisfies `_evidence_is_concrete` for every required
+  id; the unattended driver's step order and its resume message; the anchor
+  stage advances both constants and deletes its branch on failure; the lineage
+  check names all four sensitive surfaces; both requirement files are audited
+  with the same waivers.
+- `_detail_routes` enumerated 57 pk-scoped routes on the development stack,
+  every one reversible.
+- The 2.9.2 release itself is the integration test.
+
+## Rollback
+
+Revert. The manual flags (`--finish`, `--post-release`, `--anchor`) remain
+individually runnable, so a release in flight can be finished by hand at any
+step.
+
+## Decision Log
+
+- **`.dev0` is gone, not narrowed.** The incident it documented was real and
+  the marker was the wrong remedy: customers install from source, so a dev
+  marker on `main` offered a version nobody had gated.
+- **Promotion lives in the anchor commit.** Not because that is tidy, but
+  because the harness ties the anchor to the current release and refuses
+  either moving alone. The release branch flip was refused on every release
+  since 2.8.6 and discarded by hand each time.
+- **The authorization is rendered, not relaxed.** It would have been simpler
+  to loosen the checker. The checker is what a reviewer trusts; the renderer
+  is tested against it instead.
+- **The bridge SHA is derived from the tag, not typed.** `git rev-list
+  --first-parent --reverse <tag>..origin/main | head -1`, then checked
+  documentation-only before anything is written.
+- **Sensitive feed unification is closed as designed, not built.** The
+  release-time feed is a repository secret; a checkout cannot derive it.
+  `check_sensitive_pattern_parity` already fails closed unless the operator
+  acknowledges the gap in the evidence, which is the honest version of parity.
+- **`poetry check --lock` is a preflight check, not a harness check**, for
+  the same reason `pip-audit` is: it needs a tool the release host has and a
+  contributor's machine may not.
+
+## Open
+
+- Nothing.

--- a/docs/03_Plans/active/README.md
+++ b/docs/03_Plans/active/README.md
@@ -6,7 +6,8 @@ Use `../plan-template.md` as the starting point.
 
 Roadmap work belongs here as explicit plans. Keep each plan decision-complete enough that another engineer can continue it without recovering session history.
 
-For the 2.6 handoff, this directory contains only the current release plan. All
-pre-2.6 plans were closed into `../completed/` as implemented or superseded
-history; old deferral language in those records is not a current roadmap or an
-accepted 2.6 defect.
+Plans stay here after they ship: they are the record of what was decided and
+why, and their `## Open` sections are the technical-debt tracker (see
+`../technical-debt.md`). Everything before 2.6 was closed into `../completed/`
+as implemented or superseded history; deferral language in those records is
+not a current roadmap.

--- a/docs/03_Plans/technical-debt.md
+++ b/docs/03_Plans/technical-debt.md
@@ -1,0 +1,27 @@
+# Technical debt
+
+There is no separate tracker. The codebase carries no `TODO`/`FIXME` markers by
+policy; every deferral is recorded in the plan that made it, under a trailing
+`## Open` heading, with enough context to act on without recovering session
+history.
+
+To see what is outstanding:
+
+```sh
+grep -l '^## Open' docs/03_Plans/active/*.md
+```
+
+and read each section. A plan whose `## Open` says "Nothing" is closed. A
+plan's `## Open` is edited - struck through with the closing change named -
+when the item ships, so the file that made a deferral is the file that records
+its end.
+
+`completed/` is history: its deferral language described a decision at the
+time and does not override current code, `ARCHITECTURE.md`, or an active plan.
+
+## Current consolidation
+
+The 2.9.2 release plan gathers every `## Open` item that was still true in
+code as of 2026-09-02 into ordered tranches, and names the one exclusion
+(NetBox 4.7 runtime support, which needs a beta `netbox-branching`). Items it
+lists as closed carry the plan or pull request that closed them.

--- a/scripts/check_release_authorization.py
+++ b/scripts/check_release_authorization.py
@@ -121,7 +121,7 @@ def _safe_environment_assignment(assignment: str) -> bool:
             "forward-netbox-release-gate",
             "forward-netbox-upgrade26",
         }
-    if name == "FORWARD_NETBOX_HOST_PORT":
+    if name in ("FORWARD_NETBOX_HOST_PORT", PLAYWRIGHT_PORT_VARIABLE):
         return value.isdigit() and 1 <= int(value) <= 65535
     if name == "NETBOX_URL":
         match = re.fullmatch(r"http://127\.0\.0\.1:(?P<port>[1-9]\d{0,4})", value)
@@ -189,9 +189,14 @@ UPGRADE_FROM_VARIABLE = "FORWARD_NETBOX_UPGRADE_FROM_VERSION"
 # tag. Recorded in the evidence rather than hidden, exactly like the offline
 # upgrade discovery above.
 PATTERN_PARITY_VARIABLE = "FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED"
+# The one variable `invoke playwright-test` actually reads for where to
+# connect. It is optional there too - the task picks a free loopback port when
+# it is unset - so it is optional here, value-bounded like the host port.
+PLAYWRIGHT_PORT_VARIABLE = "FORWARD_NETBOX_PLAYWRIGHT_HOST_PORT"
 OPTIONAL_ENVIRONMENT_VARIABLES = URL_VARIABLES | {
     UPGRADE_FROM_VARIABLE,
     PATTERN_PARITY_VARIABLE,
+    PLAYWRIGHT_PORT_VARIABLE,
 }
 
 
@@ -213,15 +218,17 @@ def _environment_matches(
     URL to loopback, and `_rtk_parts` rejects a URL whose port disagrees with
     `FORWARD_NETBOX_HOST_PORT`.
 
-    `require_url` still *demands* the pair for `ui-validation`, unchanged by this
-    revision. Note that its stated justification does not survive inspection
-    either: `invoke playwright-test` takes no port, and
-    `_run_playwright_in_isolated_runtime` reads
+    `require_url` used to *demand* the pair for `ui-validation`, on the stated
+    grounds that the Playwright run must be told where to connect. That
+    justification did not survive inspection: `invoke playwright-test` takes no
+    port, and `_run_playwright_in_isolated_runtime` reads
     `FORWARD_NETBOX_PLAYWRIGHT_HOST_PORT` - falling back to an auto-picked free
-    loopback port - then sets `NETBOX_URL` itself. So the rule requires naming
-    two variables that task never reads. It is left in place here rather than
-    widened silently: `ui-validation` is optional evidence and blocks nothing,
-    so the question of what it should require deserves its own change.
+    loopback port - then sets `NETBOX_URL` itself. So the rule required naming
+    two variables that task never reads, and a truthful evidence line could not
+    satisfy it. `ui-validation` now requires what the task actually reads and
+    nothing it does not: the release environment, with the Playwright port
+    optional. `require_url` is kept for any evidence id that genuinely needs
+    the pair; none does today.
     """
     parts = _rtk_parts(command)
     if parts is None:
@@ -428,11 +435,13 @@ def _commands_satisfy(evidence_id: str, commands: list[list[str]]) -> bool:
             )
         )
     if evidence_id == "ui-validation":
+        # The Playwright task reads FORWARD_NETBOX_PLAYWRIGHT_HOST_PORT, not the
+        # host-port pair, and picks its own port when that is unset - so the
+        # pair is neither required nor forbidden. See `_environment_matches`.
         return _has_exact_invoke_task(
             commands,
             "playwright-test",
             environment=RELEASE_RUNTIME_ENVIRONMENT,
-            require_url=True,
         )
     if evidence_id == "customer-equivalent-acceptance":
         return _has_sync_release_gate_command(commands)

--- a/scripts/check_release_lineage.py
+++ b/scripts/check_release_lineage.py
@@ -15,6 +15,14 @@ and that its workflows succeeded - are deliberately NOT reimplemented; a second
 implementation of a security check is a second thing to get wrong. This narrows
 the window to those, rather than pretending to close it.
 
+The sensitive-content gate is also run here, over every surface it reads at
+publish time: the tree, the protected history, and every ref and tag NAME. The
+first two were already being checked by hand before a tag; the names were not,
+and a stale remote-tracking ref carrying an old branch name refused a tag after
+the tree had been reviewed clean twice. A review that reports "clean" while
+never looking at a category is worth distrusting, so this looks at all four and
+says which it looked at.
+
 Run against the merge commit you are about to tag:
 
     python3 scripts/check_release_lineage.py --version 2.7.11
@@ -22,13 +30,52 @@ Run against the merge commit you are about to tag:
 from __future__ import annotations
 
 import argparse
+import subprocess
 import sys
+from pathlib import Path
 
 import verify_release_provenance as provenance
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SENSITIVE_SURFACES = ("tracked files", "protected history", "ref names", "tag names")
 
 
 class LineageError(Exception):
     """A structural rule the publish workflow would refuse."""
+
+
+def _ref_names() -> list[str]:
+    """Every local branch, remote-tracking branch and tag name in the clone."""
+    raw = provenance._git_capture(
+        "for-each-ref",
+        "--format=%(refname:short)",
+        "refs/heads",
+        "refs/remotes",
+        "refs/tags",
+    )
+    return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
+def check_sensitive_surfaces() -> dict[str, object]:
+    """Run the release-time sensitive scan over all four surfaces it covers."""
+    command = [
+        sys.executable,
+        str(REPO_ROOT / "scripts" / "check_sensitive_content.py"),
+        "--git-files",
+        "--protected-history",
+    ]
+    names = _ref_names()
+    for name in names:
+        command += ["--ref-name", name]
+    completed = subprocess.run(command, cwd=REPO_ROOT, capture_output=True, text=True)
+    if completed.returncode != 0:
+        detail = (completed.stdout + completed.stderr).strip().splitlines()
+        raise LineageError(
+            "the sensitive-content gate refused this clone: "
+            + (detail[-1] if detail else "no output")
+            + f" (surfaces scanned: {', '.join(SENSITIVE_SURFACES)})"
+        )
+    return {"surfaces": list(SENSITIVE_SURFACES), "ref_names_scanned": len(names)}
 
 
 def check_release_lineage(release_commit: str, version: str) -> dict[str, object]:
@@ -84,12 +131,15 @@ def check_release_lineage(release_commit: str, version: str) -> dict[str, object
     except Exception as exc:  # noqa: BLE001 - surfaced verbatim below
         raise LineageError(f"security bootstrap check failed: {exc}") from exc
 
+    sensitive = check_sensitive_surfaces()
+
     return {
         "release_commit": resolved,
         "production_commit": production_commit,
         "lineage_length": len(lineage),
         "reviewed_commits": reviewed,
         "release_plan": plan,
+        "sensitive_surfaces": sensitive,
         "not_checked_here": [
             "each commit arrived through a merged pull request",
             "required workflows succeeded",

--- a/scripts/check_release_preflight.py
+++ b/scripts/check_release_preflight.py
@@ -135,6 +135,11 @@ def check_ui_harness_dependencies() -> str:
 
 
 CONSTRAINTS = REPO_ROOT / "constraints.txt"
+# The release controller's own toolchain. `release.yml` installs it with
+# `--require-hashes` and nothing audited it: an advisory against `pip`,
+# `twine` or `build` would fail the publish job after the tag existed.
+RELEASE_TOOLCHAIN = REPO_ROOT / "requirements-release.txt"
+POETRY_LOCK = REPO_ROOT / "poetry.lock"
 
 # Advisories we accept rather than fix, because forward_netbox's own code never
 # exercises the vulnerable path. Each entry needs a comment naming why, and the
@@ -183,27 +188,71 @@ def check_dependency_advisories() -> str:
             "before the gate. Install it (`pip install pip-audit`) or the release "
             "workflow will be the first thing to notice an advisory."
         )
-    command = [executable, "--progress-spinner", "off", "-r", str(CONSTRAINTS)]
-    for vuln_id in sorted(ACCEPTED_DEPENDENCY_ADVISORIES):
-        command += ["--ignore-vuln", vuln_id]
+    audited = []
+    for requirements in (CONSTRAINTS, RELEASE_TOOLCHAIN):
+        if not requirements.exists():
+            raise PreflightError(
+                f"{requirements.name} is missing; dependencies cannot be audited"
+            )
+        command = [executable, "--progress-spinner", "off", "-r", str(requirements)]
+        for vuln_id in sorted(ACCEPTED_DEPENDENCY_ADVISORIES):
+            command += ["--ignore-vuln", vuln_id]
+        completed = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        if completed.returncode != 0:
+            detail = (completed.stdout or completed.stderr or "").strip()
+            raise PreflightError(
+                f"{requirements.name} carries a known advisory, which will fail "
+                f"CI and the release workflow:\n{detail}"
+            )
+        audited.append(requirements.name)
+    files = " and ".join(audited)
+    if ACCEPTED_DEPENDENCY_ADVISORIES:
+        return (
+            f"no unaccepted advisories in {files} (ignoring: "
+            f"{', '.join(sorted(ACCEPTED_DEPENDENCY_ADVISORIES))})"
+        )
+    return f"no known advisories in {files}"
+
+
+def check_lockfile_consistency() -> str:
+    """`poetry.lock` must describe `pyproject.toml`, and the tree must say so.
+
+    The lockfile described a runtime from 2.6.7 for three releases and nothing
+    noticed, because nothing read it: it is not what ships (`constraints.txt`
+    is), so no install ever failed on it. 2.9.1 corrected it by hand and
+    recorded that "accurate today and unenforced only resets the clock". This
+    is the enforcement. `poetry check --lock` compares the lock's content hash
+    to the manifest; a dependency edit that skips `poetry lock` fails here,
+    ten seconds ahead of the gate, instead of drifting for another year.
+    """
+    if not POETRY_LOCK.exists():
+        raise PreflightError("poetry.lock is missing; the lockfile cannot be checked")
+    executable = shutil.which("poetry")
+    if executable is None:
+        raise PreflightError(
+            "poetry is not installed, so poetry.lock cannot be checked against "
+            "pyproject.toml before the gate. Install it, or the lockfile will "
+            "silently describe a runtime this release does not have."
+        )
     completed = subprocess.run(
-        command,
+        [executable, "check", "--lock"],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
     )
     if completed.returncode != 0:
-        detail = (completed.stdout or completed.stderr or "").strip()
+        detail = (completed.stdout + completed.stderr).strip().splitlines()
         raise PreflightError(
-            "pinned dependencies carry a known advisory, which will fail CI and "
-            f"the release workflow:\n{detail}"
+            "poetry.lock does not match pyproject.toml: "
+            + (detail[-1] if detail else "no output")
+            + ". Run `poetry lock` and commit the result."
         )
-    if ACCEPTED_DEPENDENCY_ADVISORIES:
-        return (
-            "no unaccepted advisories in constraints.txt (ignoring: "
-            f"{', '.join(sorted(ACCEPTED_DEPENDENCY_ADVISORIES))})"
-        )
-    return "no known advisories in constraints.txt"
+    return "poetry.lock matches pyproject.toml"
 
 
 # Dependabot alert ids (GHSA, not PYSEC - a different vocabulary from
@@ -459,13 +508,20 @@ def _outcome(detail: str) -> str:
 
 
 def _report_lines(
-    version, dependencies, advisories, dependabot_alerts, evidence_base, pattern_parity
+    version,
+    dependencies,
+    advisories,
+    dependabot_alerts,
+    evidence_base,
+    pattern_parity,
+    lockfile="",
 ):
     checks = (
         (f"version {version} consistent across surfaces", "passed"),
         (f"UI harness dependencies present ({dependencies})", "passed"),
         (advisories, _outcome(advisories)),
         (dependabot_alerts, _outcome(dependabot_alerts)),
+        (lockfile, _outcome(lockfile)),
         (f"evidence base commit {evidence_base}", _outcome(evidence_base)),
         (f"sensitive pattern parity {pattern_parity}", _outcome(pattern_parity)),
     )
@@ -489,6 +545,7 @@ def main() -> int:
         dependencies = check_ui_harness_dependencies()
         advisories = check_dependency_advisories()
         dependabot_alerts = check_dependabot_alerts()
+        lockfile = check_lockfile_consistency()
         evidence_base = check_release_plan_evidence_base(version)
         pattern_parity = check_sensitive_pattern_parity()
     except PreflightError as exc:
@@ -500,6 +557,7 @@ def main() -> int:
         "ui_harness_dependencies": dependencies,
         "dependency_advisories": advisories,
         "dependabot_alerts": dependabot_alerts,
+        "lockfile": lockfile,
         "evidence_base_commit": evidence_base,
         "sensitive_pattern_parity": pattern_parity,
     }
@@ -513,6 +571,7 @@ def main() -> int:
             dependabot_alerts,
             evidence_base,
             pattern_parity,
+            lockfile,
         ):
             print(line)
     return 0

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -13,8 +13,17 @@
 #   verify   - the full local CI mirror (pre-commit x2, harness, harness tests,
 #              py_compile, mkdocs --strict, build)
 #   publish  - branch, push, and wait for the exact GitHub workflows
-#   finish   - promote metadata, open the check-gated production/evidence PRs,
-#              or tag the validated evidence-only main commit
+#   finish   - open the check-gated production PR, then the evidence PR, then
+#              tag the validated evidence-only main commit
+#   authorize - append the Release Authorization section the evidence PR needs,
+#              rendered from what `verify` actually ran
+#   post-release - open the documentation-only bridge that must follow the tag
+#   anchor   - advance the provenance anchor onto the bridge AND promote the
+#              release in the compatibility tables, as one commit
+#
+# `--publish --auto-finish` runs every stage in order and waits for each pull
+# request to merge, so a release is one invocation. Each stage is also a flag
+# of its own, for resuming after a failure: the driver prints which one.
 #
 # Default run is prepare + verify. Rollout never happens without --publish, so
 # this is safe to run for a dry build.
@@ -27,6 +36,8 @@ import re
 import socket
 import subprocess
 import sys
+from datetime import datetime
+from datetime import timezone
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -42,6 +53,19 @@ FAST_BASELINE = REPO_ROOT / "forward_netbox/utilities/fast_baseline.py"
 RUNTIME_VERSION_TEST = (
     REPO_ROOT / "forward_netbox/tests/test_runtime_dependency_check.py"
 )
+PROVENANCE = REPO_ROOT / "scripts/verify_release_provenance.py"
+TESTED_RUNTIME = REPO_ROOT / "scripts/tested_runtime.py"
+CONSTRAINTS = REPO_ROOT / "constraints.txt"
+# What `verify` ran and how it came out, so `authorize` can render the
+# Release Authorization section from evidence rather than from memory. Local
+# and gitignored: it names the host's port and log paths.
+EVIDENCE_RECORD = REPO_ROOT / ".release-evidence.json"
+EVIDENCE_LOG_DIR = REPO_ROOT / ".release-evidence-logs"
+# Waiting for a pull request to merge. Nothing gates merges but the branch
+# ruleset, so this is normally seconds; the bound exists so an unattended run
+# ends with an instruction instead of a hang.
+PULL_REQUEST_MERGE_POLL_SECONDS = 30
+PULL_REQUEST_MERGE_MAX_POLLS = 120
 # The compatibility cell shared by every table row, so a new row reuses the
 # previous row's NetBox-support text verbatim.
 CURRENT_RELEASE_RE = re.compile(
@@ -197,33 +221,6 @@ def version_surface_edits(old: str, new: str) -> dict[Path, str]:
     return edits
 
 
-def stage_open_next(version: str, *, write: bool) -> None:
-    """Move `main` onto a `.dev0` marker so an install from it is self-describing.
-
-    `main` carries the release from the moment the release PR merges — before
-    the tag exists and before anything reaches PyPI. A customer installed from
-    `main` inside that window and reported running a version PyPI did not yet
-    have. Marking `main` as `X.Y.Z.dev0` makes that visible at the install
-    rather than leaving it indistinguishable from the published release.
-
-    The tag-only publish trigger is deliberately untouched: reordering it would
-    require a `workflow_dispatch` bypass of the control that exists to prevent
-    exactly that.
-    """
-    old = read_current_version()
-    if old.endswith(".dev0"):
-        raise ReleaseError(f"already on a dev marker ({old}); nothing to open")
-    marker = f"{version}.dev0"
-    print(f"[open-next] {old} -> {marker}")
-    edits = version_surface_edits(old, marker)
-    if not write:
-        print("[open-next] dry-run: not writing files")
-        return
-    for path, text in edits.items():
-        path.write_text(text, encoding="utf-8")
-    print(f"[open-next] wrote {len(edits)} version surfaces")
-
-
 def stage_prepare(version: str, summary: str, *, write: bool) -> None:
     old = read_current_version()
     print(f"[prepare] bump {old} -> {version}")
@@ -275,31 +272,200 @@ def release_distribution_artifacts(version: str) -> list[Path]:
     return [wheels[0], sdists[0]]
 
 
-def stage_verify() -> None:
-    print("[verify] mandatory isolated local release gate")
-    release_project = "forward-netbox-release-gate"
+# The environment variables the authorization checker requires an evidence
+# command to name, in the order they are rendered. `NETBOX_VER` is included
+# explicitly because the checker requires it even though the compose default
+# would supply the same value.
+RELEASE_GATE_ENVIRONMENT = (
+    "FORWARD_NETBOX_DOCKER_PROJECT",
+    "FORWARD_NETBOX_POSTGRES_DATA_PATH",
+    "FORWARD_NETBOX_WORKER_AUTORELOAD",
+    "NETBOX_VER",
+    "FORWARD_NETBOX_UPGRADE_FROM_VERSION",
+    "FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED",
+    "FORWARD_NETBOX_HOST_PORT",
+    "NETBOX_URL",
+)
+TEST_SUMMARY_RE = re.compile(r"^Ran (?P<count>\d+) tests? in ", re.MULTILINE)
+TEST_VERDICT_RE = re.compile(
+    r"^(?P<verdict>OK|FAILED)\b(?P<detail>[^\n]*)", re.MULTILINE
+)
+
+
+def run_logged(cmd: list[str], *, env: dict[str, str], log_path: Path) -> int:
+    """Run a gate command, streaming its output and keeping a copy.
+
+    `run` streams and keeps nothing, which is right for git and wrong for a
+    forty-minute gate whose summary lines are the evidence a release needs.
+    The copy is what `authorize` reads; the stream is what the operator reads.
+    """
+    print("  $ [redacted release command]")
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("w", encoding="utf-8") as log:
+        process = subprocess.Popen(
+            cmd,
+            cwd=REPO_ROOT,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        assert process.stdout is not None
+        for line in process.stdout:
+            sys.stdout.write(line)
+            log.write(line)
+        return process.wait()
+
+
+def _gate_summary(log_text: str) -> dict:
+    """The test-count lines from a gate log, as numbers.
+
+    The authorization checker requires a digit and a retrospective outcome in
+    every evidence line; the counts are both, and they are the part an operator
+    used to transcribe by hand.
+    """
+    counts = [int(match.group("count")) for match in TEST_SUMMARY_RE.finditer(log_text)]
+    verdicts = [match.group("verdict") for match in TEST_VERDICT_RE.finditer(log_text)]
+    sbom = re.search(r"\b(?P<count>\d+) components?\b", log_text)
+    routes = re.search(
+        r"\b(?P<count>\d+) (?:authenticated )?(?:menu |detail )?routes?\b", log_text
+    )
+    return {
+        "test_runs": counts,
+        "tests_total": sum(counts),
+        "verdicts": verdicts,
+        "failed": any(verdict == "FAILED" for verdict in verdicts),
+        "sbom_components": int(sbom.group("count")) if sbom else None,
+        "routes": int(routes.group("count")) if routes else None,
+    }
+
+
+def _release_gate_environment() -> dict[str, str]:
     release_env = {
         **os.environ,
-        "FORWARD_NETBOX_DOCKER_PROJECT": release_project,
+        "FORWARD_NETBOX_DOCKER_PROJECT": "forward-netbox-release-gate",
         "FORWARD_NETBOX_HOST_PORT": _available_loopback_port(),
         "FORWARD_NETBOX_POSTGRES_DATA_PATH": "netbox-postgres-data",
         "FORWARD_NETBOX_WORKER_AUTORELOAD": "0",
+        "NETBOX_VER": f"v{_tested_netbox_version()}",
     }
     release_env["NETBOX_URL"] = (
         f"http://127.0.0.1:{release_env['FORWARD_NETBOX_HOST_PORT']}"
     )
+    return release_env
+
+
+def _tested_netbox_version() -> str:
+    match = re.search(
+        r'^TESTED_NETBOX_VERSION = "(?P<version>[^"]+)"$',
+        TESTED_RUNTIME.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    if match is None:
+        raise ReleaseError(
+            "scripts/tested_runtime.py declares no TESTED_NETBOX_VERSION"
+        )
+    return match.group("version")
+
+
+def _pinned_branching_version() -> str:
+    match = re.search(
+        r"^netboxlabs-netbox-branching==(?P<version>[0-9][^\s]*)$",
+        CONSTRAINTS.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    if match is None:
+        raise ReleaseError("constraints.txt pins no netboxlabs-netbox-branching")
+    return match.group("version")
+
+
+def _evidence_command(task: str, environment: dict[str, str], *, with_url: bool) -> str:
+    """The exact `rtk env ... invoke <task>` form the authorization checker parses."""
+    assignments = []
+    for name in RELEASE_GATE_ENVIRONMENT:
+        if name in ("FORWARD_NETBOX_HOST_PORT", "NETBOX_URL") and not with_url:
+            continue
+        value = environment.get(name)
+        if value:
+            assignments.append(f"{name}={value}")
+    return f"rtk env {' '.join(assignments)} invoke {task}"
+
+
+def write_evidence_record(record: dict) -> None:
+    EVIDENCE_RECORD.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
+
+
+def read_evidence_record(version: str) -> dict:
+    if not EVIDENCE_RECORD.exists():
+        raise ReleaseError(
+            f"{EVIDENCE_RECORD.name} is missing: run `release.py {version} --write` "
+            "(verify) first, so the authorization can be rendered from what ran"
+        )
+    record = json.loads(EVIDENCE_RECORD.read_text(encoding="utf-8"))
+    if record.get("version") != version:
+        raise ReleaseError(
+            f"{EVIDENCE_RECORD.name} records v{record.get('version')}, not v{version}"
+        )
+    return record
+
+
+def stage_verify(version: str) -> None:
+    print("[verify] mandatory isolated local release gate")
+    release_project = "forward-netbox-release-gate"
+    release_env = _release_gate_environment()
+    logs = EVIDENCE_LOG_DIR / version
+    record = {
+        "version": version,
+        "started_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "environment": {
+            name: release_env[name]
+            for name in RELEASE_GATE_ENVIRONMENT
+            if release_env.get(name)
+        },
+        "netbox_version": _tested_netbox_version(),
+        "branching_version": _pinned_branching_version(),
+        "python_version": f"{sys.version_info.major}.{sys.version_info.minor}",
+        "gate": None,
+        "artifact": None,
+    }
     try:
-        run([sys.executable, "-m", "invoke", "ci"], env=release_env)
+        gate_log = logs / "invoke-ci.log"
+        status = run_logged(
+            [sys.executable, "-m", "invoke", "ci"], env=release_env, log_path=gate_log
+        )
+        record["gate"] = {
+            "command": _evidence_command("ci", release_env, with_url=False),
+            "exit_status": status,
+            "log": str(gate_log.relative_to(REPO_ROOT)),
+            **_gate_summary(gate_log.read_text(encoding="utf-8")),
+        }
+        if status != 0:
+            raise ReleaseError(f"release command failed with exit code {status}")
         artifacts = release_distribution_artifacts(read_current_version())
+        record["wheel"] = next(
+            artifact.name for artifact in artifacts if artifact.suffix == ".whl"
+        )
         run(
             [sys.executable, "-m", "twine", "check", *(str(p) for p in artifacts)],
             env=release_env,
         )
-        run(
+        artifact_log = logs / "invoke-artifact-test.log"
+        status = run_logged(
             [sys.executable, "-m", "invoke", "artifact-test"],
             env=release_env,
+            log_path=artifact_log,
         )
+        record["artifact"] = {
+            "command": _evidence_command("artifact-test", release_env, with_url=True),
+            "exit_status": status,
+            "log": str(artifact_log.relative_to(REPO_ROOT)),
+            **_gate_summary(artifact_log.read_text(encoding="utf-8")),
+        }
+        if status != 0:
+            raise ReleaseError(f"release command failed with exit code {status}")
+        record["finished_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
     finally:
+        write_evidence_record(record)
         run(
             [
                 "docker",
@@ -489,12 +655,22 @@ def stage_publish(version: str, *, auto_finish: bool = False) -> None:
         raise ReleaseError("Exact required GitHub workflows did not all succeed")
     _assert_release_head(version, published_head)
     if auto_finish:
-        stage_finish(version)
+        stage_finish_unattended(version)
     else:
         print("[publish] workflows green; re-run with --finish for release PRs.")
 
 
-def _promote_release_candidate(version: str) -> bool:
+def promote_release_tables(version: str) -> bool:
+    """Flip the compatibility tables from candidate to current. Files only.
+
+    This used to commit, push and wait, on the release branch, BEFORE the tag
+    existed. `check_harness.py` requires the provenance anchor to name the
+    release the table calls current, and the anchor cannot advance until the
+    bridge exists, which cannot exist until the tag does - so the commit it made
+    was refused by construction on every release since 2.8.6, and a second copy
+    of it was left stranded on local `main` by the tag step. Promotion belongs
+    in the anchor commit, where the two move together; see `stage_anchor`.
+    """
     originals = {path: path.read_text(encoding="utf-8") for path in README_TABLES}
     edits = {
         path: set_release_intro_text(
@@ -505,30 +681,47 @@ def _promote_release_candidate(version: str) -> bool:
         for path, text in originals.items()
     }
     if edits == originals:
-        print(f"[finish] v{version} metadata is already promoted")
+        print(f"[anchor] v{version} metadata is already promoted")
         return False
     for path, text in edits.items():
         path.write_text(text, encoding="utf-8")
     run([sys.executable, "scripts/gen_changelog.py"])
-    run(
-        [
-            "git",
-            "add",
-            *(str(path.relative_to(REPO_ROOT)) for path in README_TABLES),
-            "CHANGELOG.md",
-        ]
-    )
-    run(["git", "commit", "-m", f"release: promote v{version}"])
-    run([sys.executable, "scripts/check_harness.py", "--base", "origin/main"])
-    run(["git", "push", "--no-verify", "origin", f"release/{version}"])
-    promoted_head = _capture(["git", "rev-parse", "HEAD"])
-    if not wait_for_required_workflows(
-        promoted_head,
-        expected_branch=f"release/{version}",
-    ):
-        raise ReleaseError("Promoted release exact workflows did not all succeed")
-    _assert_release_head(version, promoted_head)
     return True
+
+
+def _wait_for_pull_request_merge(
+    branch: str,
+    *,
+    poll_seconds: int = PULL_REQUEST_MERGE_POLL_SECONDS,
+    max_polls: int = PULL_REQUEST_MERGE_MAX_POLLS,
+) -> dict:
+    """Block until the pull request for ``branch`` is merged, or say why not."""
+    import time
+
+    for _ in range(max_polls):
+        pull = _pull_request_for_branch(branch)
+        if pull is None:
+            raise ReleaseError(f"no pull request exists for {branch}")
+        state = pull.get("state")
+        if state == "MERGED":
+            print(f"[merge] {pull['url']} merged")
+            return pull
+        if state == "CLOSED":
+            raise ReleaseError(f"pull request for {branch} was closed without merging")
+        print(f"[merge] waiting for {pull['url']} ({state})")
+        time.sleep(poll_seconds)
+    raise ReleaseError(
+        f"pull request for {branch} did not merge within "
+        f"{poll_seconds * max_polls} seconds; merge it, then resume"
+    )
+
+
+def _checkout_merged_main() -> str:
+    """Put the checkout on `main` at exactly `origin/main` and return that SHA."""
+    run(["git", "fetch", "origin", "main"])
+    run(["git", "checkout", "--force", "main"])
+    run(["git", "reset", "--hard", "origin/main"])
+    return _capture(["git", "rev-parse", "HEAD"])
 
 
 def _pull_request_for_branch(branch: str) -> dict | None:
@@ -735,12 +928,9 @@ def stage_finish(version: str) -> None:
     current_branch = _capture(["git", "branch", "--show-current"])
 
     if current_branch == production_branch:
-        if _promote_release_candidate(version):
-            print(
-                "[finish] metadata promotion is green. Re-run --finish to open "
-                "the production PR."
-            )
-            return
+        # No promotion here. The tables flip in the anchor commit, after the
+        # tag, because the harness ties the anchor to the current release and
+        # refuses either one moving alone - see `promote_release_tables`.
         head_commit = _capture(["git", "rev-parse", "HEAD"])
         run([sys.executable, "scripts/check_harness.py", "--base", "origin/main"])
         run(["git", "push", "--no-verify", "origin", production_branch])
@@ -924,14 +1114,16 @@ def stage_post_release(version: str, tag: str) -> None:
     the bridge - documentation-only, parented to the release commit - and that
     slot is taken by whatever lands first.
 
-    The `.dev0` question is narrowed rather than settled. `stage_open_next`
-    documents a real incident: a customer installed from `main` between the
-    release PR merging and the tag, and reported a version PyPI did not have.
-    The operating rule that `main` carries the RELEASED version is about a
-    different window - after the tag, when `main` IS that release. Both hold, so
-    a `.dev0` belongs with the first substantive change after a release rather
-    than as an automatic step that runs when nothing has changed yet.
-    `--open-next` remains available for that; it is simply no longer automatic.
+    The `.dev0` question is settled: `main` carries the RELEASED version, and
+    nothing writes a dev marker to it. `--open-next` documented a real incident
+    - a customer installed from `main` between the release PR merging and the
+    tag, and reported a version PyPI did not have - but the marker was the
+    wrong remedy for it. Customers install this plugin from source, so a
+    `2.9.2.dev0` on `main` offered a version that was never gated, tagged or
+    published; and the window it described is minutes wide, covered by the
+    tag-only publish trigger and by `--auto-finish` running straight through
+    it. Six release plans recorded the contradiction as undecided; this is the
+    decision, and the machinery is gone rather than left as a trap.
     """
     branch = f"docs/post-release-{version}"
     print(f"[post-release] opening {branch} for {tag}")
@@ -949,21 +1141,377 @@ def stage_post_release(version: str, tag: str) -> None:
         run(["git", "commit", "-m", f"docs: record the {version} post-release bridge"])
         run([sys.executable, "scripts/check_harness.py", "--base", "origin/main"])
         run(["git", "push", "--no-verify", "-u", "origin", branch])
+        _open_pull_request(
+            branch,
+            title=f"docs: record the {version} post-release bridge",
+            body=(
+                f"Documentation-only bridge for {tag}. It must be the first "
+                "commit on main after the tag; merge it before anything else."
+            ),
+        )
+    except Exception:
+        # A failed stage leaves nothing behind. The branch was created by this
+        # function and holds at most the one commit it made; deleting it means
+        # the next attempt starts from origin/main rather than inheriting a
+        # half-made bridge - which is how v2.8.3's slot was lost.
+        run(["git", "checkout", "--force", starting_branch], check=False)
+        run(["git", "branch", "-D", branch], check=False)
+        raise
     finally:
         run(["git", "checkout", "--force", starting_branch], check=False)
 
     print(
-        "\n[post-release] merge that pull request, then advance the anchor:\n"
+        "\n[post-release] once that pull request merges, advance the anchor:\n"
         "\n"
-        f"    git fetch origin main\n"
-        f"    BRIDGE=$(git rev-list --first-parent {tag}..origin/main | tail -1)\n"
-        f"    # in scripts/verify_release_provenance.py set:\n"
-        f'    #   PRIOR_RELEASE_TAG = "{tag}"\n'
-        f'    #   PRIOR_POST_RELEASE_DOC_COMMIT = "$BRIDGE"\n'
+        f"    python3 scripts/release.py {version} --anchor\n"
         "\n"
-        "The harness fails until that lands, so this cannot be forgotten "
-        "quietly - only deferred.\n"
+        "It derives the bridge commit from the tag, advances "
+        "PRIOR_RELEASE_TAG and PRIOR_POST_RELEASE_DOC_COMMIT, and promotes the "
+        "release in the compatibility tables, as one commit. The harness fails "
+        "until that lands, so this cannot be forgotten quietly - only deferred.\n"
     )
+
+
+def _open_pull_request(branch: str, *, title: str, body: str) -> dict:
+    """Open a squash-merging pull request for ``branch`` if none exists."""
+    pull = _pull_request_for_branch(branch)
+    if pull is None:
+        run(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--repo",
+                GITHUB_REPOSITORY,
+                "--base",
+                "main",
+                "--head",
+                branch,
+                "--title",
+                title,
+                "--body",
+                body,
+            ]
+        )
+        pull = _pull_request_for_branch(branch)
+    if pull is None:
+        raise ReleaseError(f"failed to resolve pull request for {branch}")
+    if pull.get("state") == "OPEN":
+        run(
+            [
+                "gh",
+                "pr",
+                "merge",
+                str(pull["number"]),
+                "--repo",
+                GITHUB_REPOSITORY,
+                "--auto",
+                "--squash",
+            ]
+        )
+    print(f"[pr] {pull['url']}")
+    return pull
+
+
+def _bridge_commit_for(tag: str) -> str:
+    """The first first-parent commit after ``tag`` on origin/main: the bridge."""
+    run(["git", "fetch", "origin", "main"])
+    lineage = _capture(
+        ["git", "rev-list", "--first-parent", "--reverse", f"{tag}..origin/main"]
+    ).splitlines()
+    if not lineage:
+        raise ReleaseError(f"nothing has landed on origin/main after {tag} yet")
+    bridge = lineage[0]
+    tag_commit = _capture(["git", "rev-list", "-n", "1", tag])
+    changed = [
+        line
+        for line in _capture(
+            ["git", "diff", "--name-only", tag_commit, bridge]
+        ).splitlines()
+        if line
+    ]
+    if not changed or not all(_is_bridge_path(path) for path in changed):
+        raise ReleaseError(
+            f"the first commit after {tag} ({bridge[:12]}) is not "
+            f"documentation-only ({changed}); the bridge slot is taken and the "
+            "anchor cannot advance onto it"
+        )
+    return bridge
+
+
+def _is_bridge_path(path: str) -> bool:
+    # Mirrors `verify_release_provenance._is_documentation_path` without
+    # importing it: the verifier is the trusted scanner and stays untouched.
+    return (path.startswith("docs/") and path.endswith(".md")) or path in {
+        "CHANGELOG.md",
+        "README.md",
+        "docs/README.md",
+        "docs/01_User_Guide/README.md",
+    }
+
+
+def _anchor_plan_path(version: str) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return REPO_ROOT / "docs" / "03_Plans" / "active" / f"{stamp}-anchor-{version}.md"
+
+
+def _anchor_plan_text(version: str, tag: str, bridge: str) -> str:
+    return f"""# Advance the release provenance anchor to {version}
+
+## Goal
+
+Move the provenance anchor onto the shipped {version} release and promote it to
+current in the compatibility tables, as one commit.
+
+## Constraints
+
+- The bridge must be the first commit after the tag on the first-parent lineage
+  and documentation-only. `{bridge[:12]}` was checked for both by
+  `scripts/release.py --anchor` before this file was written.
+- The table promotion belongs here, not on the release branch: the harness
+  requires the anchor to name the release the table calls current, so the two
+  can only move together.
+
+## Touched Surfaces
+
+- `scripts/verify_release_provenance.py`
+- `README.md`, `docs/README.md`, `docs/01_User_Guide/README.md`, `CHANGELOG.md`
+- this plan
+
+## Approach
+
+Anchor to `{tag}` / bridge `{bridge}`; promote {version} to current and demote
+the previous release to superseded.
+
+## Validation
+
+`check_harness.py --base origin/main` passes with the anchor advanced.
+
+## Rollback
+
+Revert; the harness fails again, which blocks the next release rather than
+permitting an unverified one - the safe direction.
+
+## Decision Log
+
+- **Generated by `scripts/release.py --anchor`.** The anchor and the promotion
+  were hand-edited for every release through 2.9.1, and skipping either was
+  silent at the time and expensive later.
+"""
+
+
+def _capture_constant(text: str, key: str) -> str:
+    match = re.search(rf'^{re.escape(key)} = "(?P<value>[^"]+)"$', text, re.MULTILINE)
+    if match is None:
+        raise ReleaseError(f"scripts/verify_release_provenance.py declares no {key}")
+    return match.group("value")
+
+
+def stage_anchor(version: str, tag: str) -> None:
+    """Advance the provenance anchor onto the bridge and promote the release.
+
+    One commit, because the harness ties the two together: the anchor must name
+    the release the compatibility table calls current. Promoting on the release
+    branch was refused for exactly that reason on every release since 2.8.6.
+    """
+    bridge = _bridge_commit_for(tag)
+    branch = f"chore/anchor-{version}"
+    print(f"[anchor] {tag} -> bridge {bridge[:12]} on {branch}")
+    starting_branch = _capture(["git", "branch", "--show-current"]) or "main"
+    plan_path = _anchor_plan_path(version)
+    try:
+        run(["git", "checkout", "-B", branch, "origin/main"])
+        text = PROVENANCE.read_text(encoding="utf-8")
+        text = bump_version_text(
+            text,
+            _capture_constant(text, "PRIOR_RELEASE_TAG"),
+            tag,
+            key="PRIOR_RELEASE_TAG",
+        )
+        text = bump_version_text(
+            text,
+            _capture_constant(text, "PRIOR_POST_RELEASE_DOC_COMMIT"),
+            bridge,
+            key="PRIOR_POST_RELEASE_DOC_COMMIT",
+        )
+        PROVENANCE.write_text(text, encoding="utf-8")
+        promote_release_tables(version)
+        plan_path.write_text(_anchor_plan_text(version, tag, bridge), encoding="utf-8")
+        run(
+            [
+                "git",
+                "add",
+                str(PROVENANCE.relative_to(REPO_ROOT)),
+                *(str(path.relative_to(REPO_ROOT)) for path in README_TABLES),
+                "CHANGELOG.md",
+                str(plan_path.relative_to(REPO_ROOT)),
+            ]
+        )
+        run(
+            [
+                "git",
+                "commit",
+                "-m",
+                f"chore: advance the release provenance anchor to {version}",
+            ]
+        )
+        run([sys.executable, "scripts/check_harness.py", "--base", "origin/main"])
+        run(["git", "push", "--no-verify", "-u", "origin", branch])
+        _open_pull_request(
+            branch,
+            title=f"chore: advance the release provenance anchor to {version}",
+            body=(
+                f"Anchor to `{tag}` / bridge `{bridge}`, and promote {version} to "
+                "current in the compatibility tables. Generated by "
+                "`scripts/release.py --anchor`."
+            ),
+        )
+    except Exception:
+        run(["git", "checkout", "--force", starting_branch], check=False)
+        run(["git", "branch", "-D", branch], check=False)
+        raise
+    finally:
+        run(["git", "checkout", "--force", starting_branch], check=False)
+
+
+def _release_plan_path(version: str) -> Path:
+    plans = sorted(
+        (REPO_ROOT / "docs" / "03_Plans" / "active").glob(f"*release-{version}*.md")
+    )
+    if len(plans) != 1:
+        raise ReleaseError(
+            f"expected exactly one active release-{version} plan, found {len(plans)}"
+        )
+    return plans[0]
+
+
+def render_release_authorization(record: dict, evidence_base: str) -> str:
+    """The Release Authorization section, from what `verify` recorded.
+
+    Every claim here is something the record holds: the exact command form the
+    checker parses, the exit status, the test counts from the gate's own
+    summary lines, and the runtime versions the tree declares. Nothing is
+    typed from memory, which is where the 2.9.x sections got their numbers.
+    """
+    gate = record.get("gate") or {}
+    artifact = record.get("artifact") or {}
+    if gate.get("exit_status") != 0 or artifact.get("exit_status") != 0:
+        raise ReleaseError(
+            "the evidence record does not show both gate commands passing; "
+            "re-run verify before authorizing"
+        )
+    version = record["version"]
+    runs = gate.get("test_runs") or []
+    counts = ", ".join(f"{count} tests OK" for count in runs) or "every suite OK"
+    sbom = artifact.get("sbom_components")
+    sbom_text = f"a validated SBOM of {sbom} components" if sbom else "a validated SBOM"
+    routes = artifact.get("routes")
+    routes_text = (
+        f"{routes} authenticated routes returning 200"
+        if routes
+        else "every installed route returning 200"
+    )
+    wheel = record.get("wheel", f"forward_netbox-{version}-py3-none-any.whl")
+    lines = [
+        "## Release Authorization",
+        "",
+        f"- Evidence base commit: `{evidence_base}`",
+        "",
+        f"- [x] `final-tree-full-gate` - `{gate['command']}` passed on the final "
+        f"{version} tree with exit status 0: {counts} across "
+        f"{gate.get('tests_total', 0)} tests in total, and the upgrade leg "
+        "seeded under the previous release and upgraded onto the tested "
+        "runtime with its rows surviving.",
+        "",
+        "  The gated tree is the release tree apart from this authorization record,",
+        "  which is Markdown in a single plan file and is appended after the gate by",
+        "  construction.",
+        "",
+        f"- [x] `exact-runtime-artifact` - `{artifact['command']}` passed with exit "
+        f"status 0 against the installed `{wheel}` on NetBox "
+        f"{record['netbox_version']}, Branching {record['branching_version']}, "
+        f"Python {record['python_version']}, with {routes_text}, all plugin "
+        f"migrations applying cleanly with no drift, and {sbom_text}.",
+        "",
+        "The optional evidence ids are not recorded. The release owner's 2026-07-27",
+        "proportionality decision applies; see",
+        "`docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md`.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def stage_authorize(version: str) -> None:
+    """Append the Release Authorization section on the evidence branch.
+
+    Runs after the production pull request has merged, because the evidence
+    base commit is the commit the tag's parent will be - `origin/main` at that
+    moment - and nothing else.
+    """
+    record = read_evidence_record(version)
+    evidence_branch = f"release/{version}-evidence"
+    evidence_base = _checkout_merged_main()
+    plan_path = _release_plan_path(version)
+    text = plan_path.read_text(encoding="utf-8")
+    if "## Release Authorization" in text:
+        raise ReleaseError(f"{plan_path.name} already carries a Release Authorization")
+    run(["git", "checkout", "-B", evidence_branch, "origin/main"])
+    section = render_release_authorization(record, evidence_base)
+    plan_path.write_text(text.rstrip("\n") + "\n\n" + section, encoding="utf-8")
+    run(["git", "add", str(plan_path.relative_to(REPO_ROOT))])
+    run(["git", "commit", "-m", f"release: authorize v{version}"])
+    run(
+        [
+            sys.executable,
+            "scripts/check_release_authorization.py",
+            "--version",
+            version,
+        ]
+    )
+    print(f"[authorize] {evidence_branch} carries the rendered authorization")
+
+
+def stage_finish_unattended(version: str) -> None:
+    """Drive the release from the pushed production branch to the anchor.
+
+    Each step is the same function the matching flag runs by hand, so a
+    failure names the flag to resume with rather than leaving the operator to
+    reconstruct where the sequence stopped.
+    """
+    production_branch = f"release/{version}"
+    evidence_branch = f"{production_branch}-evidence"
+    tag = f"v{version}"
+    steps = (
+        ("--finish (production)", lambda: stage_finish(version)),
+        (
+            "merge (production)",
+            lambda: _wait_for_pull_request_merge(production_branch),
+        ),
+        ("--authorize", lambda: stage_authorize(version)),
+        ("--finish (evidence)", lambda: stage_finish(version)),
+        ("merge (evidence)", lambda: _wait_for_pull_request_merge(evidence_branch)),
+        ("checkout main", _checkout_merged_main),
+        ("--finish (tag)", lambda: stage_finish(version)),
+        (
+            "merge (bridge)",
+            lambda: _wait_for_pull_request_merge(f"docs/post-release-{version}"),
+        ),
+        ("--anchor", lambda: stage_anchor(version, tag)),
+        (
+            "merge (anchor)",
+            lambda: _wait_for_pull_request_merge(f"chore/anchor-{version}"),
+        ),
+    )
+    for label, step in steps:
+        print(f"[auto-finish] {label}")
+        try:
+            step()
+        except ReleaseError as exc:
+            raise ReleaseError(
+                f"stopped at {label}: {exc}. Fix that, then resume with the "
+                "matching flag; every later step is a flag of its own."
+            ) from exc
+    print(f"[auto-finish] v{version} released, bridged and anchored.")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -991,12 +1539,19 @@ def main(argv: list[str] | None = None) -> int:
         help="promote, open release PRs, or tag validated main (rollout)",
     )
     parser.add_argument(
-        "--open-next",
+        "--authorize",
         action="store_true",
-        help=(
-            "after a release ships, move main to <version>.dev0 so an install "
-            "from main is visibly not the published release"
-        ),
+        help="after the production PR merges: render and commit the authorization",
+    )
+    parser.add_argument(
+        "--post-release",
+        action="store_true",
+        help="after the tag publishes: open the documentation-only bridge PR",
+    )
+    parser.add_argument(
+        "--anchor",
+        action="store_true",
+        help="after the bridge merges: advance the anchor and promote the tables",
     )
     args = parser.parse_args(argv)
 
@@ -1004,15 +1559,24 @@ def main(argv: list[str] | None = None) -> int:
         parser.error(f"version must be X.Y.Z, got {args.version!r}")
 
     try:
-        if args.open_next:
-            stage_open_next(args.version, write=args.write)
+        if args.anchor:
+            stage_anchor(args.version, f"v{args.version}")
+            return 0
+        if args.post_release:
+            stage_post_release(args.version, f"v{args.version}")
+            return 0
+        if args.authorize:
+            stage_authorize(args.version)
             return 0
         if args.finish:
-            stage_finish(args.version)
+            if args.auto_finish:
+                stage_finish_unattended(args.version)
+            else:
+                stage_finish(args.version)
             return 0
         stage_prepare(args.version, args.summary, write=args.write)
         if args.write:
-            stage_verify()
+            stage_verify(args.version)
         if args.publish:
             stage_publish(args.version, auto_finish=args.auto_finish)
     except ReleaseError as exc:

--- a/scripts/tests/test_release.py
+++ b/scripts/tests/test_release.py
@@ -223,18 +223,42 @@ class FinishReleaseTest(unittest.TestCase):
         self.assertIn("--controls-only", command)
         self.assertEqual(run.call_args.kwargs["env"]["GH_TOKEN"], "secret-token")
 
+    @patch.object(release, "_open_release_pull_request")
+    @patch.object(release, "_assert_branch_head")
     @patch.object(release, "run")
-    @patch.object(release, "_promote_release_candidate", return_value=True)
-    def test_first_finish_stops_after_metadata_promotion(self, promote, run):
-        with patch.object(
-            release,
-            "_capture",
-            return_value="release/2.6.0",
-        ):
+    def test_finish_on_the_production_branch_does_not_promote(
+        self, run, _assert_head, open_pull_request
+    ):
+        """The tables flip in the anchor commit, after the tag - never here.
+
+        `--finish` used to commit `release: promote` on the release branch and
+        run the harness against it, which refused it by construction on every
+        release since 2.8.6: the harness ties the anchor to the release the
+        table calls current, and the anchor cannot move until the bridge
+        exists, which cannot exist until the tag does.
+        """
+        with patch.object(release, "_capture", return_value="release/2.6.0"):
             release.stage_finish("2.6.0")
 
-        promote.assert_called_once_with("2.6.0")
-        run.assert_not_called()
+        commands = [" ".join(call.args[0]) for call in run.call_args_list]
+        self.assertFalse(
+            any("commit" in command for command in commands),
+            commands,
+        )
+        self.assertFalse(
+            any("gen_changelog" in command for command in commands),
+            commands,
+        )
+        self.assertTrue(any("check_harness.py" in command for command in commands))
+        self.assertTrue(any(command.startswith("git push") for command in commands))
+        open_pull_request.assert_called_once_with(
+            "2.6.0", "release/2.6.0", evidence=False
+        )
+
+    def test_the_promotion_helper_no_longer_exists(self):
+        # Its commit-push-wait body is what stranded a `release: promote` on
+        # local main and on the release branch; only the file edit survives.
+        self.assertFalse(hasattr(release, "_promote_release_candidate"))
 
     def test_release_head_requires_exact_local_and_remote_commit(self):
         expected = "a" * 40
@@ -450,51 +474,483 @@ class VersionSurfaceEditTest(unittest.TestCase):
                     item.stop()
 
 
-class OpenNextDevCycleTest(unittest.TestCase):
-    """`main` must be self-describing as not-the-release.
+class NoDevMarkerOnMainTest(unittest.TestCase):
+    """`main` carries the released version. Decided, and the machinery gone.
 
-    It carries the release from the moment the release PR merges — before the
-    tag and before PyPI. A customer installed from `main` in that window and
-    reported running a version PyPI did not have.
+    `--open-next` put `X.Y.Z.dev0` on `main`; the operating rule since 2.7.13
+    said it must never be there; six release plans recorded the contradiction
+    as undecided, and the post-release step failed on it every release. A
+    customer installs this plugin from source, so a dev marker on `main`
+    offered a version that was never gated, tagged or published. The window it
+    described - between the release PR merging and the tag - is minutes wide
+    and `--auto-finish` runs straight through it.
     """
 
-    def test_the_marker_is_the_next_version_with_dev0(self):
-        # `version_surface_edits` is patched too: without it the test reads the
-        # repository's real pyproject and fails on every version bump, which is
-        # exactly how it broke when this tranche moved the tree to 2.6.6.
+    def test_the_stage_and_its_flag_are_gone(self):
+        self.assertFalse(hasattr(release, "stage_open_next"))
+        with patch.object(release, "stage_finish"):
+            with self.assertRaises(SystemExit):
+                release.main(["2.9.2", "--open-next"])
+
+    def test_nothing_in_the_tool_writes_a_dev_marker(self):
+        # Prose may still say `.dev0` when recording the decision; no string
+        # literal may build one.
+        source = Path(release.__file__).read_text(encoding="utf-8")
+        body = source[source.index("def bump_version_text") :]
+        self.assertNotIn('.dev0"', body)
+        self.assertNotIn(".dev0'", body)
+
+
+class PromoteReleaseTablesTest(unittest.TestCase):
+    """Promotion is a file edit. The commit belongs to the anchor."""
+
+    def _tables(self):
+        scratch = tempfile.TemporaryDirectory()
+        self.addCleanup(scratch.cleanup)
+        paths = tuple(Path(scratch.name) / f"table-{index}.md" for index in range(3))
+        for path in paths:
+            path.write_text("candidate table\n", encoding="utf-8")
+        return paths
+
+    def test_it_rewrites_the_tables_and_regenerates_the_changelog_only(self):
+        paths = self._tables()
         with (
-            patch.object(release, "read_current_version", return_value="2.6.5"),
-            patch.object(release, "version_surface_edits", return_value={}),
+            patch.object(release, "README_TABLES", paths),
+            patch.object(
+                release,
+                "promote_release_candidate_text",
+                side_effect=lambda text, version: text.replace("candidate", "current"),
+            ),
+            patch.object(
+                release,
+                "set_release_intro_text",
+                side_effect=lambda text, v, candidate: text,
+            ),
+            patch.object(release, "run") as run,
         ):
-            output = StringIO()
-            with redirect_stdout(output):
-                release.stage_open_next("2.6.6", write=False)
-        self.assertIn("2.6.5 -> 2.6.6.dev0", output.getvalue())
+            self.assertTrue(release.promote_release_tables("2.9.2"))
 
-    def test_it_does_not_depend_on_the_repository_version(self):
-        # Guards the coupling directly: any current version must work.
-        for current, target in (("1.0.0", "1.0.1"), ("9.9.9", "10.0.0")):
-            with (
-                patch.object(release, "read_current_version", return_value=current),
-                patch.object(release, "version_surface_edits", return_value={}),
-            ):
-                output = StringIO()
-                with redirect_stdout(output):
-                    release.stage_open_next(target, write=False)
-            self.assertIn(f"{current} -> {target}.dev0", output.getvalue())
+        for path in paths:
+            self.assertEqual(path.read_text(encoding="utf-8"), "current table\n")
+        commands = [" ".join(call.args[0]) for call in run.call_args_list]
+        self.assertEqual(len(commands), 1, commands)
+        self.assertIn("gen_changelog.py", commands[0])
 
-    def test_a_dry_run_writes_nothing(self):
-        with patch.object(release, "read_current_version", return_value="2.6.5"):
-            with patch.object(release, "version_surface_edits") as edits:
-                output = StringIO()
-                with redirect_stdout(output):
-                    release.stage_open_next("2.6.6", write=False)
-                edits.assert_called_once_with("2.6.5", "2.6.6.dev0")
-        self.assertIn("not writing files", output.getvalue())
+    def test_an_already_promoted_table_is_reported_not_rewritten(self):
+        paths = self._tables()
+        with (
+            patch.object(release, "README_TABLES", paths),
+            patch.object(
+                release, "promote_release_candidate_text", side_effect=lambda t, v: t
+            ),
+            patch.object(
+                release, "set_release_intro_text", side_effect=lambda t, v, candidate: t
+            ),
+            patch.object(release, "run") as run,
+        ):
+            self.assertFalse(release.promote_release_tables("2.9.2"))
+        run.assert_not_called()
 
-    def test_refuses_to_open_a_cycle_twice(self):
-        with patch.object(release, "read_current_version", return_value="2.6.6.dev0"):
-            with self.assertRaisesRegex(
-                release.ReleaseError, "already on a dev marker"
-            ):
-                release.stage_open_next("2.6.7", write=False)
+
+class GateSummaryTest(unittest.TestCase):
+    def test_it_reads_every_suite_summary_from_the_log(self):
+        log = (
+            "Ran 334 tests in 81.300s\nOK\n...\n"
+            "Ran 2324 tests in 906.639s\nOK (skipped=4)\n"
+            "validated SBOM of 178 components\n"
+            "7 authenticated menu routes returned 200\n"
+        )
+        summary = release._gate_summary(log)
+        self.assertEqual(summary["test_runs"], [334, 2324])
+        self.assertEqual(summary["tests_total"], 2658)
+        self.assertFalse(summary["failed"])
+        self.assertEqual(summary["sbom_components"], 178)
+        self.assertEqual(summary["routes"], 7)
+
+    def test_a_failed_suite_is_visible(self):
+        summary = release._gate_summary("Ran 5 tests in 1s\nFAILED (failures=2)\n")
+        self.assertTrue(summary["failed"])
+        self.assertEqual(summary["verdicts"], ["FAILED"])
+
+
+class EvidenceCommandTest(unittest.TestCase):
+    ENVIRONMENT = {
+        "FORWARD_NETBOX_DOCKER_PROJECT": "forward-netbox-release-gate",
+        "FORWARD_NETBOX_POSTGRES_DATA_PATH": "netbox-postgres-data",
+        "FORWARD_NETBOX_WORKER_AUTORELOAD": "0",
+        "NETBOX_VER": "v4.6.8",
+        "FORWARD_NETBOX_HOST_PORT": "18080",
+        "NETBOX_URL": "http://127.0.0.1:18080",
+        "HOME": "/nowhere",
+    }
+
+    def test_the_gate_command_omits_the_host_port_pair(self):
+        command = release._evidence_command("ci", self.ENVIRONMENT, with_url=False)
+        self.assertEqual(
+            command,
+            "rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate "
+            "FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data "
+            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 invoke ci",
+        )
+
+    def test_the_artifact_command_carries_the_pair_and_nothing_foreign(self):
+        command = release._evidence_command(
+            "artifact-test", self.ENVIRONMENT, with_url=True
+        )
+        self.assertIn(
+            "FORWARD_NETBOX_HOST_PORT=18080 NETBOX_URL=http://127.0.0.1:18080", command
+        )
+        self.assertNotIn("HOME", command)
+        self.assertTrue(command.endswith("invoke artifact-test"))
+
+
+class RenderReleaseAuthorizationTest(unittest.TestCase):
+    """The rendered section must satisfy the checker that gates the tag.
+
+    Asked of the checker's own predicate, not of a restated rule, so the
+    renderer cannot drift from what `check_release_authorization.py` accepts.
+    """
+
+    def _record(self, **overrides):
+        environment = EvidenceCommandTest.ENVIRONMENT
+        record = {
+            "version": "2.9.2",
+            "netbox_version": "4.6.8",
+            "branching_version": "1.1.3",
+            "python_version": "3.14",
+            "wheel": "forward_netbox-2.9.2-py3-none-any.whl",
+            "gate": {
+                "command": release._evidence_command("ci", environment, with_url=False),
+                "exit_status": 0,
+                "test_runs": [334, 70, 2324],
+                "tests_total": 2728,
+            },
+            "artifact": {
+                "command": release._evidence_command(
+                    "artifact-test", environment, with_url=True
+                ),
+                "exit_status": 0,
+                "sbom_components": 178,
+                "routes": 7,
+            },
+        }
+        record.update(overrides)
+        return record
+
+    def _checker(self):
+        import sys
+
+        scripts = str(Path(release.__file__).resolve().parent)
+        if scripts not in sys.path:
+            sys.path.insert(0, scripts)
+        import check_release_authorization
+
+        return check_release_authorization
+
+    def test_every_required_evidence_line_is_concrete_to_the_checker(self):
+        checker = self._checker()
+        section = release.render_release_authorization(self._record(), "e" * 40)
+
+        self.assertIn("- Evidence base commit: `" + "e" * 40 + "`", section)
+        for evidence_id in checker.REQUIRED_EVIDENCE_IDS:
+            line = next(
+                line for line in section.splitlines() if f"`{evidence_id}`" in line
+            )
+            evidence = line.split(" - ", 1)[1]
+            self.assertTrue(
+                checker._evidence_is_concrete(evidence_id, evidence),
+                f"{evidence_id}: {evidence}",
+            )
+
+    def test_a_failed_gate_cannot_be_rendered_as_passing(self):
+        record = self._record()
+        record["gate"]["exit_status"] = 1
+        with self.assertRaisesRegex(release.ReleaseError, "re-run verify"):
+            release.render_release_authorization(record, "e" * 40)
+
+
+class WaitForPullRequestMergeTest(unittest.TestCase):
+    def _pull(self, state):
+        return {"state": state, "url": "https://example.invalid/pull/1", "number": 1}
+
+    def test_it_returns_once_the_pull_request_is_merged(self):
+        states = iter([self._pull("OPEN"), self._pull("MERGED")])
+        with (
+            patch.object(
+                release, "_pull_request_for_branch", side_effect=lambda b: next(states)
+            ),
+            patch("time.sleep") as sleep,
+        ):
+            pull = release._wait_for_pull_request_merge("release/2.9.2", poll_seconds=1)
+        self.assertEqual(pull["state"], "MERGED")
+        sleep.assert_called_once_with(1)
+
+    def test_a_closed_pull_request_is_a_refusal_not_a_wait(self):
+        with patch.object(
+            release, "_pull_request_for_branch", return_value=self._pull("CLOSED")
+        ):
+            with self.assertRaisesRegex(release.ReleaseError, "closed without merging"):
+                release._wait_for_pull_request_merge("release/2.9.2")
+
+    def test_a_missing_pull_request_is_named(self):
+        with patch.object(release, "_pull_request_for_branch", return_value=None):
+            with self.assertRaisesRegex(release.ReleaseError, "no pull request"):
+                release._wait_for_pull_request_merge("release/2.9.2")
+
+    def test_the_wait_is_bounded_and_says_how_to_resume(self):
+        with (
+            patch.object(
+                release, "_pull_request_for_branch", return_value=self._pull("OPEN")
+            ),
+            patch("time.sleep"),
+        ):
+            with self.assertRaisesRegex(release.ReleaseError, "resume"):
+                release._wait_for_pull_request_merge(
+                    "release/2.9.2", poll_seconds=1, max_polls=2
+                )
+
+
+class UnattendedFinishTest(unittest.TestCase):
+    """One invocation from the pushed production branch to the anchor."""
+
+    STEP_FUNCTIONS = (
+        "stage_finish",
+        "_wait_for_pull_request_merge",
+        "stage_authorize",
+        "_checkout_merged_main",
+        "stage_anchor",
+    )
+
+    def _patched(self):
+        calls = []
+        patches = {
+            name: patch.object(
+                release,
+                name,
+                side_effect=lambda *a, _n=name, **k: calls.append((_n, a)),
+            )
+            for name in self.STEP_FUNCTIONS
+        }
+        return calls, patches
+
+    def test_the_steps_run_in_release_order(self):
+        calls, patches = self._patched()
+        for patcher in patches.values():
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+        release.stage_finish_unattended("2.9.2")
+
+        self.assertEqual(
+            [name for name, _args in calls],
+            [
+                "stage_finish",
+                "_wait_for_pull_request_merge",
+                "stage_authorize",
+                "stage_finish",
+                "_wait_for_pull_request_merge",
+                "_checkout_merged_main",
+                "stage_finish",
+                "_wait_for_pull_request_merge",
+                "stage_anchor",
+                "_wait_for_pull_request_merge",
+            ],
+        )
+        waited_for = [
+            args[0] for name, args in calls if name == "_wait_for_pull_request_merge"
+        ]
+        self.assertEqual(
+            waited_for,
+            [
+                "release/2.9.2",
+                "release/2.9.2-evidence",
+                "docs/post-release-2.9.2",
+                "chore/anchor-2.9.2",
+            ],
+        )
+
+    def test_a_failure_names_the_step_and_how_to_resume(self):
+        _calls, patches = self._patched()
+        for patcher in patches.values():
+            patcher.start()
+            self.addCleanup(patcher.stop)
+        with patch.object(
+            release, "stage_authorize", side_effect=release.ReleaseError("no record")
+        ):
+            with self.assertRaises(release.ReleaseError) as caught:
+                release.stage_finish_unattended("2.9.2")
+        message = str(caught.exception)
+        self.assertIn("stopped at --authorize", message)
+        self.assertIn("no record", message)
+        self.assertIn("resume", message)
+
+
+class BridgeCommitForTest(unittest.TestCase):
+    def _capture(self, changed):
+        def capture(cmd):
+            if cmd[:2] == ["git", "rev-list"] and "--first-parent" in cmd:
+                return "b" * 40 + "\n" + "c" * 40
+            if cmd[:2] == ["git", "rev-list"]:
+                return "t" * 40
+            if cmd[:2] == ["git", "diff"]:
+                return "\n".join(changed)
+            raise AssertionError(cmd)
+
+        return capture
+
+    def test_the_first_documentation_only_commit_after_the_tag_is_the_bridge(self):
+        with (
+            patch.object(release, "run"),
+            patch.object(
+                release,
+                "_capture",
+                side_effect=self._capture(
+                    ["docs/03_Plans/active/post-release-2.9.2.md"]
+                ),
+            ),
+        ):
+            self.assertEqual(release._bridge_commit_for("v2.9.2"), "b" * 40)
+
+    def test_a_code_commit_in_the_slot_is_refused_by_name(self):
+        with (
+            patch.object(release, "run"),
+            patch.object(
+                release, "_capture", side_effect=self._capture(["scripts/release.py"])
+            ),
+        ):
+            with self.assertRaisesRegex(release.ReleaseError, "documentation-only"):
+                release._bridge_commit_for("v2.9.2")
+
+    def test_nothing_after_the_tag_is_reported_not_guessed(self):
+        def capture(cmd):
+            return ""
+
+        with patch.object(release, "run"), patch.object(release, "_capture", capture):
+            with self.assertRaisesRegex(release.ReleaseError, "nothing has landed"):
+                release._bridge_commit_for("v2.9.2")
+
+
+class StageAnchorTest(unittest.TestCase):
+    """The anchor and the promotion move together, as one reviewed commit."""
+
+    def _run(self, *, failing=None):
+        scratch = tempfile.TemporaryDirectory()
+        self.addCleanup(scratch.cleanup)
+        root = Path(scratch.name)
+        provenance = root / "verify_release_provenance.py"
+        provenance.write_text(
+            'PRIOR_RELEASE_TAG = "v2.9.1"\n'
+            'PRIOR_POST_RELEASE_DOC_COMMIT = "' + "a" * 40 + '"\n',
+            encoding="utf-8",
+        )
+        plan = root / "anchor-2.9.2.md"
+        calls = []
+
+        def run(cmd, **kwargs):
+            calls.append(cmd)
+            if failing and failing in " ".join(cmd):
+                raise release.ReleaseError("release command failed with exit code 1")
+
+        with (
+            patch.object(release, "PROVENANCE", provenance),
+            patch.object(release, "REPO_ROOT", root),
+            patch.object(release, "README_TABLES", ()),
+            patch.object(release, "_bridge_commit_for", return_value="b" * 40),
+            patch.object(release, "_anchor_plan_path", return_value=plan),
+            patch.object(release, "promote_release_tables") as promote,
+            patch.object(release, "_open_pull_request") as open_pull_request,
+            patch.object(release, "_capture", return_value="main"),
+            patch.object(release, "run", side_effect=run),
+        ):
+            try:
+                release.stage_anchor("2.9.2", "v2.9.2")
+            except release.ReleaseError:
+                if not failing:
+                    raise
+        return (
+            provenance.read_text(encoding="utf-8"),
+            plan,
+            calls,
+            promote,
+            open_pull_request,
+        )
+
+    def test_it_advances_both_constants_and_promotes(self):
+        text, plan, calls, promote, open_pull_request = self._run()
+        self.assertIn('PRIOR_RELEASE_TAG = "v2.9.2"', text)
+        self.assertIn('PRIOR_POST_RELEASE_DOC_COMMIT = "' + "b" * 40 + '"', text)
+        promote.assert_called_once_with("2.9.2")
+        open_pull_request.assert_called_once()
+        joined = [" ".join(call) for call in calls]
+        self.assertIn("git checkout -B chore/anchor-2.9.2 origin/main", joined)
+        commit = next(i for i, c in enumerate(joined) if "git commit" in c)
+        harness = next(i for i, c in enumerate(joined) if "check_harness.py" in c)
+        push = next(i for i, c in enumerate(joined) if c.startswith("git push"))
+        self.assertLess(commit, harness)
+        self.assertLess(harness, push)
+        self.assertEqual(joined[-1], "git checkout --force main")
+
+    def test_the_generated_plan_carries_the_harness_headings(self):
+        _text, plan, _calls, _promote, _open = self._run()
+        text = plan.read_text(encoding="utf-8")
+        for heading in (
+            "## Goal",
+            "## Constraints",
+            "## Touched Surfaces",
+            "## Approach",
+            "## Validation",
+            "## Rollback",
+            "## Decision Log",
+        ):
+            self.assertIn(heading, text)
+        self.assertIn("b" * 40, text)
+
+    def test_a_failed_stage_deletes_the_branch_it_made(self):
+        _text, _plan, calls, _promote, open_pull_request = self._run(
+            failing="check_harness.py"
+        )
+        joined = [" ".join(call) for call in calls]
+        self.assertIn("git branch -D chore/anchor-2.9.2", joined)
+        open_pull_request.assert_not_called()
+
+
+class StageAuthorizeTest(unittest.TestCase):
+    def _run(self, *, existing_section=False):
+        scratch = tempfile.TemporaryDirectory()
+        self.addCleanup(scratch.cleanup)
+        root = Path(scratch.name)
+        plan = root / "2026-09-02-release-2.9.2.md"
+        plan.write_text(
+            "# Release 2.9.2\n\n## Goal\n\nShip.\n"
+            + ("\n## Release Authorization\n" if existing_section else ""),
+            encoding="utf-8",
+        )
+        calls = []
+        with (
+            patch.object(release, "REPO_ROOT", root),
+            patch.object(
+                release,
+                "read_evidence_record",
+                return_value=RenderReleaseAuthorizationTest()._record(),
+            ),
+            patch.object(release, "_checkout_merged_main", return_value="e" * 40),
+            patch.object(release, "_release_plan_path", return_value=plan),
+            patch.object(
+                release, "run", side_effect=lambda cmd, **k: calls.append(cmd)
+            ),
+        ):
+            release.stage_authorize("2.9.2")
+        return plan.read_text(encoding="utf-8"), calls
+
+    def test_it_appends_the_rendered_section_on_the_evidence_branch(self):
+        text, calls = self._run()
+        self.assertIn("## Release Authorization", text)
+        self.assertIn("- Evidence base commit: `" + "e" * 40 + "`", text)
+        joined = [" ".join(call) for call in calls]
+        self.assertIn("git checkout -B release/2.9.2-evidence origin/main", joined)
+        self.assertTrue(any("release: authorize v2.9.2" in c for c in joined))
+        self.assertTrue(any("check_release_authorization.py" in c for c in joined))
+
+    def test_it_refuses_to_authorize_twice(self):
+        with self.assertRaisesRegex(release.ReleaseError, "already carries"):
+            self._run(existing_section=True)

--- a/scripts/tests/test_release_authorization.py
+++ b/scripts/tests/test_release_authorization.py
@@ -318,11 +318,34 @@ class ReleaseAuthorizationTest(unittest.TestCase):
                 self._plan(evidence_overrides={"final-tree-full-gate": evidence})
             )
 
-    def test_still_requires_the_url_pair_for_ui_validation(self):
-        # Playwright has to be told where to connect, so an absent pair there
-        # means the cited run was not the run being described.
+    def test_ui_validation_no_longer_demands_the_url_pair(self):
+        # The rule required naming two variables `invoke playwright-test` never
+        # reads - it picks its own loopback port and sets NETBOX_URL itself -
+        # so a truthful evidence line could not satisfy it.
         evidence = self.VALID_EVIDENCE["ui-validation"].replace(
             "FORWARD_NETBOX_HOST_PORT=18081 NETBOX_URL=http://127.0.0.1:18081 ", ""
+        )
+        # Optional ids are validated when recorded and rejected with
+        # `placeholder_evidence`; acceptance is the absence of that refusal.
+        result = release_authorization.check_release_authorization(
+            self._plan(evidence_overrides={"ui-validation": evidence})
+        )
+        self.assertTrue(result["authorized_evidence_ids"])
+
+    def test_ui_validation_accepts_the_port_the_task_actually_reads(self):
+        evidence = self.VALID_EVIDENCE["ui-validation"].replace(
+            "FORWARD_NETBOX_HOST_PORT=18081 NETBOX_URL=http://127.0.0.1:18081 ",
+            "FORWARD_NETBOX_PLAYWRIGHT_HOST_PORT=18081 ",
+        )
+        result = release_authorization.check_release_authorization(
+            self._plan(evidence_overrides={"ui-validation": evidence})
+        )
+        self.assertTrue(result["authorized_evidence_ids"])
+
+    def test_ui_validation_still_bounds_the_playwright_port(self):
+        evidence = self.VALID_EVIDENCE["ui-validation"].replace(
+            "FORWARD_NETBOX_HOST_PORT=18081 NETBOX_URL=http://127.0.0.1:18081 ",
+            "FORWARD_NETBOX_PLAYWRIGHT_HOST_PORT=99999 ",
         )
         with self.assertRaisesRegex(ValueError, "placeholder_evidence"):
             release_authorization.check_release_authorization(

--- a/scripts/tests/test_release_flow_post_release.py
+++ b/scripts/tests/test_release_flow_post_release.py
@@ -25,19 +25,46 @@ class NextPatchVersionTest(unittest.TestCase):
 
 
 class StagePostReleaseTest(unittest.TestCase):
-    def _run(self):
+    def _run(self, *, failing=None):
         calls = []
+
+        def run(cmd, **kwargs):
+            calls.append(cmd)
+            if failing and failing in " ".join(cmd):
+                raise release.ReleaseError("release command failed with exit code 1")
+
         with tempfile.TemporaryDirectory() as scratch:
             plan_path = pathlib.Path(scratch) / "post-release-2.7.0.md"
             with (
-                patch.object(
-                    release, "run", side_effect=lambda cmd, **kw: calls.append(cmd)
-                ),
+                patch.object(release, "run", side_effect=run),
                 patch.object(release, "_bridge_plan_path", return_value=plan_path),
+                patch.object(release, "_open_pull_request") as open_pull_request,
             ):
-                release.stage_post_release("2.7.0", "v2.7.0")
+                try:
+                    release.stage_post_release("2.7.0", "v2.7.0")
+                except release.ReleaseError:
+                    if not failing:
+                        raise
             written = plan_path.read_text(encoding="utf-8")
+        self.open_pull_request = open_pull_request
         return calls, written
+
+    def test_it_opens_the_bridge_pull_request_itself(self):
+        # The old version pushed and printed "merge that pull request" without
+        # opening one, so an unattended run could never get past this step.
+        self._run()
+        self.open_pull_request.assert_called_once()
+        self.assertEqual(
+            self.open_pull_request.call_args.args[0], "docs/post-release-2.7.0"
+        )
+
+    def test_a_failed_stage_deletes_the_branch_it_made(self):
+        # Leaving the branch behind is how v2.8.3's bridge slot was lost: the
+        # next `git checkout -b` inherited a commit nobody meant to keep.
+        calls, _written = self._run(failing="check_harness.py")
+        joined = [" ".join(call) for call in calls]
+        self.assertIn("git branch -D docs/post-release-2.7.0", joined)
+        self.open_pull_request.assert_not_called()
 
     def test_it_writes_the_bridge_plan(self):
         _calls, written = self._run()
@@ -72,6 +99,7 @@ class StagePostReleaseTest(unittest.TestCase):
             with (
                 patch.object(release, "run"),
                 patch.object(release, "_bridge_plan_path", return_value=plan_path),
+                patch.object(release, "_open_pull_request"),
                 patch("builtins.print") as printed,
             ):
                 release.stage_post_release("2.7.0", "v2.7.0")
@@ -80,7 +108,7 @@ class StagePostReleaseTest(unittest.TestCase):
         )
         self.assertIn("PRIOR_RELEASE_TAG", text)
         self.assertIn("PRIOR_POST_RELEASE_DOC_COMMIT", text)
-        self.assertIn("v2.7.0..origin/main", text)
+        self.assertIn("release.py 2.7.0 --anchor", text)
 
 
 class PostReleaseOpensTheBridgeTest(unittest.TestCase):
@@ -107,10 +135,11 @@ class PostReleaseOpensTheBridgeTest(unittest.TestCase):
             "released version, and the bump used to poison the bridge slot",
         )
 
-    def test_open_next_still_exists_for_a_deliberate_caller(self):
-        # Narrowed, not removed: it documents a real incident about the window
-        # between the release PR merging and the tag existing.
-        self.assertTrue(callable(release.stage_open_next))
+    def test_open_next_is_gone(self):
+        # It documented a real incident and was the wrong remedy for it: a dev
+        # marker on `main` offered source installs a version that was never
+        # gated, tagged or published. The decision is recorded on the stage.
+        self.assertFalse(hasattr(release, "stage_open_next"))
 
     def test_the_commit_carries_exactly_one_plan_file(self):
         source = inspect.getsource(release.stage_post_release)

--- a/scripts/tests/test_release_lineage.py
+++ b/scripts/tests/test_release_lineage.py
@@ -6,7 +6,7 @@
 # a release author gets wrong by squashing the production content into the
 # release commit.
 import sys
-import unittest
+import unittest.mock
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -42,9 +42,18 @@ class ReleaseLineageTest(unittest.TestCase):
         self._patch(provenance, "_git_capture", lambda *args: self.release)
         self._patch(provenance, "_require_release_plan", lambda *a, **k: "plan.md")
         self._patch(provenance, "_require_security_bootstrap", lambda commit: None)
+        self._patch(
+            check_release_lineage,
+            "check_sensitive_surfaces",
+            lambda: {"surfaces": list(check_release_lineage.SENSITIVE_SURFACES)},
+        )
 
     def _patch(self, module, name, value):
-        self._patched[(module, name)] = getattr(module, name)
+        # The FIRST saved value is the original. Patching the same attribute
+        # twice in one test used to overwrite the saved original with the
+        # earlier stub, and tearDown then restored the stub - which leaked into
+        # every later test in the process.
+        self._patched.setdefault((module, name), getattr(module, name))
         setattr(module, name, value)
 
     def tearDown(self):
@@ -102,6 +111,74 @@ class ReleaseLineageTest(unittest.TestCase):
         self.assertTrue(
             any("pull request" in item for item in result["not_checked_here"])
         )
+
+    def test_it_reports_every_sensitive_surface_it_scanned(self):
+        # Four surfaces: tree, protected history, ref names, tag names. A
+        # review that reported "clean" while covering one of them let a stale
+        # remote-tracking ref refuse a tag after two clean tree reviews.
+        self._lineage([self.bridge, self.control, self.production, self.release])
+
+        result = check_release_lineage.check_release_lineage(self.release, "2.7.11")
+
+        self.assertEqual(
+            result["sensitive_surfaces"]["surfaces"],
+            ["tracked files", "protected history", "ref names", "tag names"],
+        )
+
+    def test_a_sensitive_refusal_stops_the_lineage_check(self):
+        self._lineage([self.bridge, self.control, self.production, self.release])
+
+        def refuse():
+            raise check_release_lineage.LineageError(
+                "the sensitive-content gate refused"
+            )
+
+        self._patch(check_release_lineage, "check_sensitive_surfaces", refuse)
+        with self.assertRaisesRegex(check_release_lineage.LineageError, "refused"):
+            check_release_lineage.check_release_lineage(self.release, "2.7.11")
+
+
+class SensitiveSurfacesTest(unittest.TestCase):
+    def test_every_ref_and_tag_name_is_handed_to_the_scanner(self):
+        names = ["main", "origin/main", "v2.9.1", "origin/feature/old-customer-name"]
+        with (
+            unittest.mock.patch.object(
+                check_release_lineage, "_ref_names", return_value=names
+            ),
+            unittest.mock.patch.object(
+                check_release_lineage.subprocess,
+                "run",
+                return_value=unittest.mock.Mock(returncode=0, stdout="", stderr=""),
+            ) as run,
+        ):
+            result = check_release_lineage.check_sensitive_surfaces()
+        command = run.call_args.args[0]
+        self.assertIn("--git-files", command)
+        self.assertIn("--protected-history", command)
+        for name in names:
+            self.assertIn(name, command)
+        self.assertEqual(command.count("--ref-name"), len(names))
+        self.assertEqual(result["ref_names_scanned"], len(names))
+
+    def test_a_refusal_names_the_surfaces_that_were_looked_at(self):
+        with (
+            unittest.mock.patch.object(
+                check_release_lineage, "_ref_names", return_value=[]
+            ),
+            unittest.mock.patch.object(
+                check_release_lineage.subprocess,
+                "run",
+                return_value=unittest.mock.Mock(
+                    returncode=1, stdout="", stderr="opaque match in ref name"
+                ),
+            ),
+        ):
+            with self.assertRaises(check_release_lineage.LineageError) as caught:
+                check_release_lineage.check_sensitive_surfaces()
+        message = str(caught.exception)
+        self.assertIn("opaque match in ref name", message)
+        for surface in check_release_lineage.SENSITIVE_SURFACES:
+            self.assertIn(surface, message)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_release_preflight.py
+++ b/scripts/tests/test_release_preflight.py
@@ -306,6 +306,111 @@ def _dependabot_alert(*, ghsa, severity, package="sqlparse"):
     }
 
 
+class DependencyAdvisoryAuditTest(unittest.TestCase):
+    """Both requirement files are audited, and the report names both.
+
+    `requirements-release.txt` is what the publish workflow installs with
+    `--require-hashes`, and nothing audited it: an advisory against the
+    controller's own toolchain would fail the job after the tag existed.
+    """
+
+    def _completed(self, returncode=0, stdout=""):
+        completed = mock.Mock()
+        completed.returncode = returncode
+        completed.stdout = stdout
+        completed.stderr = ""
+        return completed
+
+    def test_both_files_are_audited_with_the_same_waivers(self):
+        with (
+            mock.patch.object(
+                preflight.shutil, "which", return_value="/usr/bin/pip-audit"
+            ),
+            mock.patch.object(
+                preflight.subprocess, "run", return_value=self._completed()
+            ) as run,
+        ):
+            result = preflight.check_dependency_advisories()
+        audited = [
+            call.args[0][call.args[0].index("-r") + 1] for call in run.call_args_list
+        ]
+        self.assertEqual(
+            audited, [str(preflight.CONSTRAINTS), str(preflight.RELEASE_TOOLCHAIN)]
+        )
+        for call in run.call_args_list:
+            for vuln_id in preflight.ACCEPTED_DEPENDENCY_ADVISORIES:
+                self.assertIn(vuln_id, call.args[0])
+        self.assertIn("constraints.txt and requirements-release.txt", result)
+
+    def test_an_advisory_in_the_toolchain_names_the_file(self):
+        outcomes = iter([self._completed(), self._completed(1, "pip 26.1.2 GHSA-x")])
+        with (
+            mock.patch.object(
+                preflight.shutil, "which", return_value="/usr/bin/pip-audit"
+            ),
+            mock.patch.object(
+                preflight.subprocess, "run", side_effect=lambda *a, **k: next(outcomes)
+            ),
+        ):
+            with self.assertRaises(preflight.PreflightError) as caught:
+                preflight.check_dependency_advisories()
+        self.assertIn("requirements-release.txt", str(caught.exception))
+        self.assertIn("GHSA-x", str(caught.exception))
+
+
+class LockfileConsistencyTest(unittest.TestCase):
+    """`poetry.lock` described a runtime three releases stale and nothing read
+    it. This is the reader."""
+
+    def test_a_missing_poetry_fails_closed_with_the_remedy(self):
+        with mock.patch.object(preflight.shutil, "which", return_value=None):
+            with self.assertRaisesRegex(
+                preflight.PreflightError, "poetry is not installed"
+            ):
+                preflight.check_lockfile_consistency()
+
+    def test_a_stale_lockfile_is_refused_and_names_the_fix(self):
+        completed = mock.Mock(returncode=1, stdout="", stderr="pyproject.toml changed")
+        with (
+            mock.patch.object(
+                preflight.shutil, "which", return_value="/usr/bin/poetry"
+            ),
+            mock.patch.object(preflight.subprocess, "run", return_value=completed),
+        ):
+            with self.assertRaises(preflight.PreflightError) as caught:
+                preflight.check_lockfile_consistency()
+        self.assertIn("poetry lock", str(caught.exception))
+        self.assertIn("pyproject.toml changed", str(caught.exception))
+
+    def test_a_consistent_lockfile_passes(self):
+        completed = mock.Mock(returncode=0, stdout="", stderr="")
+        with (
+            mock.patch.object(
+                preflight.shutil, "which", return_value="/usr/bin/poetry"
+            ),
+            mock.patch.object(
+                preflight.subprocess, "run", return_value=completed
+            ) as run,
+        ):
+            result = preflight.check_lockfile_consistency()
+        self.assertEqual(result, "poetry.lock matches pyproject.toml")
+        self.assertEqual(run.call_args.args[0][1:], ["check", "--lock"])
+
+    def test_the_report_carries_the_lockfile_line(self):
+        lines = preflight._report_lines(
+            "2.9.2",
+            "deps",
+            "no advisories",
+            "no alerts",
+            "ok",
+            "verified",
+            "poetry.lock matches pyproject.toml",
+        )
+        self.assertIn(
+            "release preflight passed: poetry.lock matches pyproject.toml", lines
+        )
+
+
 class DependabotAlertsTest(unittest.TestCase):
     """Pins the gap `constraints.txt`-only `pip-audit` cannot see: a
     transitive dependency's advisory (the real sqlparse alerts Dependabot

--- a/scripts/validate_installed_routes.py
+++ b/scripts/validate_installed_routes.py
@@ -88,13 +88,13 @@ def main():
         policy=policy,
         snapshot_id="artifact-route-smoke",
     )
-    ForwardIngestion.objects.create(
+    ingestion = ForwardIngestion.objects.create(
         sync=sync,
         validation_run=validation_run,
         snapshot_id="artifact-route-smoke",
         baseline_ready=True,
     )
-    ForwardNQEMap.objects.create(
+    nqe_map = ForwardNQEMap.objects.create(
         name="Artifact route smoke map",
         netbox_model=ContentType.objects.get(app_label="dcim", model="device"),
         query_id="artifact-route-smoke-query",
@@ -122,7 +122,7 @@ def main():
         role=device_role,
         site=site,
     )
-    ForwardDeviceAnalysis.objects.create(
+    analysis = ForwardDeviceAnalysis.objects.create(
         sync=sync,
         device=device,
         snapshot_id="artifact-route-smoke",
@@ -144,7 +144,70 @@ def main():
             )
         rendered.append({"route": route_name, "status_code": response.status_code})
 
-    print(json.dumps({"installed_menu_routes": rendered}, sort_keys=True))
+    # Every registered detail-scoped view, not only the menu lists. The
+    # ingestion-issue list route was registered against a view that did not
+    # exist and no menu led to it, so the menu probe reported the artifact
+    # clean while a click from the ingestion page raised. Enumerating the URL
+    # resolver catches that class at the artifact rather than in a customer's
+    # browser. A GET refused with 405 is a POST-only action, and a 302 is an
+    # action view bouncing back to its object with a message; both count as
+    # registered. Anything else must render.
+    fixtures = {
+        "forwardsource": source.pk,
+        "forwardsync": sync.pk,
+        "forwardingestion": ingestion.pk,
+        "forwardvalidationrun": validation_run.pk,
+        "forwarddeviceanalysis": analysis.pk,
+        "forwardnqemap": nqe_map.pk,
+        "forwarddriftpolicy": policy.pk,
+    }
+    detail = []
+    for route_name, pk in _detail_routes(fixtures):
+        url = reverse(route_name, kwargs={"pk": pk})
+        response = client.get(url)
+        if response.status_code not in (200, 302, 405):
+            raise SystemExit(
+                f"installed detail route {route_name} returned HTTP "
+                f"{response.status_code}"
+            )
+        detail.append({"route": route_name, "status_code": response.status_code})
+
+    print(
+        json.dumps(
+            {"installed_menu_routes": rendered, "installed_detail_routes": detail},
+            sort_keys=True,
+        )
+    )
+
+
+def _detail_routes(fixtures):
+    """Every `plugins:forward_netbox:<model>*` route that takes exactly a pk.
+
+    Namespaced names are not in the root resolver's `reverse_dict`; they live
+    in the nested resolver two namespaces down, keyed by their short name.
+    """
+    from django.urls import get_resolver
+
+    _prefix, plugins = get_resolver().namespace_dict["plugins"]
+    _prefix, plugin = plugins.namespace_dict["forward_netbox"]
+    routes = set()
+    for short in plugin.reverse_dict:
+        if not isinstance(short, str):
+            continue
+        model = next(
+            (candidate for candidate in fixtures if short.startswith(candidate)), None
+        )
+        if model is None:
+            continue
+        for (
+            possibilities,
+            _pattern,
+            _defaults,
+            _converters,
+        ) in plugin.reverse_dict.getlist(short):
+            if any(set(params) == {"pk"} for _result, params in possibilities):
+                routes.add((f"plugins:forward_netbox:{short}", fixtures[model]))
+    return sorted(routes)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Every release since 2.7.13 has needed hand work after the tag and recorded the same open items. This lands first in the 2.9.2 cycle so 2.9.2 itself is the integration test.

**Decided:** `main` carries the released version. `--open-next` / `stage_open_next` are deleted, not narrowed — a dev marker on `main` offered source installs a version nobody had gated, and the window it described is minutes wide. Six plans had this as undecided; `2026-08-18-no-dev0-on-main.md` now records the decision.

**Promotion moves to the anchor commit.** `--finish` committed `release: promote` on the release branch before the tag; the harness refused it by construction on every release since 2.8.6 (the anchor must name the release the table calls current, and cannot move until the bridge exists, which cannot exist until the tag does). `stage_anchor` now derives the bridge from the tag (`rev-list --first-parent --reverse <tag>..origin/main`, checked documentation-only), advances both constants, promotes the tables, regenerates the changelog, writes its plan, and opens the PR — one commit.

**The authorization is rendered, not typed.** `stage_verify` tees both gate commands to logs and records the exact `rtk env … invoke` forms, exit statuses, `Ran N tests` lines and declared runtime versions. `stage_authorize` renders the Release Authorization from that after the production PR merges (when the evidence base commit is knowable). Tested against `check_release_authorization._evidence_is_concrete` for every required id — the checker is not relaxed.

**`--auto-finish` is one invocation:** production PR → wait merge → authorize → evidence PR → wait merge → tag → bridge PR → wait merge → anchor PR → wait merge. Every step is also a flag (`--authorize`, `--post-release`, `--anchor`), and a failure names which one to resume with.

Also:
- `check_release_lineage.py` runs the sensitive gate over **all four** surfaces it reads (tree, protected history, ref names, tag names) and says which — a stale remote-tracking ref refused a tag after two clean tree reviews.
- Preflight audits `requirements-release.txt` alongside `constraints.txt` (nothing audited the controller's own toolchain), and `poetry check --lock` so the lockfile cannot drift silently for another three releases.
- `ui-validation` evidence accepts what `invoke playwright-test` actually reads (`FORWARD_NETBOX_PLAYWRIGHT_HOST_PORT`, optional) instead of two variables it never reads.
- `validate_installed_routes.py` probes every registered pk-scoped route from the resolver (57 on the dev stack), not only menu lists.
- `stage_post_release` opens its own PR and deletes its branch on failure (how v2.8.3's bridge slot was lost).

Three survey items were already closed on `main` and are recorded as such rather than re-opened: `_github_json` retry/keep-alive, skipped preflight checks printing `skipped`, and the release command not reporting a published release as failed.

## Validation

`invoke harness-test` **375 OK** (was 334) · `invoke harness-check` ✓ · pre-commit ✓ · `_detail_routes` enumerated 57 routes on the dev stack, all reversible.

Plan: `docs/03_Plans/active/2026-09-02-release-tooling.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa