### PR TITLE
feat: measure drift for cables, and fix a latent preview-runner defect

### DIFF
--- a/docs/03_Plans/active/2026-08-24-adapter-model-drift-cable.md
+++ b/docs/03_Plans/active/2026-08-24-adapter-model-drift-cable.md
@@ -1,0 +1,133 @@
+# Measure drift for cables
+
+## Goal
+
+Slice two of the adapter-only drift comparison begun in
+`2026-08-24-adapter-model-drift-taggeditem.md`: `dcim.cable`.
+
+## Why
+
+Same as slice one. Every adapter-only model reports a workload upper bound, so
+`in_sync` is unanswerable while any of the eight remains uncompared. Cables are
+the second smallest and the natural next step: single phase, no recursive
+`_ensure_*` chain, and thirteen existing regression tests around the apply.
+
+## Constraints
+
+- Reuse the apply's own resolution; do not reimplement the comparison.
+- The preview must write nothing - and for cables that means NetBox core's
+  writes too, not just this module's.
+- A row the apply refuses must not be counted as drift.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/sync_cable.py` - `apply_dcim_cable` gains
+  `preview`
+- `forward_netbox/utilities/drift_comparison.py` - the shared adapter loop,
+  the cable comparison, three missing runner shims, and one shim defect fixed
+- `forward_netbox/tests/test_cable_drift_comparison.py` (new)
+
+## Approach
+
+### A latent defect in the preview runner, found before it could bite
+
+`PreviewRunner` seeded `self._conflict_policy = {}` - a dict. On the real
+runner `_conflict_policy` is a METHOD (`sync_runner_contracts.py:50`), and
+every caller invokes it. Nothing reads the dict form, so the mistake was
+invisible: the bulk paths write through `bulk_create` and never ask for a
+policy.
+
+Every adapter model writes through `coalesce_upsert`, which asks on every row.
+The first adapter model to reach it would have died on
+`TypeError: 'dict' object is not callable`. It is now a method reading the
+same `MODEL_CONFLICT_POLICIES` table the apply reads - not a local default,
+because the policy decides whether a conflicting row is skipped or raises, and
+a preview that disagreed about that would classify a row the apply refuses as
+one it would write.
+
+This is the same class of finding as `_ensure_vrf` in the bulk work: a
+mismatch between preview and apply that no grep would surface, found only by
+reading what the path actually calls.
+
+### The writes are direct, so the firewall does not help
+
+Tagged items had one write behind a `runner.` call and one M2M write outside
+it. Cables have neither shape: `cable.save()` for a status change and
+`Cable(...).save()` for a new cable are both direct, and `Cable.save()`
+additionally makes NetBox core persist the two `CableTermination` rows that
+are the durable relationship (the `Interface.cable` cache is not, per this
+module's own note about Branching).
+
+So the preview returns at three points, each before its write. The create
+return is placed before `Cable(...)` is even constructed, and the test asserts
+on `CableTermination` count rather than only `Cable` count - so a return
+placed one line later would fail.
+
+### The refusals are the interesting half
+
+Two rows the apply declines:
+
+- a LAG endpoint, because NetBox does not allow a cable terminated directly to
+  a LAG;
+- an interface already cabled to something else, which under the default
+  `strict` policy raises and under `skip_warn_aggregate` warns and skips.
+
+Counting either as a create would report drift that no apply could ever
+resolve - the report would show a permanent non-zero that re-running never
+clears, which is the "re-running cannot change this" complaint that opened
+#206 in the first place, wearing different clothes. Both count as `rejected`.
+
+### The loop is now shared
+
+`_compare_adapter_rows` takes the apply function and does the iteration,
+exception handling and tallying. Both adapter models use it, and the remaining
+six will. It treats a `False`/`None` return - the apply functions' own "I
+declined this row" answer - as rejected, and refuses the whole model on an
+outcome it does not recognise rather than defaulting it to `unchanged`.
+
+## Validation
+
+13 tests. Both writes were proven guarded by their own negative control, run
+separately:
+
+- Removing the create guard failed
+  `test_a_preview_creates_no_cable_and_no_terminations` and
+  `test_an_uncabled_pair_is_a_create`.
+- Removing the update guard failed
+  `test_a_preview_does_not_rewrite_a_drifted_status` and
+  `test_a_cable_whose_status_drifted_is_an_update`.
+
+Two parity tests apply for real afterwards and assert the preview predicted
+the write count.
+
+Full run: 313 tests green across both adapter suites, the bulk drift suite,
+the preview contract and priming suites, and `ForwardSyncRunnerTest`.
+
+## Rollback
+
+Remove `dcim.cable` from `_ADAPTER_COMPARISONS`; it returns to an upper bound.
+`preview` defaults to `False`, so every existing caller is unchanged. The
+`_conflict_policy` fix is not part of that rollback and should stay - it
+corrects the shim regardless of which models are wired up.
+
+## Decision Log
+
+- **Read `MODEL_CONFLICT_POLICIES` rather than defaulting to `strict` in the
+  shim.** A local default would have been simpler and would have made the
+  preview disagree with the apply for exactly the models that configure a
+  policy.
+- **Assert on `CableTermination`, not just `Cable`.** The termination rows are
+  what NetBox core writes inside `save()`, and they are the assertion that
+  catches a guard placed too late.
+- **Refusals count as `rejected`, not `creates`.** A permanent non-zero drift
+  figure that re-running cannot clear is the original #206 complaint.
+
+## Open
+
+- Six models remain: inventory items, FHRP groups, lifecycle (netbox-dlm),
+  modules, peering, routing.
+- Modules will need the same care as cables and more: `Module.save()` with
+  `_adopt_components` makes NetBox core instantiate component rows, and the
+  path writes Manufacturer, ModuleType and ModuleBay beneath it.
+- Routing and peering last, and together: peering is 30 lines but calls
+  `_ensure_netbox_routing_bgppeer` first, inheriting a 7-deep write chain.

--- a/forward_netbox/tests/test_cable_drift_comparison.py
+++ b/forward_netbox/tests/test_cable_drift_comparison.py
@@ -1,0 +1,290 @@
+# Slice two of the adapter-only drift comparison: `dcim.cable`.
+#
+# Cables differ from tagged items in where the writes live. Both of this path's
+# writes are DIRECT - `cable.save()` for a status change, `Cable(...).save()`
+# for a new one - so the preview runner's firewall covers neither, and
+# `Cable.save()` additionally makes NetBox core persist the two
+# `CableTermination` rows that are the durable relationship.
+#
+# The refusals carry as much weight as the writes here. A LAG endpoint and an
+# already-cabled interface are rows the apply declines to write; counting
+# either as a create would report drift that no apply would ever resolve, so
+# the report would never converge.
+from dcim.models import Cable
+from dcim.models import CableTermination
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import Interface
+from dcim.models import Manufacturer
+from dcim.models import Site
+from django.test import TestCase
+
+from forward_netbox.utilities.drift_comparison import compare_model_rows
+
+
+class CablePreviewTest(TestCase):
+    def setUp(self):
+        site = Site.objects.create(name="C Site", slug="c-site")
+        mfr = Manufacturer.objects.create(name="C Mfr", slug="c-mfr")
+        dtype = DeviceType.objects.create(manufacturer=mfr, model="C DT", slug="c-dt")
+        role = DeviceRole.objects.create(name="C Role", slug="c-role")
+        self.left = Device.objects.create(
+            name="left-dev", site=site, device_type=dtype, role=role, status="active"
+        )
+        self.right = Device.objects.create(
+            name="right-dev", site=site, device_type=dtype, role=role, status="active"
+        )
+        self.left_if = Interface.objects.create(
+            device=self.left, name="Ethernet1", type="1000base-t"
+        )
+        self.right_if = Interface.objects.create(
+            device=self.right, name="Ethernet1", type="1000base-t"
+        )
+
+    def _row(self, **extra):
+        row = {
+            "device": "left-dev",
+            "interface": "Ethernet1",
+            "remote_device": "right-dev",
+            "remote_interface": "Ethernet1",
+            "status": "connected",
+        }
+        row.update(extra)
+        return row
+
+    def _cable_them(self, status="connected"):
+        cable = Cable(
+            a_terminations=[self.left_if],
+            b_terminations=[self.right_if],
+            status=status,
+        )
+        cable.full_clean()
+        cable.save()
+        return cable
+
+    # --- the negative space -------------------------------------------------
+
+    def test_a_preview_creates_no_cable_and_no_terminations(self):
+        cables_before = Cable.objects.count()
+        terminations_before = CableTermination.objects.count()
+
+        result = compare_model_rows(None, "dcim.cable", [self._row()])
+
+        self.assertEqual(Cable.objects.count(), cables_before)
+        # The terminations are what NetBox core writes inside `Cable.save()`,
+        # so they are the assertion that a "return before the save" would have
+        # been insufficient if the return had been placed one line later.
+        self.assertEqual(CableTermination.objects.count(), terminations_before)
+        self.assertEqual(result["creates"], 1)
+
+    def test_a_preview_does_not_rewrite_a_drifted_status(self):
+        cable = self._cable_them(status="planned")
+
+        result = compare_model_rows(None, "dcim.cable", [self._row()])
+
+        cable.refresh_from_db()
+        self.assertEqual(cable.status, "planned")
+        self.assertEqual(result["updates"], 1)
+
+    def test_a_preview_deletes_no_cable(self):
+        self._cable_them()
+        cables_before = Cable.objects.count()
+
+        compare_model_rows(None, "dcim.cable", [self._row()])
+
+        self.assertEqual(Cable.objects.count(), cables_before)
+
+    # --- classification -----------------------------------------------------
+
+    def test_an_uncabled_pair_is_a_create(self):
+        result = compare_model_rows(None, "dcim.cable", [self._row()])
+
+        self.assertEqual(
+            result, {"creates": 1, "updates": 0, "unchanged": 0, "rejected": 0}
+        )
+
+    def test_a_matching_cable_is_unchanged(self):
+        self._cable_them(status="connected")
+
+        result = compare_model_rows(None, "dcim.cable", [self._row()])
+
+        self.assertEqual(
+            result, {"creates": 0, "updates": 0, "unchanged": 1, "rejected": 0}
+        )
+
+    def test_a_cable_whose_status_drifted_is_an_update(self):
+        self._cable_them(status="planned")
+
+        result = compare_model_rows(None, "dcim.cable", [self._row()])
+
+        self.assertEqual(
+            result, {"creates": 0, "updates": 1, "unchanged": 0, "rejected": 0}
+        )
+
+    # --- the refusals, which must not read as drift -------------------------
+
+    def test_a_lag_endpoint_is_rejected_not_a_create(self):
+        # NetBox refuses cables terminated directly to a LAG, so the apply
+        # declines the row. Counting it as a create would report drift that no
+        # run could ever clear.
+        self.left_if.type = "lag"
+        self.left_if.save()
+
+        result = compare_model_rows(None, "dcim.cable", [self._row()])
+
+        self.assertEqual(result["creates"], 0)
+        self.assertEqual(result["rejected"], 1)
+
+    def test_an_already_cabled_interface_is_rejected_not_a_create(self):
+        # The near interface is cabled to a THIRD interface, so the row's pair
+        # is not connected and never will be while that cable stands.
+        other = Interface.objects.create(
+            device=self.right, name="Ethernet99", type="1000base-t"
+        )
+        cable = Cable(
+            a_terminations=[self.left_if],
+            b_terminations=[other],
+            status="connected",
+        )
+        cable.full_clean()
+        cable.save()
+        cables_before = Cable.objects.count()
+
+        result = compare_model_rows(None, "dcim.cable", [self._row()])
+
+        self.assertEqual(Cable.objects.count(), cables_before)
+        self.assertEqual(result["creates"], 0)
+        self.assertEqual(result["rejected"], 1)
+
+    def test_an_unknown_device_is_rejected(self):
+        result = compare_model_rows(
+            None, "dcim.cable", [self._row(remote_device="no-such-device")]
+        )
+
+        self.assertEqual(result["rejected"], 1)
+        self.assertEqual(result["creates"], 0)
+
+    def test_an_unknown_interface_is_rejected(self):
+        result = compare_model_rows(
+            None, "dcim.cable", [self._row(remote_interface="Ethernet404")]
+        )
+
+        self.assertEqual(result["rejected"], 1)
+        self.assertEqual(result["creates"], 0)
+
+    def test_a_mixed_batch_is_not_all_or_nothing(self):
+        third = Device.objects.create(
+            name="third-dev",
+            site=self.left.site,
+            device_type=self.left.device_type,
+            role=self.left.role,
+            status="active",
+        )
+        third_if = Interface.objects.create(
+            device=third, name="Ethernet1", type="1000base-t"
+        )
+        cable = Cable(
+            a_terminations=[self.right_if],
+            b_terminations=[third_if],
+            status="connected",
+        )
+        cable.full_clean()
+        cable.save()
+
+        result = compare_model_rows(
+            None,
+            "dcim.cable",
+            [
+                # right-dev:Ethernet1 is taken by the cable above.
+                self._row(),
+                self._row(remote_device="no-such-device"),
+            ],
+        )
+
+        self.assertEqual(result["creates"], 0)
+        self.assertEqual(result["rejected"], 2)
+
+    # --- parity with the apply ----------------------------------------------
+
+    def test_the_preview_count_matches_what_an_apply_actually_writes(self):
+        rows = [self._row()]
+
+        predicted = compare_model_rows(None, "dcim.cable", rows)
+
+        before = Cable.objects.count()
+        self._apply_for_real(rows)
+        written = Cable.objects.count() - before
+
+        self.assertEqual(predicted["creates"], written)
+
+    def test_a_second_preview_after_the_apply_reports_no_drift(self):
+        rows = [self._row()]
+        self._apply_for_real(rows)
+
+        result = compare_model_rows(None, "dcim.cable", rows)
+
+        self.assertEqual(result["unchanged"], 1)
+        self.assertEqual(result["creates"], 0)
+
+    def _apply_for_real(self, rows):
+        from forward_netbox.utilities.sync_cable import apply_dcim_cable
+
+        runner = _WritingRunner()
+        for row in rows:
+            apply_dcim_cable(runner, row)
+
+
+class _WritingRunner:
+    """The real primitives, no preview - so the parity tests apply for real."""
+
+    def __init__(self):
+        self._content_types = {}
+        self._device_by_name_cache = {}
+        self._missing_device_by_name_cache = set()
+        self._interface_by_device_name_cache = {}
+        self._interface_canonical_cache = {}
+        self._missing_interface_by_device_name_cache = set()
+        self._unique_lookup_cache = {}
+        self._primed_missing_unique_lookup_keys = set()
+        self._model_coalesce_fields = {}
+        self._cable_between_cache = {}
+        self.logger = _NullLogger()
+
+    def _get_device_by_name(self, name):
+        from forward_netbox.utilities.sync_primitives import get_device_by_name
+
+        return get_device_by_name(self, name)
+
+    def _lookup_interface(self, device, interface_name):
+        from forward_netbox.utilities.sync_primitives import lookup_interface
+
+        return lookup_interface(self, device, interface_name)
+
+    def _get_unique_or_raise(self, model, lookup):
+        from forward_netbox.utilities.sync_primitives import get_unique_or_raise
+
+        return get_unique_or_raise(self, model, lookup)
+
+    def _conflict_policy(self, model_string):
+        return "strict"
+
+    def _dependency_failed(self, model_string, key):
+        return False
+
+    def _record_issue(self, *args, **kwargs):
+        return None
+
+    def _record_aggregated_skip_warning(self, **kwargs):
+        return None
+
+    def _record_aggregated_conflict_warning(self, **kwargs):
+        return None
+
+
+class _NullLogger:
+    def increment_statistics(self, *args, **kwargs):
+        return None
+
+    def log_warning(self, *args, **kwargs):
+        return None

--- a/forward_netbox/utilities/drift_comparison.py
+++ b/forward_netbox/utilities/drift_comparison.py
@@ -96,8 +96,8 @@ class PreviewRunner:
         self._unique_lookup_cache = {}
         self._primed_missing_unique_lookup_keys = set()
         self._model_coalesce_fields = {}
-        self._conflict_policy = {}
         self._device_tag_ids_cache = {}
+        self._cable_between_cache = {}
         self._scope_matched_tags = {}
         self._scope_tag_objs = {}
         self.rejected_rows = 0
@@ -112,6 +112,33 @@ class PreviewRunner:
         # (`context`, `exception`, and more as paths are added), and a preview
         # cares only that a row was unusable - not why, since it files nothing.
         self.rejected_rows += 1
+
+    def _conflict_policy(self, model_string):
+        """The same policy the apply would use for this model.
+
+        This was seeded as an empty DICT, which is what the real runner is not:
+        `sync_runner_contracts` defines it as a method and every caller invokes
+        it. Nothing read the dict form, so the mistake was invisible - the bulk
+        paths write through `bulk_create` and never ask. The adapter models all
+        write through `coalesce_upsert`, which asks on every row, so the first
+        one wired up would have hit `TypeError: 'dict' object is not callable`.
+
+        Read from the real table rather than defaulted here, because the policy
+        decides whether a conflicting row is skipped or raises - and a preview
+        that disagreed with the apply about that would classify a row the apply
+        refuses as one it would write.
+        """
+        from .sync import ForwardSyncRunner
+
+        return ForwardSyncRunner.MODEL_CONFLICT_POLICIES.get(model_string, "strict")
+
+    def _record_aggregated_conflict_warning(self, **kwargs):
+        return None
+
+    def _lookup_device_by_name(self, device_name):
+        from .sync_primitives import lookup_device_by_name
+
+        return lookup_device_by_name(self, device_name)
 
     def _content_type_for(self, model):
         # Read-only: a cached ContentType lookup, which the macaddress path
@@ -298,42 +325,67 @@ class PreviewRunner:
         return None
 
 
-def _compare_extras_taggeditem(runner, rows):
-    """Classify feature-tag assignments one row at a time.
+def _compare_adapter_rows(runner, rows, apply_row):
+    """Classify adapter-only rows one at a time.
 
-    The adapter-only models have no bulk path, so there is nothing to call with
-    ``preview=True`` and return counts from; each row is applied on its own.
-    That makes the loop the caller's job rather than the apply function's, and
-    it is the shape every remaining adapter model will use.
+    The bulk models hand a whole batch to a classifier that returns counts. The
+    adapter models have no batch - each row is applied on its own - so the loop
+    belongs here rather than to any one apply function, and every adapter model
+    shares it.
+
+    ``apply_row`` is called with ``preview=True`` and must return one of the
+    count keys. The apply functions' own "I declined this row" answers -
+    ``False`` for the skip paths, ``None`` where a function falls off its end -
+    are counted as rejected, because a row the apply refuses is not a
+    difference between the two systems and must never be reported as drift the
+    next run would resolve.
     """
     from ..exceptions import ForwardDependencySkipError
     from ..exceptions import ForwardSearchError
-    from .sync_interface import apply_extras_taggeditem
+    from ..exceptions import ForwardSyncDataError
 
     counts = {"creates": 0, "updates": 0, "unchanged": 0, "rejected": 0}
     for row in rows:
         try:
-            outcome = apply_extras_taggeditem(runner, row, preview=True)
-        except (ForwardDependencySkipError, ForwardSearchError):
+            outcome = apply_row(runner, row, preview=True)
+        except (
+            ForwardDependencySkipError,
+            ForwardSearchError,
+            ForwardSyncDataError,
+        ):
             # An unusable row is a defect in the row, not a difference between
             # the two systems, so it is counted apart from drift rather than
-            # inflating it. The apply raises the same pair for a device it
-            # cannot resolve.
+            # inflating it.
             counts["rejected"] += 1
             continue
         except KeyError:
-            # `row["device"]` / `row["tag"]` absent. Same class as above: the
-            # row cannot be applied, and calling that zero drift would be the
+            # A row missing a key the apply indexes directly (`row["device"]`).
+            # Same class as above; calling it zero drift would be the
             # confident-zero failure this feature exists to prevent.
             counts["rejected"] += 1
             continue
+        if outcome is False or outcome is None:
+            counts["rejected"] += 1
+            continue
         if outcome not in counts:
-            # An outcome this function does not recognise must not be silently
+            # An outcome this loop does not recognise must not be silently
             # dropped into "unchanged". Refusing the whole model is the honest
             # answer, and the caller falls back to the upper bound for it.
             return None
         counts[outcome] += 1
     return counts
+
+
+def _compare_extras_taggeditem(runner, rows):
+    from .sync_interface import apply_extras_taggeditem
+
+    return _compare_adapter_rows(runner, rows, apply_extras_taggeditem)
+
+
+def _compare_dcim_cable(runner, rows):
+    from .sync_cable import apply_dcim_cable
+
+    return _compare_adapter_rows(runner, rows, apply_dcim_cable)
 
 
 # Adapter-only models that can be compared, and the function that does it.
@@ -342,9 +394,11 @@ def _compare_extras_taggeditem(runner, rows):
 # what every adapter model gave before this: the caller keeps its upper-bound
 # estimate rather than reporting a zero nothing measured. Adding a model here
 # means auditing its `runner.` calls, not just grepping it for ORM writes - the
-# writes that matter in these paths hide behind `_ensure_*` and `_upsert_*`.
+# writes that matter in these paths hide behind `_ensure_*` and `_upsert_*`,
+# and in `dcim.cable`'s case inside NetBox core's own `Cable.save()`.
 _ADAPTER_COMPARISONS = {
     "extras.taggeditem": _compare_extras_taggeditem,
+    "dcim.cable": _compare_dcim_cable,
 }
 
 

--- a/forward_netbox/utilities/sync_cable.py
+++ b/forward_netbox/utilities/sync_cable.py
@@ -99,7 +99,23 @@ def delete_dcim_cable(runner, row):
     return True
 
 
-def apply_dcim_cable(runner, row):
+def apply_dcim_cable(runner, row, *, preview=False):
+    """Cable the two interfaces, or - with ``preview`` - classify and write.
+
+    ``preview`` returns ``"creates"``, ``"updates"``, ``"unchanged"`` or
+    ``"rejected"`` for the one row and performs neither write.
+
+    Unlike the bulk paths, both writes here are DIRECT - ``cable.save()`` for a
+    status change and ``Cable(...).save()`` for a new one - so the preview
+    runner's firewall does not cover either, and ``Cable.save()`` additionally
+    makes NetBox core persist the ``CableTermination`` rows. A flag is the only
+    way to stop them.
+
+    The refusals matter as much as the writes. A LAG endpoint and an
+    already-cabled interface are both rows the apply declines to write, so a
+    preview must not count either as a create - that would report drift no
+    apply would ever resolve, and it would never converge.
+    """
     from dcim.models import Cable
 
     try:
@@ -206,7 +222,11 @@ def apply_dcim_cable(runner, row):
     cable = lookup_cable_between(runner, interface, remote_interface)
     if cable is not None:
         if str(getattr(cable, "status", "") or "") == str(row["status"]):
-            return cable
+            return "unchanged" if preview else cable
+        if preview:
+            # The cable exists and its status differs, so the apply would
+            # rewrite it. Classified before the save, not after.
+            return "updates"
         cable.status = row["status"]
         cable.full_clean()
         cable.save()
@@ -244,6 +264,12 @@ def apply_dcim_cable(runner, row):
             },
             data=row,
         )
+
+    if preview:
+        # Both interfaces are free and neither is a LAG, so the apply would
+        # create the cable. Returned before `Cable.save()`, which would also
+        # make NetBox core write the two CableTermination rows.
+        return "creates"
 
     cable = Cable(
         a_terminations=[interface],


### PR DESCRIPTION
## Summary

Slice two of eight toward #206's remaining scope. **Stacked on #289** (slice
one, tagged items) — base is `feat/taggeditem-drift-comparison`, so review that
one first; this diff shows only the cable work.

## The writes are direct, so the firewall does not help

Tagged items had one write behind a `runner.` call. Cables have neither shape:
`cable.save()` (status change) and `Cable(...).save()` (new cable) are both
direct, and `Cable.save()` additionally makes NetBox core persist the two
`CableTermination` rows that are the durable relationship.

The preview returns at three points, each before its write. The create return
sits before `Cable(...)` is constructed, and the test asserts on
**`CableTermination` count**, not just `Cable` count — so a guard placed one
line later fails.

## The refusals are the interesting half

A LAG endpoint and an already-cabled interface are rows the apply *declines* to
write. Counting either as a create would report drift no apply could ever
resolve — a permanent non-zero that re-running never clears, which is the
complaint that opened #206 wearing different clothes. Both count as `rejected`.

## A latent preview-runner defect, found by reading rather than by failing

`PreviewRunner` seeded `_conflict_policy` as a **dict**. The real runner
defines it as a **method** (`sync_runner_contracts.py:50`) and every caller
invokes it. Nothing reads the dict form, so it was invisible — the bulk paths
write through `bulk_create` and never ask for a policy.

Every adapter model writes through `coalesce_upsert`, which asks on every row,
so the first one wired up would have died on
`TypeError: 'dict' object is not callable`. It now reads the same
`MODEL_CONFLICT_POLICIES` table the apply reads — not a local default, because
the policy decides whether a conflicting row is skipped or raises, and a
preview that disagreed would classify a row the apply refuses as one it would
write. Same class of finding as `_ensure_vrf` in the bulk work.

## Test plan

- [x] 13 new tests; **313 green** across both adapter suites, the bulk drift
      suite, the preview contract and priming suites, and `ForwardSyncRunnerTest`
- [x] pre-commit clean; `check_harness.py --base origin/main` passes
- [x] **Negative controls run separately, per write:** removing the create
      guard failed `test_a_preview_creates_no_cable_and_no_terminations` and
      `test_an_uncabled_pair_is_a_create`; removing the update guard failed
      `test_a_preview_does_not_rewrite_a_drifted_status` and
      `test_a_cable_whose_status_drifted_is_an_update`.

## Rollback

Remove `dcim.cable` from `_ADAPTER_COMPARISONS`. The `_conflict_policy` fix
should stay regardless — it corrects the shim independently of which models are
wired up.

Refs #206

Claude-Session: https://claude.ai/code/session_012Qfd3hTSxZtmFHuzRJnZre

---
Re-opened from #290, which GitHub auto-closed when its parent branch was deleted on merge; the branch is rebased onto main with the same single commit.