### PR TITLE
docs: give the slice 7 and 8 plans the headings the harness requires

### DIFF
--- a/docs/03_Plans/active/2026-09-01-adapter-model-drift-ospf.md
+++ b/docs/03_Plans/active/2026-09-01-adapter-model-drift-ospf.md
@@ -91,12 +91,23 @@ Fixed by giving `ForwardQueryError` the same structured keywords
 several `except ForwardDataError` sites would silently start catching query
 failures, and nothing here needs that.
 
-## Testing
+## Validation
 
 `forward_netbox/tests/test_ospf_drift_comparison.py`, 19 tests: the firewall,
 the classification for all three models, the absent-VRF collision, the two
 double-counting cases, the rejection paths, and three on the exception
 signature including one that drives the real OSPF raise site.
+
+## Rollback
+
+Revert. The models return to the workload upper bound; nothing else reads the
+preview paths this slice added.
+
+## Decision Log
+
+- The verdict rule is stated at the call site in `sync_routing_impl.py`,
+  because the two rules are opposite and getting it backwards is silent in
+  both directions. See the rule of thumb in the Approach.
 
 ## Limits
 

--- a/docs/03_Plans/active/2026-09-01-adapter-model-drift-peering.md
+++ b/docs/03_Plans/active/2026-09-01-adapter-model-drift-peering.md
@@ -123,7 +123,7 @@ continues. The loop now does the same and counts the row rejected, which is
 what the apply does with that row. This was a latent defect in the earlier
 slices, not one this slice introduced; no shipped adapter path raises it yet.
 
-## Testing
+## Validation
 
 `forward_netbox/tests/test_peering_drift_comparison.py`, 16 tests: the firewall
 (no ASN, RIR, address, router, scope or peer created; a drifted peer not
@@ -134,6 +134,17 @@ rejection paths including one malformed row not taking the batch with it.
 The converged fixture is built from the apply's own `bgp_peer_name` and
 `bgp_peer_comments` rather than from literals, so it cannot quietly stop being
 converged when either format changes.
+
+## Rollback
+
+Revert. The models return to the workload upper bound; nothing else reads the
+preview paths this slice added.
+
+## Decision Log
+
+- The verdict rule is stated at the call site in `sync_routing_impl.py`,
+  because the two rules are opposite and getting it backwards is silent in
+  both directions. See the rule of thumb in the Approach.
 
 ## Limits
 


### PR DESCRIPTION
The peering and OSPF slice plans (#308, #309) used Testing/Limits where the harness requires Validation, Rollback and Decision Log, so harness-check failed on every branch from main. Docs only.