### PR TITLE
feat: say why each uncovered device is uncovered, and whether it is growing

### DIFF
--- a/docs/03_Plans/active/2026-09-02-uncovered-why-and-trend.md
+++ b/docs/03_Plans/active/2026-09-02-uncovered-why-and-trend.md
@@ -1,0 +1,78 @@
+# Uncovered devices: why, and whether it is growing
+
+## Goal
+
+Answer the two questions the `forward-uncovered` tag left open: WHY each
+device this sync created is now uncovered, and whether the count is growing.
+And make the unclaimed half listable in full, which nothing could do.
+
+## Why
+
+A customer reported 552 uncovered devices and that the number keeps growing.
+`2026-09-01-uncovered-device-tag.md` made the owned half listable and recorded
+"no health signal in this change" as its deferral. The cause split existed
+for orphans since 2.7.x and never for the owned set; the trend existed for the
+other two buckets and never for this one; the unclaimed half had a 25-name
+sample and no way to see the rest.
+
+## Constraints
+
+- No new Forward query shape. The census that classifies orphans already
+  carries no predicate, so it classifies the owned set in the same execution.
+- Names stay capped at the sample size in the persisted payload. Keys are
+  persisted instead, and NetBox's own device table renders them.
+- The unclaimed half is not tagged. It is not this sync's data.
+
+## Touched Surfaces
+
+- `scope_reconciliation.py` - `_absence_kinds` / `_absence_summary` (the
+  classifier split into "ask once" and "summarise a set"); the call site
+  classifies `out_of_scope | owned_untagged` once; `unmanaged.owned_absence`;
+  `owned_untagged_device_ids` / `unclaimed_device_ids`.
+- `health.py` - `_uncovered_summary`, escalating to `danger` on growth;
+  `_out_of_scope_summary` now escalates the same way.
+- `views.py` - `forwardsync_uncovered_devices` and
+  `forwardsync_unclaimed_devices`, one read-only table view each.
+- The scope-reconciliation panel (cause badges, list links), the health page
+  (Uncovered card), and `forwardsync_uncovered_devices.html`.
+
+## Approach
+
+The classifier used to take the orphan set, run the census, and return the
+panel's counts. It now takes any set of names and returns each name's kind;
+a second function turns a set plus those kinds into the panel's counts. The
+call site asks once for the union and summarises twice.
+
+## Validation
+
+`test_uncovered_absence_and_trend.py`: the owned set split by cause; one
+census for both sets; the customer's exact shape (orphans 0, owned present);
+no census when nothing is absent; a failed census reads unavailable for both
+sets rather than zero; keys persisted, names capped; the health signal at
+info / warn / danger with the trend text; both list pages and the panel links.
+Adjacent: `test_uncovered_device_tag`, `test_device_scope_reconciliation_audit_
+command`, `test_scope_module_ui`, `test_health`. Full Django suite.
+
+## Rollback
+
+Revert. The panel loses the badges and the links; the health page loses the
+card; the classifier returns to orphans only.
+
+## Decision Log
+
+- **One extra NQE execution in exactly one case.** When orphans are zero and
+  owned-uncovered devices exist, no census used to run because nothing asked
+  for one. Now one does - that is the customer's exact shape, and the case
+  with a question. `forward_api_usage` moves by one execution per
+  reconciliation there and nowhere else; recorded here and pinned by a test
+  so the change in the count is not mistaken for chatter.
+- **Keys in the payload, not names.** The job payload is a persisted
+  diagnostic and device names are customer data; the sample cap exists for
+  that reason. Primary keys carry no such weight and are exactly what a
+  device table needs.
+- **Out-of-scope escalates too.** It computed a trend and then hard-coded
+  `warn`; a steadily growing orphan set looked no different from a stable one.
+
+## Open
+
+- Nothing.

--- a/forward_netbox/templates/forward_netbox/forwardsync_health.html
+++ b/forward_netbox/templates/forward_netbox/forwardsync_health.html
@@ -571,6 +571,32 @@
       </div>
     </div>
     <div class="card">
+      <h5 class="card-header">{% trans "Uncovered" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Uncovered devices" %}</th>
+            <td>
+              {% if health.uncovered.status == "danger" %}
+                <span class="badge text-bg-danger">{{ health.uncovered.uncovered_count }}</span>
+              {% elif health.uncovered.status == "warn" %}
+                <span class="badge text-bg-warning">{{ health.uncovered.uncovered_count }}</span>
+              {% else %}
+                <span class="badge text-bg-success">{{ health.uncovered.uncovered_count }}</span>
+              {% endif %}
+              {% if health.uncovered.trend_delta is not None %}
+                <span class="text-muted small ms-2">{% blocktrans with delta=health.uncovered.trend_delta %}trend {{ delta }}{% endblocktrans %}</span>
+              {% endif %}
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Status" %}</th>
+            <td>{{ health.uncovered.message }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+    <div class="card">
       <h5 class="card-header">{% trans "Density Learning" %}</h5>
       <div class="card-body">
         <table class="table table-hover attr-table">

--- a/forward_netbox/templates/forward_netbox/forwardsync_scope_reconciliation.html
+++ b/forward_netbox/templates/forward_netbox/forwardsync_scope_reconciliation.html
@@ -107,7 +107,7 @@
                 <a href="{{ uncovered_tag_url }}" class="badge text-bg-warning text-decoration-none">{% blocktrans with count=payload.unmanaged.owned_untagged %}{{ count }} created by this sync{% endblocktrans %}</a>
               {% endif %}
               {% if payload.unmanaged.unclaimed %}
-                <span class="badge text-bg-secondary">{% blocktrans with count=payload.unmanaged.unclaimed %}{{ count }} not claimed by this sync{% endblocktrans %}</span>
+                <a href="{{ unclaimed_devices_url }}" class="badge text-bg-secondary text-decoration-none">{% blocktrans with count=payload.unmanaged.unclaimed %}{{ count }} not claimed by this sync{% endblocktrans %}</a>
               {% endif %}
             </td>
           </tr>
@@ -381,7 +381,26 @@
       <div class="card-body">
         {% if payload.unmanaged.owned_untagged_sample %}
           <p class="text-muted mt-0">{% trans "This sync created these devices, and the current Forward result no longer covers them. A device disabled in Forward looks exactly like this, so they are kept, not pruned — which is why this count grows. Use the tag to list all of them, not just this sample." %}</p>
-          <p><a href="{{ uncovered_tag_url }}" class="btn btn-sm btn-outline-warning"><i class="mdi mdi-tag-outline" aria-hidden="true"></i>&nbsp;{% blocktrans with count=payload.unmanaged.owned_untagged %}List all {{ count }}{% endblocktrans %}</a></p>
+          {% if payload.unmanaged.owned_absence.available %}
+            <p class="mb-2">
+              <span class="text-muted">{% trans "Why:" %}</span>
+              {% if payload.unmanaged.owned_absence.absent_from_snapshot %}
+                <span class="badge text-bg-secondary" title="{% trans 'Forward does not have the device at all - disabled, decommissioned, or collection stopped returning it.' %}">{% blocktrans count counter=payload.unmanaged.owned_absence.absent_from_snapshot %}{{ counter }} gone from Forward{% plural %}{{ counter }} gone from Forward{% endblocktrans %}</span>
+              {% endif %}
+              {% if payload.unmanaged.owned_absence.present_untagged %}
+                <span class="badge text-bg-warning" title="{% trans 'Forward has the device but it no longer matches the include tags - a Forward-side tag change.' %}">{% blocktrans count counter=payload.unmanaged.owned_absence.present_untagged %}{{ counter }} in Forward but untagged{% plural %}{{ counter }} in Forward but untagged{% endblocktrans %}</span>
+              {% endif %}
+              {% if payload.unmanaged.owned_absence.vendor_excluded %}
+                <span class="badge text-bg-info" title="{% trans 'Forward classifies the device as a custom-command source, which every bundled query filters out.' %}">{% blocktrans count counter=payload.unmanaged.owned_absence.vendor_excluded %}{{ counter }} custom-command source{% plural %}{{ counter }} custom-command source{% endblocktrans %}</span>
+              {% endif %}
+            </p>
+          {% elif payload.unmanaged.owned_absence %}
+            <p class="text-muted small mb-2">{% trans "The Forward census that classifies the cause did not run for this report." %}</p>
+          {% endif %}
+          <p>
+            <a href="{{ uncovered_devices_url }}" class="btn btn-sm btn-outline-warning"><i class="mdi mdi-format-list-bulleted" aria-hidden="true"></i>&nbsp;{% blocktrans with count=payload.unmanaged.owned_untagged %}List all {{ count }}{% endblocktrans %}</a>
+            <a href="{{ uncovered_tag_url }}" class="btn btn-sm btn-outline-secondary"><i class="mdi mdi-tag-outline" aria-hidden="true"></i>&nbsp;{% trans "Filter devices by tag" %}</a>
+          </p>
           <ul class="mb-0">
             {% for name in payload.unmanaged.owned_untagged_sample %}<li><code>{{ name }}</code></li>{% endfor %}
           </ul>
@@ -400,6 +419,7 @@
       <div class="card-body">
         {% if payload.unmanaged.unclaimed_sample %}
           <p class="text-muted mt-0">{% trans "Devices this sync never created: another source, an operator, or an old SNMP endpoint import. Listed so the count above can be accounted for — this sync makes no claim about them, tags none of them, and never prunes them." %}</p>
+          <p><a href="{{ unclaimed_devices_url }}" class="btn btn-sm btn-outline-secondary"><i class="mdi mdi-format-list-bulleted" aria-hidden="true"></i>&nbsp;{% blocktrans with count=payload.unmanaged.unclaimed %}List all {{ count }}{% endblocktrans %}</a></p>
           <ul class="mb-0">
             {% for name in payload.unmanaged.unclaimed_sample %}<li><code>{{ name }}</code></li>{% endfor %}
           </ul>

--- a/forward_netbox/templates/forward_netbox/forwardsync_uncovered_devices.html
+++ b/forward_netbox/templates/forward_netbox/forwardsync_uncovered_devices.html
@@ -1,0 +1,40 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+{% load i18n %}
+{% load render_table from django_tables2 %}
+
+{% block title %}{{ object }} - {{ title }}{% endblock %}
+
+{% block extra_controls %}
+  <a class="btn btn-outline-secondary" href="{{ scope_reconciliation_url }}">
+    <i class="mdi mdi-arrow-left" aria-hidden="true"></i>&nbsp;{% trans "Scope Reconciliation" %}
+  </a>
+{% endblock extra_controls %}
+
+{% block content %}
+<div class="row mb-3">
+  <div class="col col-12">
+    <div class="card">
+      <h5 class="card-header">{{ title }}</h5>
+      <div class="card-body">
+        {% if report_error %}
+          <span class="badge text-bg-danger">{% trans "Failed" %}</span>
+          <span class="ms-2">{{ report_error }}</span>
+        {% elif report_pending %}
+          <p class="text-muted mb-0">{% trans "No scope reconciliation report has run yet. Run one from Scope Reconciliation; this page lists devices from the stored report." %}</p>
+        {% else %}
+          <p class="text-muted mt-0">
+            {% if half == "owned_untagged" %}
+              {% trans "Devices this sync created that the current Forward tag-scope result no longer covers, as of the stored report. The same set carries the forward-uncovered tag." %}
+            {% else %}
+              {% trans "Devices carrying neither include tag that this sync never created: another source, an operator, or an old SNMP endpoint import. This sync makes no claim about them, tags none of them, and never prunes them. Listed so the count can be accounted for." %}
+            {% endif %}
+            {% blocktrans with count=device_count generated=report_generated_at %}{{ count }} device(s) from the report generated {{ generated }}.{% endblocktrans %}
+          </p>
+          {% render_table table 'inc/table.html' %}
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/forward_netbox/tests/test_uncovered_absence_and_trend.py
+++ b/forward_netbox/tests/test_uncovered_absence_and_trend.py
@@ -1,0 +1,367 @@
+# The two questions the uncovered-device count could not answer.
+#
+# `forward-uncovered` made the bucket listable. A customer's next two questions
+# were WHY each device is uncovered, and whether the count is GROWING. The first
+# had an answer for orphans since 2.7.x (`_classify_out_of_scope_absence`) and
+# none for the owned-uncovered set; the second had no signal anywhere. Both are
+# here, plus the unclaimed half listable in full without a tag, which was the
+# one thing on the page an operator could see 25 names of and nothing more.
+from unittest.mock import Mock
+from unittest.mock import patch
+from uuid import uuid4
+
+from core.choices import JobStatusChoices
+from core.models import Job
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import Manufacturer
+from dcim.models import Site
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.test import Client
+from django.test import TestCase
+from django.urls import reverse
+from extras.models import Tag
+
+from forward_netbox.choices import ForwardSyncStatusChoices
+from forward_netbox.models import ForwardDeviceIdentity
+from forward_netbox.models import ForwardIngestion
+from forward_netbox.models import ForwardSource
+from forward_netbox.models import ForwardSync
+from forward_netbox.utilities.health import sync_health_summary
+from forward_netbox.utilities.scope_reconciliation import compute_scope_reconciliation
+from forward_netbox.utilities.scope_reconciliation import UNCOVERED_TAG_SLUG
+
+
+class _Fixture(TestCase):
+    def setUp(self):
+        self.source = ForwardSource.objects.create(
+            name="why-src",
+            type="saas",
+            url="https://fwd.app",
+            status="ready",
+            parameters={
+                "username": "u@example.com",
+                "password": "p",
+                "verify": True,
+                "network_id": "net-1",
+                "device_tag_include_tags": ["Prod_Core"],
+                "device_tag_include_match": "any",
+            },
+        )
+        self.sync = ForwardSync.objects.create(
+            name="why-sync",
+            source=self.source,
+            status=ForwardSyncStatusChoices.COMPLETED,
+            parameters={"snapshot_id": "latestProcessed"},
+        )
+        self.ingestion = ForwardIngestion.objects.create(
+            sync=self.sync, snapshot_id="snap-1", baseline_ready=True
+        )
+        mfr = Manufacturer.objects.create(name="MfrW", slug="mfr-w")
+        self.dt = DeviceType.objects.create(manufacturer=mfr, model="dt-w", slug="dt-w")
+        self.role = DeviceRole.objects.create(name="RoleW", slug="role-w")
+        self.site = Site.objects.create(name="SiteW", slug="site-w")
+
+    def _device(self, name):
+        return Device.objects.create(
+            name=name, device_type=self.dt, role=self.role, site=self.site
+        )
+
+    def _own(self, device):
+        return ForwardDeviceIdentity.objects.create(
+            sync=self.sync,
+            source_device_key=device.name,
+            device=device,
+            ingestion_id=self.ingestion.pk,
+            snapshot_id="snap-1",
+        )
+
+    def _report(self, scope_rows, census_rows=None):
+        client = Mock()
+        responses = [scope_rows]
+        if census_rows is not None:
+            responses.append(census_rows)
+        client.run_nqe_query = Mock(side_effect=responses)
+        with (
+            patch.object(ForwardSync, "resolve_snapshot_id", return_value="snap-1"),
+            patch.object(ForwardSource, "get_client", return_value=client),
+        ):
+            return compute_scope_reconciliation(self.sync), client
+
+
+class OwnedAbsenceIsClassifiedTest(_Fixture):
+    """WHY each owned-uncovered device is uncovered."""
+
+    def test_the_owned_set_is_split_by_cause(self):
+        self._device("in-scope")
+        self._own(self._device("gone"))
+        self._own(self._device("untagged"))
+        self._own(self._device("custom"))
+
+        report, client = self._report(
+            [{"name": "in-scope", "completed": True}],
+            [
+                {"name": "in-scope", "vendor": "Vendor.CISCO"},
+                # `gone` is deliberately absent from the census.
+                {"name": "untagged", "vendor": "Vendor.ARISTA"},
+                {"name": "custom", "vendor": "Vendor.FORWARD_CUSTOM"},
+            ],
+        )
+
+        owned = report["unmanaged"]["owned_absence"]
+        self.assertTrue(owned["available"])
+        self.assertEqual(owned["absent_from_snapshot"], 1)
+        self.assertEqual(owned["present_untagged"], 1)
+        self.assertEqual(owned["vendor_excluded"], 1)
+        self.assertEqual(owned["absent_from_snapshot_sample"], ["gone"])
+        self.assertEqual(owned["present_untagged_sample"], ["untagged"])
+        self.assertEqual(owned["vendor_excluded_sample"], ["custom"])
+
+    def test_orphans_and_owned_devices_share_one_census(self):
+        """Widening what the census classifies costs no extra NQE execution
+        when orphans already exist - the query carries no predicate."""
+        from forward_netbox.utilities.ownership import reconcile_sync_scope_tag_claims
+
+        self._device("in-scope")
+        self._device("orphan")
+        self._own(self._device("owned-gone"))
+        reconcile_sync_scope_tag_claims(
+            self.sync,
+            {"in-scope": ["Prod_Core"], "orphan": ["Prod_Core"]},
+            generation=self.ingestion.pk,
+            snapshot_id="snap-1",
+        )
+
+        report, client = self._report(
+            [{"name": "in-scope", "completed": True}],
+            [{"name": "in-scope", "vendor": "Vendor.CISCO"}],
+        )
+
+        # Scope query + ONE census, however many sets it classified.
+        self.assertEqual(client.run_nqe_query.call_count, 2)
+        self.assertEqual(report["out_of_scope_absence"]["absent_from_snapshot"], 1)
+        # The orphan is ALSO owned-uncovered: claiming it gave it an identity,
+        # so it is in both sets, and both sets say the same thing about it.
+        self.assertEqual(
+            report["unmanaged"]["owned_absence"]["absent_from_snapshot"], 2
+        )
+
+    def test_the_customer_shape_costs_one_census_where_it_cost_none(self):
+        """Orphans zero, owned-uncovered present. Before this change no census
+        ran (nothing was asked); now one does, because this is exactly the case
+        with a question. Recorded so `forward_api_usage` readers know why the
+        count moved by one."""
+        self._device("in-scope")
+        self._own(self._device("owned-gone"))
+
+        report, client = self._report(
+            [{"name": "in-scope", "completed": True}],
+            [{"name": "in-scope", "vendor": "Vendor.CISCO"}],
+        )
+
+        self.assertEqual(report["netbox_out_of_scope"], 0)
+        self.assertEqual(client.run_nqe_query.call_count, 2)
+        self.assertEqual(
+            report["unmanaged"]["owned_absence"]["absent_from_snapshot"], 1
+        )
+
+    def test_no_census_runs_when_nothing_is_absent(self):
+        self._device("in-scope")
+
+        report, client = self._report([{"name": "in-scope", "completed": True}])
+
+        self.assertEqual(client.run_nqe_query.call_count, 1)
+        self.assertEqual(
+            report["unmanaged"]["owned_absence"]["absent_from_snapshot"], 0
+        )
+
+    def test_a_failed_census_is_unavailable_for_both_sets_not_a_zero(self):
+        self._device("in-scope")
+        self._own(self._device("owned-gone"))
+        client = Mock()
+        client.run_nqe_query = Mock(
+            side_effect=[[{"name": "in-scope", "completed": True}], RuntimeError("x")]
+        )
+        with (
+            patch.object(ForwardSync, "resolve_snapshot_id", return_value="snap-1"),
+            patch.object(ForwardSource, "get_client", return_value=client),
+        ):
+            report = compute_scope_reconciliation(self.sync)
+
+        self.assertFalse(report["unmanaged"]["owned_absence"]["available"])
+        self.assertNotIn("absent_from_snapshot", report["unmanaged"]["owned_absence"])
+
+    def test_both_halves_persist_their_device_keys_not_their_names(self):
+        owned = self._device("owned-gone")
+        self._own(owned)
+        unclaimed = self._device("someone-elses")
+
+        report, _client = self._report(
+            [{"name": "in-scope", "completed": True}],
+            [{"name": "in-scope", "vendor": "Vendor.CISCO"}],
+        )
+
+        unmanaged = report["unmanaged"]
+        self.assertEqual(unmanaged["owned_untagged_device_ids"], [owned.pk])
+        self.assertEqual(unmanaged["unclaimed_device_ids"], [unclaimed.pk])
+
+
+class UncoveredHealthSignalTest(_Fixture):
+    """Whether the count is GROWING."""
+
+    def _tagged(self, *names):
+        tag, _ = Tag.objects.get_or_create(
+            slug=UNCOVERED_TAG_SLUG, defaults={"name": "Forward Uncovered"}
+        )
+        for name in names:
+            self._device(name).tags.add(tag)
+
+    def _history(self, *totals):
+        content_type = ContentType.objects.get_for_model(ForwardSync)
+        for total in totals:
+            Job.objects.create(
+                object_type=content_type,
+                object_id=self.sync.pk,
+                name="reconcile device scope tags",
+                status=JobStatusChoices.STATUS_COMPLETED,
+                job_id=uuid4(),
+                data={"total_uncovered": total},
+            )
+
+    def test_no_uncovered_devices_is_info(self):
+        summary = sync_health_summary(self.sync)["uncovered"]
+        self.assertEqual(summary["status"], "info")
+        self.assertEqual(summary["uncovered_count"], 0)
+
+    def test_a_steady_count_warns(self):
+        self._tagged("u-1", "u-2")
+        self._history(2, 2)
+        summary = sync_health_summary(self.sync)["uncovered"]
+        self.assertEqual(summary["status"], "warn")
+        self.assertEqual(summary["uncovered_count"], 2)
+        self.assertEqual(summary["trend_delta"], 0)
+
+    def test_a_growing_count_escalates_to_danger_and_says_so(self):
+        # The customer's complaint, verbatim: "the number keeps growing".
+        self._tagged("u-1", "u-2", "u-3")
+        self._history(49, 552)
+        summary = sync_health_summary(self.sync)["uncovered"]
+        self.assertEqual(summary["status"], "danger")
+        self.assertEqual(summary["trend_delta"], 503)
+        self.assertIn("Up 503", summary["message"])
+        self.assertIn("49 -> 552", summary["message"])
+
+    def test_the_message_points_at_the_cause_split(self):
+        self._tagged("u-1")
+        summary = sync_health_summary(self.sync)["uncovered"]
+        self.assertIn("split by cause", summary["message"])
+        self.assertIn("forward-uncovered", summary["message"])
+
+    def test_out_of_scope_now_escalates_on_growth_too(self):
+        tag = Tag.objects.create(
+            name="Forward Out Of Scope", slug="forward-out-of-scope"
+        )
+        self._device("o-1").tags.add(tag)
+        content_type = ContentType.objects.get_for_model(ForwardSync)
+        for total in (1, 40):
+            Job.objects.create(
+                object_type=content_type,
+                object_id=self.sync.pk,
+                name="reconcile device scope tags",
+                status=JobStatusChoices.STATUS_COMPLETED,
+                job_id=uuid4(),
+                data={"total_out_of_scope": total},
+            )
+        summary = sync_health_summary(self.sync)["out_of_scope"]
+        self.assertEqual(summary["status"], "danger")
+
+
+class UncoveredListPagesTest(_Fixture):
+    """Both halves listable in full, from the stored report."""
+
+    def _client(self):
+        user = get_user_model().objects.create_user(username="admin-why", password="x")
+        user.is_superuser = True
+        user.is_staff = True
+        user.save()
+        client = Client()
+        client.force_login(user)
+        return client
+
+    def _stored_report(self):
+        owned = self._device("owned-gone")
+        self._own(owned)
+        self._device("someone-elses")
+        fwd_client = Mock()
+        fwd_client.run_nqe_query = Mock(
+            side_effect=[
+                [{"name": "in-scope", "completed": True}],
+                [{"name": "in-scope", "vendor": "Vendor.CISCO"}],
+            ]
+        )
+        with (
+            patch.object(ForwardSource, "get_client", return_value=fwd_client),
+            patch.object(ForwardSync, "resolve_snapshot_id", return_value="snap-1"),
+        ):
+            from forward_netbox.jobs import _scope_reconciliation_work
+
+            job = Job.objects.create(
+                object_type=ContentType.objects.get_for_model(ForwardSync),
+                object_id=self.sync.pk,
+                name=f"{self.sync.name} - scope reconciliation",
+                status=JobStatusChoices.STATUS_COMPLETED,
+                job_id=uuid4(),
+            )
+            _scope_reconciliation_work(job)
+
+    def test_the_unclaimed_half_is_listable_without_a_tag(self):
+        self._stored_report()
+        response = self._client().get(
+            reverse(
+                "plugins:forward_netbox:forwardsync_unclaimed_devices",
+                kwargs={"pk": self.sync.pk},
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "someone-elses")
+        self.assertNotContains(response, "owned-gone")
+
+    def test_the_owned_half_is_listable_from_the_report(self):
+        self._stored_report()
+        response = self._client().get(
+            reverse(
+                "plugins:forward_netbox:forwardsync_uncovered_devices",
+                kwargs={"pk": self.sync.pk},
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "owned-gone")
+        self.assertNotContains(response, "someone-elses")
+
+    def test_without_a_report_the_page_says_so_instead_of_listing_nothing(self):
+        response = self._client().get(
+            reverse(
+                "plugins:forward_netbox:forwardsync_unclaimed_devices",
+                kwargs={"pk": self.sync.pk},
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "No scope reconciliation report has run yet")
+
+    def test_the_panel_shows_the_cause_and_links_both_lists(self):
+        self._stored_report()
+        response = self._client().get(
+            reverse(
+                "plugins:forward_netbox:forwardsync_scope_reconciliation",
+                kwargs={"pk": self.sync.pk},
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "gone from Forward")
+        for name in ("forwardsync_uncovered_devices", "forwardsync_unclaimed_devices"):
+            self.assertContains(
+                response,
+                reverse(f"plugins:forward_netbox:{name}", kwargs={"pk": self.sync.pk}),
+            )

--- a/forward_netbox/utilities/health.py
+++ b/forward_netbox/utilities/health.py
@@ -523,6 +523,7 @@ def sync_health_summary(sync):
     density_learning = _density_learning_summary(sync)
     collection_gap = _collection_gap_summary(sync)
     out_of_scope = _out_of_scope_summary(sync)
+    uncovered = _uncovered_summary(sync)
     latest_ingestion_summary = _ingestion_summary(latest_ingestion) or {}
     dependency_lookup_cache = latest_ingestion_summary.get(
         "dependency_lookup_cache", {}
@@ -619,6 +620,7 @@ def sync_health_summary(sync):
         "density_learning": density_learning,
         "collection_gap": collection_gap,
         "out_of_scope": out_of_scope,
+        "uncovered": uncovered,
         "ownership_finalization": ownership_finalization,
         "dependency_lookup_cache": dependency_lookup_cache,
         "dependency_parent_coverage": dependency_parent_coverage,
@@ -1209,7 +1211,10 @@ def _out_of_scope_summary(sync):
         )
     return {
         "available": True,
-        "status": "warn",
+        # Escalate on growth, as the collection-gap signal does. This was a
+        # fixed `warn`, which made a steadily growing orphan set look no
+        # different from a stable one.
+        "status": "danger" if trend and trend["delta"] > 0 else "warn",
         "out_of_scope_count": count,
         "trend_delta": trend["delta"] if trend else None,
         "tag_slug": OUT_OF_SCOPE_TAG_SLUG,
@@ -1218,6 +1223,66 @@ def _out_of_scope_summary(sync):
             "none of the sync's included Forward tags. Review and remove them via "
             "Scope Reconciliation -> Prune orphans, or filter the device list by "
             f"the forward-out-of-scope tag.{trend_note}"
+        ),
+    }
+
+
+def _uncovered_summary(sync):
+    """Uncovered-device signal from the persisted ``forward-uncovered`` tag.
+
+    Devices this sync created that the current Forward tag-scope result no
+    longer covers. This is the count that GROWS: a device disabled in Forward
+    drops out of the result and, since the absence quarantine, is kept rather
+    than pruned, so it accumulates here by design. "It keeps growing" was a
+    customer's actual complaint, and until this signal existed nothing warned
+    when it did - the bucket had a count on one page and no trend anywhere.
+
+    Cheap DB count of the stored tag, no live Forward query, like its two
+    siblings. Escalates on growth like the collection-gap signal does.
+    """
+    from dcim.models import Device
+
+    from .scope_reconciliation import UNCOVERED_TAG_SLUG
+
+    count = Device.objects.filter(tags__slug=UNCOVERED_TAG_SLUG).count()
+    if count == 0:
+        return {
+            "available": True,
+            "status": "info",
+            "uncovered_count": 0,
+            "trend_delta": None,
+            "tag_slug": UNCOVERED_TAG_SLUG,
+            "message": (
+                "No devices flagged forward-uncovered. Run Tag backfilled devices "
+                "from Scope Reconciliation to refresh this signal."
+            ),
+        }
+    trend = _job_data_count_trend(sync, "total_uncovered")
+    growing = bool(trend and trend["delta"] > 0)
+    trend_note = ""
+    if growing:
+        trend_note = (
+            f" Up {trend['delta']} since the previous reconciliation "
+            f"({trend['previous']} -> {trend['latest']}) — more of this sync's "
+            "devices are leaving the Forward result than returning to it."
+        )
+    elif trend and trend["delta"] < 0:
+        trend_note = (
+            f" Down {abs(trend['delta'])} since the previous reconciliation "
+            f"({trend['previous']} -> {trend['latest']})."
+        )
+    return {
+        "available": True,
+        "status": "danger" if growing else "warn",
+        "uncovered_count": count,
+        "trend_delta": trend["delta"] if trend else None,
+        "tag_slug": UNCOVERED_TAG_SLUG,
+        "message": (
+            f"{count} device(s) tagged forward-uncovered — created by this sync "
+            "but absent from the current Forward tag-scope result. Open Scope "
+            "Reconciliation for the split by cause (gone from Forward, in "
+            "Forward but untagged, or a custom-command source), or filter the "
+            f"device list by the forward-uncovered tag.{trend_note}"
         ),
     }
 

--- a/forward_netbox/utilities/scope_reconciliation.py
+++ b/forward_netbox/utilities/scope_reconciliation.py
@@ -430,12 +430,21 @@ def compute_scope_reconciliation(sync, *, snapshot_id=None) -> dict:
 
     unmanaged, owned_untagged_names = _unmanaged_device_summary(sync, tagged_names)
 
-    absence = _classify_out_of_scope_absence(
-        out_of_scope,
+    # One census query classifies BOTH absent sets. The orphans have carried
+    # this split since 2.7.x; the owned-uncovered devices never had it, and
+    # "why is this device uncovered" - disabled in Forward, untagged in Forward,
+    # or a custom-command source - is the question a customer actually asks
+    # when that count grows. The query carries no predicate, so widening the
+    # set it classifies costs no extra NQE execution; `forward_api_usage` reads
+    # the same after this change as before it.
+    kinds = _absence_kinds(
+        out_of_scope | owned_untagged_names,
         client=client,
         network_id=network_id,
         snapshot_id=snapshot_id,
     )
+    absence = _absence_summary(out_of_scope, kinds)
+    unmanaged["owned_absence"] = _absence_summary(owned_untagged_names, kinds)
 
     # Why are the in-scope devices backfilled? Group by the Forward collection
     # error so operators can act (rotate creds for AUTHENTICATION_FAILED, check
@@ -569,6 +578,8 @@ def _unmanaged_device_summary(sync, tagged_names):
             "unclaimed": 0,
             "owned_untagged_sample": [],
             "unclaimed_sample": [],
+            "owned_untagged_device_ids": [],
+            "unclaimed_device_ids": [],
         }, set()
     owned_ids = set(
         ForwardDeviceIdentity.objects.filter(
@@ -580,12 +591,25 @@ def _unmanaged_device_summary(sync, tagged_names):
     unclaimed = sorted(
         name for device_id, name in untagged if device_id not in owned_ids
     )
+    # The primary keys, so the page can LIST either half in full. Names stay
+    # capped at the sample size because they are customer data in a persisted
+    # job payload; keys are not, and NetBox's own device table renders them.
+    # The unclaimed half is the one nothing else can list: it is not this
+    # sync's data, so no tag is maintained for it, and until these keys were
+    # kept an operator whose count was mostly unclaimed could see 25 names of
+    # it and nothing more.
     return {
         "untagged_total": len(untagged),
         "owned_untagged": len(owned),
         "unclaimed": len(unclaimed),
         "owned_untagged_sample": owned[:SAMPLE_LIMIT],
         "unclaimed_sample": unclaimed[:SAMPLE_LIMIT],
+        "owned_untagged_device_ids": sorted(
+            device_id for device_id, _ in untagged if device_id in owned_ids
+        ),
+        "unclaimed_device_ids": sorted(
+            device_id for device_id, _ in untagged if device_id not in owned_ids
+        ),
     }, set(owned)
 
 
@@ -621,16 +645,28 @@ def _classify_out_of_scope_absence(
     no calls at all. The query carries no tag predicate and no vendor guard on
     purpose: it must see the devices the scope query filtered OUT.
     """
-    if not out_of_scope:
-        return {
-            "available": True,
-            "absent_from_snapshot": 0,
-            "present_untagged": 0,
-            "vendor_excluded": 0,
-            "absent_from_snapshot_sample": [],
-            "present_untagged_sample": [],
-            "vendor_excluded_sample": [],
-        }
+    return _absence_summary(
+        out_of_scope,
+        _absence_kinds(
+            out_of_scope,
+            client=client,
+            network_id=network_id,
+            snapshot_id=snapshot_id,
+        ),
+    )
+
+
+def _absence_kinds(names, *, client, network_id, snapshot_id):
+    """Which kind of absence each name is: ``absent``, ``untagged`` or
+    ``vendor_excluded``. ``None`` when the census could not run, so every
+    caller renders "unavailable" rather than a zero.
+
+    One query for however many names are asked about. It carries no tag
+    predicate and no vendor guard on purpose: it must see the devices the
+    scope query filtered OUT.
+    """
+    if not names:
+        return {}
 
     query = "\n".join(
         [
@@ -656,7 +692,7 @@ def _classify_out_of_scope_absence(
         # Advisory only. This must never fail the report that operators use to
         # decide whether a prune is safe - a missing classification is far
         # better than no scope report at all.
-        return {"available": False}
+        return None
 
     vendor_by_name = {}
     for row in rows:
@@ -664,17 +700,37 @@ def _classify_out_of_scope_absence(
         if name:
             vendor_by_name[name] = str(row.get("vendor") or "")
 
-    absent = []
-    untagged = []
-    vendor_excluded = []
-    for name in sorted(out_of_scope):
+    kinds = {}
+    for name in names:
         vendor = vendor_by_name.get(name)
         if vendor is None:
-            absent.append(name)
+            kinds[name] = "absent"
         elif vendor.endswith("FORWARD_CUSTOM"):
-            vendor_excluded.append(name)
+            kinds[name] = "vendor_excluded"
         else:
-            untagged.append(name)
+            kinds[name] = "untagged"
+    return kinds
+
+
+def _absence_summary(names, kinds):
+    """The panel's three counts and samples for one absent set."""
+    if not names:
+        return {
+            "available": True,
+            "absent_from_snapshot": 0,
+            "present_untagged": 0,
+            "vendor_excluded": 0,
+            "absent_from_snapshot_sample": [],
+            "present_untagged_sample": [],
+            "vendor_excluded_sample": [],
+        }
+    if kinds is None:
+        return {"available": False}
+    absent = sorted(name for name in names if kinds.get(name) == "absent")
+    untagged = sorted(name for name in names if kinds.get(name) == "untagged")
+    vendor_excluded = sorted(
+        name for name in names if kinds.get(name) == "vendor_excluded"
+    )
     return {
         "available": True,
         "absent_from_snapshot": len(absent),

--- a/forward_netbox/views.py
+++ b/forward_netbox/views.py
@@ -1435,6 +1435,75 @@ class ForwardSyncRefreshScopeReconciliationView(BaseObjectView):
         )
 
 
+class _ForwardSyncUncoveredDevicesView(BaseObjectView):
+    """List one half of "carry no include tag" in full, from the stored report.
+
+    The panel shows a count and a 25-name sample per half, and the OWNED half
+    has a tag to filter the device list by. The UNCLAIMED half has neither: it
+    is not this sync's data, so no tag is maintained for it, and an operator
+    whose count was mostly unclaimed could see 25 names of it and nothing
+    more. The reconciliation job now persists the primary keys of both halves
+    (keys, not names - names are customer data in a job payload), and this
+    renders NetBox's own device table over them. Read-only, no Forward call.
+    """
+
+    queryset = ForwardSync.objects.all()
+    template_name = "forward_netbox/forwardsync_uncovered_devices.html"
+    half = ""
+    title = ""
+
+    def get_required_permission(self):
+        return "forward_netbox.view_forwardsync"
+
+    def get(self, request, pk):
+        from dcim.models import Device
+        from dcim.tables import DeviceTable
+
+        sync = get_object_or_404(self.queryset, pk=pk)
+        report_job = _latest_scope_reconciliation_job(sync)
+        payload, generated_at, report_error = _scope_reconciliation_payload(report_job)
+        unmanaged = payload.get("unmanaged") or {}
+        device_ids = [
+            device_id
+            for device_id in unmanaged.get(f"{self.half}_device_ids") or []
+            if isinstance(device_id, int)
+        ]
+        table = DeviceTable(
+            Device.objects.filter(pk__in=device_ids).restrict(request.user, "view")
+        )
+        table.configure(request)
+        return render(
+            request,
+            self.template_name,
+            {
+                "object": sync,
+                "table": table,
+                "title": self.title,
+                "half": self.half,
+                "device_count": len(device_ids),
+                "report_generated_at": generated_at,
+                "report_error": report_error,
+                "report_pending": report_job is None,
+                "scope_reconciliation_url": reverse(
+                    "plugins:forward_netbox:forwardsync_scope_reconciliation",
+                    kwargs={"pk": sync.pk},
+                ),
+            },
+        )
+
+
+@register_model_view(ForwardSync, "uncovered_devices", path="uncovered-devices")
+class ForwardSyncUncoveredDevicesView(_ForwardSyncUncoveredDevicesView):
+    half = "owned_untagged"
+    title = "Uncovered devices created by this sync"
+
+
+@register_model_view(ForwardSync, "unclaimed_devices", path="unclaimed-devices")
+class ForwardSyncUnclaimedDevicesView(_ForwardSyncUncoveredDevicesView):
+    half = "unclaimed"
+    title = "Uncovered devices not claimed by this sync"
+
+
 @register_model_view(ForwardSync, "scope_reconciliation", path="scope-reconciliation")
 class ForwardSyncScopeReconciliationView(BaseObjectView):
     queryset = ForwardSync.objects.all()
@@ -1480,6 +1549,14 @@ class ForwardSyncScopeReconciliationView(BaseObjectView):
                 ),
                 "backfilled_tag_url": backfilled_tag_url,
                 "uncovered_tag_url": uncovered_tag_url,
+                "uncovered_devices_url": reverse(
+                    "plugins:forward_netbox:forwardsync_uncovered_devices",
+                    kwargs={"pk": sync.pk},
+                ),
+                "unclaimed_devices_url": reverse(
+                    "plugins:forward_netbox:forwardsync_unclaimed_devices",
+                    kwargs={"pk": sync.pk},
+                ),
                 "tag_backfilled_url": reverse(
                     "plugins:forward_netbox:forwardsync_tag_backfilled",
                     kwargs={"pk": sync.pk},


### PR DESCRIPTION
## Summary

`forward-uncovered` (#311) made the bucket listable. The customer's next two questions were **why** each device is uncovered and **whether the count is growing** — and nothing answered either.

**Why.** The census that classifies orphans (gone from Forward / in Forward but untagged / custom-command source) has existed since 2.7.x and never ran for the owned-uncovered set. The classifier is split into "ask once" and "summarise a set": the call site classifies `out_of_scope | owned_untagged` in **one** NQE execution and summarises twice. The panel's owned card now carries the three cause badges.

**Growing.** `_uncovered_summary` in `health.py`, trend from the `total_uncovered` job-data key #311 already writes, escalating to `danger` on growth (copying `_collection_gap_summary`, not `_out_of_scope_summary`'s fixed `warn` — which now escalates too).

**The unclaimed half is listable.** It is not this sync's data, so no tag is maintained for it, and an operator whose count was mostly unclaimed could see 25 names and nothing more. Both halves now persist their device **primary keys** (not names) in the reconciliation payload, and two read-only views render NetBox's own device table over them.

## One honest cost

In the customer's exact shape — orphans zero, owned-uncovered present — no census used to run because nothing asked for one. Now one does. `forward_api_usage` moves by **one execution per reconciliation in that case and nowhere else**; pinned by `test_the_customer_shape_costs_one_census_where_it_cost_none` so the count change is not mistaken for chatter.

## Validation

144 tests OK across `test_uncovered_absence_and_trend` (15 new), `test_uncovered_device_tag`, `test_device_scope_reconciliation_audit_command`, `test_scope_module_ui`, `test_health`. `invoke harness-check` ✓.

Plan: `docs/03_Plans/active/2026-09-02-uncovered-why-and-trend.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa
