### PR TITLE
fix: scope the software-version catalogue sweep to what this sync can attribute

### DIFF
--- a/docs/03_Plans/active/2026-09-02-softwareversion-catalog-scope.md
+++ b/docs/03_Plans/active/2026-09-02-softwareversion-catalog-scope.md
@@ -1,0 +1,70 @@
+# Scope the software-version catalogue sweep to what this sync can attribute
+
+## Goal
+
+Stop the `netbox_dlm.softwareversion` durable-state delta from enumerating
+the entire `SoftwareVersion` table as delete candidates.
+
+## Why
+
+`apply_durable_workload_deltas` treated every row in the table that the
+current result did not name as a delete - operator-created versions included.
+Carried as open through `2026-08-21-ownership-sweep-quarantine.md`,
+`2026-08-21-release-2.8.9.md` and `2026-08-22-release-2.9.0.md`: "quarantine
+is device-shaped and does not apply; scoping it to plugin-provenanced rows is
+its own question." With the device sweep quarantined in 2.8.9, this was the
+last ungated whole-table delete producer.
+
+## Constraints
+
+- Attribution decides what is a candidate; the existing reference protection
+  (`_locally_referenced_delete_identities`, peer protection) decides what is
+  deleted. This change does not bypass either.
+- The sweep's purpose - catching versions the sync wrote before durable state
+  existed - is preserved for exactly the rows it can prove were its own.
+- `CATALOG_SWEEP_MODELS` is the allowlist. A model outside it never has its
+  table enumerated, however the branch is keyed.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/workload_state.py` - `CATALOG_SWEEP_MODELS`;
+  `_software_version_catalog_rows(sync)` attributes through `DeviceSoftware`
+  and `InventoryItemSoftware` on `_sync_exclusive_device_ids(sync)`.
+- `forward_netbox/tests/test_workload_state.py`.
+
+## Approach
+
+Same attribution `_bootstrap_dlm_rows` already uses for the association
+models: a device only this sync manages. A version referenced by such a
+device is a candidate; one referenced by nothing, by another sync's devices,
+or by an operator's, is left to whatever the current result says.
+
+## Validation
+
+- Negative space pinned: an operator-created unreferenced version survives; a
+  version referenced only by another sync's device survives; the allowlist
+  holds exactly one model.
+- Positive: an attributed version no longer in the result is a candidate and
+  is held by the reference gate while the association still stands - the
+  existing "catalog deletes follow authoritative association deletes in the
+  same run" test still passes, because those fixtures already own the device.
+- Full Django suite.
+
+## Rollback
+
+Revert. The table-wide sweep returns, with its known cost.
+
+## Decision Log
+
+- **The test that enshrined the whole-table behaviour was rewritten, not
+  deleted.** `test_software_catalog_reconciliation_deletes_only_unreferenced_
+  rows` asserted that an unreferenced operator row is deleted. That was the
+  defect stated as a requirement; the replacement asserts the opposite and
+  says why.
+- **`InventoryItemSoftware` is attributed too**, through its inventory item's
+  device, so a version that only an inventory item references is still this
+  sync's when the item's device is.
+
+## Open
+
+- Nothing.

--- a/forward_netbox/tests/test_workload_state.py
+++ b/forward_netbox/tests/test_workload_state.py
@@ -503,14 +503,58 @@ class DurableWorkloadStateTest(TestCase):
         )
         self.assertEqual(summaries[0]["delete_rows"], 1)
 
-    def test_software_catalog_reconciliation_deletes_only_unreferenced_rows(self):
+    def _catalog_fixture(self):
+        """A platform, two versions, and a device of this sync on one of them."""
+        from dcim.models import Device
+        from dcim.models import DeviceRole
+        from dcim.models import DeviceType
+        from dcim.models import Manufacturer
         from dcim.models import Platform
+        from dcim.models import Site
         from django.apps import apps
 
         SoftwareVersion = apps.get_model("netbox_dlm", "SoftwareVersion")
         platform = Platform.objects.create(name="Catalog OS", slug="catalog-os")
-        SoftwareVersion.objects.create(platform=platform, version="1.0")
-        SoftwareVersion.objects.create(platform=platform, version="2.0")
+        old = SoftwareVersion.objects.create(platform=platform, version="1.0")
+        new = SoftwareVersion.objects.create(platform=platform, version="2.0")
+        manufacturer = Manufacturer.objects.create(name="Cat Vendor", slug="cat-vendor")
+        device_type = DeviceType.objects.create(
+            manufacturer=manufacturer, model="Cat Model", slug="cat-model"
+        )
+        role = DeviceRole.objects.create(name="Cat Role", slug="cat-role")
+        site = Site.objects.create(name="Cat Site", slug="cat-site")
+        device = Device.objects.create(
+            name="catalog-device", device_type=device_type, role=role, site=site
+        )
+        return platform, old, new, device
+
+    def _own(self, device, sync=None):
+        sync = sync or self.sync
+        ForwardDeviceIdentity.objects.create(
+            sync=sync,
+            ingestion=ForwardIngestion.objects.create(
+                sync=sync, snapshot_id=f"snapshot-{device.name}"
+            ),
+            source_device_key=device.name,
+            device=device,
+        )
+
+    def test_software_catalog_sweep_is_scoped_to_versions_this_sync_can_attribute(
+        self,
+    ):
+        """The sweep used to enumerate the WHOLE SoftwareVersion table.
+
+        Every row the current result did not name was a delete, operator-
+        created rows included. Now a version is a candidate only when a device
+        this sync alone manages references it - the same attribution the
+        association bootstrap uses - and everything else is left alone.
+        """
+        from django.apps import apps
+
+        DeviceSoftware = apps.get_model("netbox_dlm", "DeviceSoftware")
+        platform, old, _new, device = self._catalog_fixture()
+        self._own(device)
+        DeviceSoftware.objects.create(device=device, software_version=old)
         current = {"platform_slug": platform.slug, "version": "2.0"}
 
         workloads, _, summaries = apply_durable_workload_deltas(
@@ -518,11 +562,63 @@ class DurableWorkloadStateTest(TestCase):
             [_workload([current], model_string="netbox_dlm.softwareversion")],
         )
 
-        self.assertEqual(
-            workloads[0].delete_rows,
-            [{"platform_slug": platform.slug, "version": "1.0"}],
+        # Attributed and no longer in the result: a candidate. It survives this
+        # run only because the DeviceSoftware row still references it - the
+        # reference gate, which attribution does not bypass.
+        self.assertEqual(workloads[0].delete_rows, [])
+        self.assertEqual(summaries[0]["protected_delete_rows"], 1)
+
+    def test_an_operator_created_version_is_not_a_sweep_candidate(self):
+        # No device of this sync references `1.0`. Before this change it was
+        # deleted on every full run because it was in the table and not in
+        # the result. Now it is nobody's to sweep.
+        platform, _old, _new, device = self._catalog_fixture()
+        self._own(device)
+        current = {"platform_slug": platform.slug, "version": "2.0"}
+
+        workloads, _, summaries = apply_durable_workload_deltas(
+            self.sync,
+            [_workload([current], model_string="netbox_dlm.softwareversion")],
         )
-        self.assertEqual(summaries[0]["catalog_delete_rows"], 1)
+
+        self.assertEqual(workloads[0].delete_rows, [])
+        self.assertEqual(summaries[0]["catalog_delete_rows"], 0)
+
+    def test_a_version_referenced_only_by_another_syncs_device_is_not_swept(self):
+        from django.apps import apps
+
+        DeviceSoftware = apps.get_model("netbox_dlm", "DeviceSoftware")
+        platform, old, _new, device = self._catalog_fixture()
+        other_source = ForwardSource.objects.create(
+            name="other-catalog-source",
+            type="saas",
+            url="https://fwd.app",
+            status="ready",
+            parameters={},
+        )
+        other_sync = ForwardSync.objects.create(
+            name="other-catalog-sync", source=other_source
+        )
+        self._own(device, sync=other_sync)
+        DeviceSoftware.objects.create(device=device, software_version=old)
+        current = {"platform_slug": platform.slug, "version": "2.0"}
+
+        workloads, _, summaries = apply_durable_workload_deltas(
+            self.sync,
+            [_workload([current], model_string="netbox_dlm.softwareversion")],
+        )
+
+        self.assertEqual(workloads[0].delete_rows, [])
+        self.assertEqual(summaries[0]["catalog_delete_rows"], 0)
+
+    def test_only_the_allowlisted_model_gets_a_catalog_sweep(self):
+        # The negative space of the allowlist: a model outside it never has
+        # rows enumerated from its table, however the branch is keyed.
+        from forward_netbox.utilities.workload_state import CATALOG_SWEEP_MODELS
+
+        self.assertEqual(
+            CATALOG_SWEEP_MODELS, frozenset({"netbox_dlm.softwareversion"})
+        )
 
     def test_catalog_deletes_follow_authoritative_association_deletes_same_run(self):
         from django.apps import apps
@@ -703,6 +799,33 @@ class DurableWorkloadStateTest(TestCase):
         )
         stage_workload_states(peer_ingestion, peer_pending)
         promote_workload_states_locked(peer_ingestion)
+
+        # The version has to be a CANDIDATE for the peer protection to have
+        # anything to protect. The sweep is scoped to versions this sync can
+        # attribute, so a device of this sync references it; the empty,
+        # authoritative devicesoftware workload below then withdraws the local
+        # reference, leaving the peer's association state as the only thing
+        # holding the delete back - which is exactly the path under test.
+        DeviceSoftware = apps.get_model("netbox_dlm", "DeviceSoftware")
+        from dcim.models import Device
+        from dcim.models import DeviceRole
+        from dcim.models import DeviceType
+        from dcim.models import Manufacturer
+        from dcim.models import Site
+
+        manufacturer = Manufacturer.objects.create(
+            name="Peer Vendor", slug="peer-vendor"
+        )
+        device = Device.objects.create(
+            name="peer-owned-device",
+            device_type=DeviceType.objects.create(
+                manufacturer=manufacturer, model="Peer Model", slug="peer-model"
+            ),
+            role=DeviceRole.objects.create(name="Peer Role", slug="peer-role"),
+            site=Site.objects.create(name="Peer Site", slug="peer-site"),
+        )
+        self._own(device)
+        DeviceSoftware.objects.create(device=device, software_version=software_version)
 
         workloads, _, summaries = apply_durable_workload_deltas(
             self.sync,

--- a/forward_netbox/utilities/workload_state.py
+++ b/forward_netbox/utilities/workload_state.py
@@ -722,13 +722,58 @@ def _owned_device_rows(sync, coalesce_fields):
     return rows, device_id_by_name
 
 
-def _software_version_catalog_rows():
+# The models whose durable-state delta may sweep a CATALOGUE - rows the sync
+# did not write in this run and may never have written at all - for deletes.
+# An explicit allowlist, because the sweep below deleted every row in the
+# `SoftwareVersion` table that the current result did not name, operator-
+# created rows included, and nothing named that as a policy: it was a branch
+# keyed on a model string. This is the last whole-table delete producer now
+# that the device sweep is quarantined, and it carries the rule its siblings
+# do: name the allowlist, state which gate is not bypassed, pin the negative
+# space with tests.
+#
+# The gate it does NOT bypass: `_locally_referenced_delete_identities` and the
+# peer protection below still hold every candidate back while something
+# references it. Attribution decides what is a CANDIDATE; reference protection
+# decides what is deleted.
+CATALOG_SWEEP_MODELS = frozenset({"netbox_dlm.softwareversion"})
+
+
+def _software_version_catalog_rows(sync):
+    """Software versions this sync can attribute to itself, as catalogue rows.
+
+    A version is attributable when a `DeviceSoftware` or `InventoryItemSoftware`
+    row on a device only this sync manages references it - the same
+    attribution `_bootstrap_dlm_rows` uses for the association models. A
+    version referenced by nothing, or only by another sync's devices, or only
+    by an operator's, is not this sync's to sweep: it stays whatever the
+    current result says.
+
+    The table-wide enumeration this replaces deleted operator-created versions
+    on every full run and was carried as open through three release plans.
+    """
+    device_ids = _sync_exclusive_device_ids(sync)
+    if not device_ids:
+        return []
     SoftwareVersion = apps.get_model("netbox_dlm", "SoftwareVersion")
-    return list(
-        SoftwareVersion.objects.order_by("platform__slug", "version").values(
-            "platform__slug",
-            "version",
+    DeviceSoftware = apps.get_model("netbox_dlm", "DeviceSoftware")
+    InventoryItemSoftware = apps.get_model("netbox_dlm", "InventoryItemSoftware")
+    version_ids = set(
+        DeviceSoftware.objects.filter(device_id__in=device_ids).values_list(
+            "software_version_id", flat=True
         )
+    )
+    version_ids.update(
+        InventoryItemSoftware.objects.filter(
+            inventory_item__device_id__in=device_ids
+        ).values_list("software_version_id", flat=True)
+    )
+    if not version_ids:
+        return []
+    return list(
+        SoftwareVersion.objects.filter(pk__in=version_ids)
+        .order_by("platform__slug", "version")
+        .values("platform__slug", "version")
     )
 
 
@@ -932,7 +977,7 @@ def apply_durable_workload_deltas(sync, workloads):
                 [*explicit_deletes, *ownership_deletes],
                 coalesce_fields,
             )
-        if model_string == "netbox_dlm.softwareversion" and (
+        if model_string in CATALOG_SWEEP_MODELS and (
             current_state is None or compatible
         ):
             catalog_rows = [
@@ -940,7 +985,7 @@ def apply_durable_workload_deltas(sync, workloads):
                     "platform_slug": row["platform__slug"],
                     "version": row["version"],
                 }
-                for row in _software_version_catalog_rows()
+                for row in _software_version_catalog_rows(sync)
             ]
             catalog_entries = build_state_entries(
                 model_string,


### PR DESCRIPTION
## Summary

`apply_durable_workload_deltas` enumerated the **entire `SoftwareVersion` table** as delete candidates for `netbox_dlm.softwareversion` — every row the current result did not name, operator-created rows included (`workload_state.py:725`). Carried as open through `2026-08-21-ownership-sweep-quarantine.md`, `-release-2.8.9.md` and `2026-08-22-release-2.9.0.md`; with the device sweep quarantined in 2.8.9 this was the last ungated whole-table delete producer.

**Now:** a version is a candidate only when a `DeviceSoftware` or `InventoryItemSoftware` row on a device *only this sync manages* references it — the same attribution `_bootstrap_dlm_rows` already uses for the association models. `CATALOG_SWEEP_MODELS` names the allowlist explicitly.

**What this does not bypass:** the reference protection (`_locally_referenced_delete_identities`) and the peer protection are unchanged. Attribution decides what is a *candidate*; they decide what is *deleted*.

## Negative space, pinned

- an operator-created, unreferenced version survives (it used to be deleted on every full run);
- a version referenced only by another sync's device survives;
- the allowlist holds exactly one model.

The test that enshrined the whole-table behaviour (`…deletes_only_unreferenced_rows`) asserted the defect as a requirement; it is rewritten to assert the opposite and say why. The peer-protection test now attributes its version first — the protection has nothing to hold back for a version that is never a candidate.

## Validation

`test_workload_state` (92), `test_diff_removal_allowlist`, `test_dlm_integration` — OK. `invoke harness-check` ✓.

Plan: `docs/03_Plans/active/2026-09-02-softwareversion-catalog-scope.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa
