### PR TITLE
fix: the dependency-skip rollup says which way the dependency points

### DIFF
--- a/docs/03_Plans/active/2026-09-02-skip-rollup-direction.md
+++ b/docs/03_Plans/active/2026-09-02-skip-rollup-direction.md
@@ -1,0 +1,72 @@
+# The dependency-skip rollup says which way the dependency points
+
+## Goal
+
+Stop the rolled-up dependency-skip issue from describing a protected delete
+as a missing parent, and make ten rows distinguishable from ten-of-many.
+
+## Why
+
+`emit_dependency_skip_issue_summary` hard-coded "their NetBox parent is not
+synced yet" and recommended enabling the parent sync for every skip in a
+model. A customer's `netbox_dlm.softwareversion` skips were protected
+deletes - a surviving `inventoryitemsoftware` row refusing the prune - and the
+rollup told him to sync a parent that was already there. The per-row path had
+learned the difference in 2.8.x (`dependency_phrase`); the rollup had not.
+Carried as open through `2026-08-21-ownership-sweep-quarantine.md`,
+`-release-2.8.9.md` and `2026-08-22-release-2.9.0.md`.
+
+## Constraints
+
+- `DEPENDENCY_SKIP_ISSUE_DETAIL_LIMIT` and its `> limit` trigger are
+  unchanged: at exactly the cap nothing is suppressed, so the cap IS the
+  count. The survey's suggestion to emit at `>=` was wrong and is not taken.
+- Nothing customer-valued is persisted. The reason token is derived from the
+  dependency MODEL name, a schema identifier.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/sync_reporting.py` - `dependency_skip_direction`,
+  `dependency_skip_reason`, per-direction buckets recorded alongside the
+  per-model count, a direction-aware rollup, the cap sentence on the last
+  per-row issue, `skip_reason` / `skip_direction` in the persisted context.
+- `forward_netbox/tests/test_skip_rollup_direction.py`.
+
+## Approach
+
+Bucket each skip by `dependency_is_protecting` as it is recorded, keeping up
+to five distinct dependency models per direction. The rollup renders one
+sentence per non-empty bucket, each with its own remedy, and persists both
+counts. The catalogued reason (`missing-device`, `still-referenced-by-
+inventoryitemsoftware`, ...) is derived from the same two attributes rather
+than taught to twenty-seven raisers separately; the three that name nothing
+persist `dependency-unnamed`.
+
+## Validation
+
+`test_skip_rollup_direction.py`: a protected-delete rollup names the child
+and the right remedy and never the wrong one; a missing-parent rollup keeps
+its remedy; a mixed model gets one sentence per direction with both counts;
+exactly the cap emits no rollup and the last per-row issue says the cap is
+here; the reason and direction reach `coalesce_fields`; an unnamed raiser is
+recorded honestly. `test_dlm_integration`, `test_issue_diagnosis`,
+`test_skip_names_netbox_row`, `test_health`. Full Django suite.
+
+## Rollback
+
+Revert. The rollup returns to one sentence, wrong for half the cases.
+
+## Decision Log
+
+- **Derived, not taught.** The reason vocabulary lived in the aggregated-
+  warning callers and never reached the database. Twenty-four raisers already
+  name their dependency model on the exception; deriving the reason from that
+  closes the gap in one place and makes the three that name nothing visible
+  as `dependency-unnamed` rather than silently absent.
+- **The cap trigger stays at `>`.** Ten rows at a cap of ten means ten. The
+  ambiguity was that the panel could not say so; the last per-row issue now
+  does.
+
+## Open
+
+- Nothing.

--- a/forward_netbox/tests/test_skip_rollup_direction.py
+++ b/forward_netbox/tests/test_skip_rollup_direction.py
@@ -1,0 +1,153 @@
+# The dependency-skip rollup said "their NetBox parent is not synced yet" and
+# recommended enabling the parent sync for EVERY skip in a model - including a
+# protected-delete skip, where a surviving child is refusing the prune and the
+# remedy is the opposite. The per-row path had learned the difference
+# (`dependency_phrase`); the rollup had not. Carried as open through three
+# release plans.
+#
+# Two smaller things ride along: the tenth per-row issue says the cap is here,
+# so ten rows cannot masquerade as the count; and the catalogued skip reason
+# now reaches the database, derived from what twenty-four raisers already say.
+from types import SimpleNamespace
+
+from django.test import TestCase
+
+from forward_netbox.exceptions import ForwardDependencySkipError
+from forward_netbox.models import ForwardIngestion
+from forward_netbox.models import ForwardIngestionIssue
+from forward_netbox.models import ForwardSource
+from forward_netbox.models import ForwardSync
+from forward_netbox.utilities.sync_reporting import dependency_skip_reason
+from forward_netbox.utilities.sync_reporting import emit_dependency_skip_issue_summary
+from forward_netbox.utilities.sync_reporting import record_issue
+
+MODEL = "netbox_dlm.softwareversion"
+
+
+class _Logger:
+    def __init__(self):
+        self.lines = []
+
+    def log_info(self, message, obj=None):
+        self.lines.append(("info", message))
+
+    def log_warning(self, message, obj=None):
+        self.lines.append(("warning", message))
+
+    def log_failure(self, message, obj=None):
+        self.lines.append(("failure", message))
+
+
+class SkipRollupDirectionTest(TestCase):
+    def setUp(self):
+        source = ForwardSource.objects.create(
+            name="rollup-src", type="saas", url="https://fwd.app", status="ready"
+        )
+        sync = ForwardSync.objects.create(name="rollup-sync", source=source)
+        self.ingestion = ForwardIngestion.objects.create(sync=sync, snapshot_id="s")
+        self.runner = SimpleNamespace(
+            ingestion=self.ingestion,
+            sync=sync,
+            logger=_Logger(),
+            DEPENDENCY_SKIP_ISSUE_DETAIL_LIMIT=3,
+            _dependency_skip_issue_counts={},
+            _dependency_skip_issue_samples={},
+            _recorded_issue_ids=set(),
+        )
+
+    def _skip(self, *, protecting, dependency="netbox_dlm.inventoryitemsoftware", n=1):
+        for index in range(n):
+            record_issue(
+                self.runner,
+                MODEL,
+                "skipped",
+                {"platform_slug": "ios", "version": f"1.{index}"},
+                exception=ForwardDependencySkipError(
+                    "skipped",
+                    model_string=MODEL,
+                    dependency=dependency,
+                    dependency_is_protecting=protecting,
+                ),
+                context={"version": f"1.{index}"},
+            )
+
+    def _summary(self):
+        emit_dependency_skip_issue_summary(self.runner, MODEL)
+        return ForwardIngestionIssue.objects.filter(
+            ingestion=self.ingestion, coalesce_fields__dependency_skip_summary=True
+        ).first()
+
+    def test_a_protected_delete_rollup_names_the_child_and_the_right_remedy(self):
+        self._skip(protecting=True, n=5)
+
+        summary = self._summary()
+
+        self.assertIsNotNone(summary)
+        self.assertIn("surviving NetBox child", summary.message)
+        self.assertIn(
+            "still referenced by netbox_dlm.inventoryitemsoftware", summary.message
+        )
+        self.assertIn("refused deletes, not missing parents", summary.message)
+        self.assertNotIn("not synced yet", summary.message)
+        self.assertNotIn("Enable the parent sync", summary.message)
+        self.assertEqual(summary.coalesce_fields["protected_delete_count"], 5)
+        self.assertEqual(summary.coalesce_fields["missing_parent_count"], 0)
+
+    def test_a_missing_parent_rollup_keeps_the_parent_remedy(self):
+        self._skip(protecting=False, dependency="dcim.device", n=4)
+
+        summary = self._summary()
+
+        self.assertIn("not synced yet", summary.message)
+        self.assertIn("waiting on dcim.device", summary.message)
+        self.assertIn("Enable the parent sync", summary.message)
+        self.assertNotIn("surviving", summary.message)
+
+    def test_a_mixed_model_gets_one_sentence_per_direction(self):
+        self._skip(protecting=False, dependency="dcim.device", n=2)
+        self._skip(protecting=True, n=3)
+
+        summary = self._summary()
+
+        self.assertIn("2 skipped because a NetBox parent", summary.message)
+        self.assertIn("3 skipped because a surviving NetBox child", summary.message)
+        self.assertIn("5 netbox_dlm.softwareversion row(s) skipped", summary.message)
+        self.assertIn("(2 beyond the first 3 shown individually)", summary.message)
+
+    def test_exactly_the_cap_emits_no_rollup_and_is_the_true_count(self):
+        # At the cap nothing is suppressed, so ten IS the count. What changes
+        # is that the last per-row issue says so.
+        self._skip(protecting=True, n=3)
+
+        self.assertIsNone(self._summary())
+        rows = list(
+            ForwardIngestionIssue.objects.filter(ingestion=self.ingestion).order_by(
+                "pk"
+            )
+        )
+        self.assertEqual(len(rows), 3)
+        self.assertIn("rolled up into one summary issue", rows[-1].message)
+        self.assertNotIn("rolled up", rows[0].message)
+
+    def test_the_catalogued_reason_reaches_the_database(self):
+        self._skip(protecting=True, n=1)
+        self._skip(protecting=False, dependency="dcim.interface", n=1)
+
+        rows = list(
+            ForwardIngestionIssue.objects.filter(ingestion=self.ingestion).order_by(
+                "pk"
+            )
+        )
+        self.assertEqual(
+            rows[0].coalesce_fields["skip_reason"],
+            "still-referenced-by-inventoryitemsoftware",
+        )
+        self.assertEqual(rows[0].coalesce_fields["skip_direction"], "protecting")
+        self.assertEqual(rows[1].coalesce_fields["skip_reason"], "missing-interface")
+        self.assertEqual(rows[1].coalesce_fields["skip_direction"], "missing")
+
+    def test_a_raiser_that_names_nothing_is_recorded_honestly(self):
+        self.assertEqual(
+            dependency_skip_reason(ForwardDependencySkipError("x")),
+            "dependency-unnamed",
+        )

--- a/forward_netbox/utilities/sync_reporting.py
+++ b/forward_netbox/utilities/sync_reporting.py
@@ -130,28 +130,112 @@ def record_aggregated_skip_warning(
     runner._aggregated_skip_warning_counts[key] = count + 1
 
 
+def dependency_skip_direction(exception) -> str:
+    """``protecting`` when a surviving child refuses a delete, else ``missing``.
+
+    The two are opposite conditions with opposite remedies - "nothing to build
+    on" wants the parent synced first; "something still needs this" wants the
+    child gone first - and every rollup used to word both as the first.
+    """
+    if getattr(exception, "dependency_is_protecting", False):
+        return "protecting"
+    return "missing"
+
+
+def dependency_skip_reason(exception) -> str:
+    """The catalogued reason a skip persists with, derived from the exception.
+
+    The vocabulary (`missing-device`, `missing-interface`, ...) existed in
+    `record_aggregated_skip_warning`'s callers and never reached the database:
+    twenty-four raisers name their dependency model on the exception and one
+    marks it protecting, so the reason is derivable from what they already
+    say rather than something each raiser has to be taught separately. A
+    raiser that names nothing records `dependency-unnamed`, which is honest
+    about the gap rather than a guess.
+    """
+    dependency = str(getattr(exception, "dependency", "") or "")
+    if not dependency:
+        return "dependency-unnamed"
+    short = dependency.rsplit(".", 1)[-1]
+    if dependency_skip_direction(exception) == "protecting":
+        return f"still-referenced-by-{short}"
+    return f"missing-{short}"
+
+
+def _dependency_skip_directions(runner):
+    """Per-model, per-direction counts. Lazily created: not every runner-shaped
+    object that records issues declares the attribute."""
+    directions = getattr(runner, "_dependency_skip_issue_directions", None)
+    if directions is None:
+        directions = {}
+        try:
+            runner._dependency_skip_issue_directions = directions
+        except AttributeError:  # pragma: no cover - frozen runner stand-ins
+            pass
+    return directions
+
+
+def _record_dependency_skip_direction(runner, model_string, exception):
+    buckets = _dependency_skip_directions(runner).setdefault(
+        model_string, {"missing": 0, "protecting": 0, "dependencies": {}}
+    )
+    direction = dependency_skip_direction(exception)
+    buckets[direction] += 1
+    dependency = str(getattr(exception, "dependency", "") or "")
+    if dependency:
+        per_direction = buckets["dependencies"].setdefault(direction, [])
+        if dependency not in per_direction and len(per_direction) < 5:
+            per_direction.append(dependency)
+
+
 def emit_dependency_skip_issue_summary(runner, model_string):
     """One rolled-up issue when dependency skips for a model exceeded the
-    per-model detail cap (the individual rows past the cap were suppressed)."""
+    per-model detail cap (the individual rows past the cap were suppressed).
+
+    Worded per DIRECTION. The rollup used to say "their NetBox parent is not
+    synced yet" and recommend enabling the parent sync for every skip in the
+    model - including a protected-delete skip, where a surviving child is
+    refusing the prune and the remedy is the opposite. The per-row path had
+    already learned the difference (`dependency_phrase`); the rollup had not.
+    """
     total = runner._dependency_skip_issue_counts.get(model_string, 0)
     limit = runner.DEPENDENCY_SKIP_ISSUE_DETAIL_LIMIT
     if total <= limit:
         return
     remainder = total - limit
-    remedy = (
-        " Enable the parent sync (device types / devices) first. For DLM "
-        "hardware notices with the alias-aware device query, use the "
-        "'Forward DLM Hardware Notices with NetBox Aliases' map."
-    )
+    buckets = _dependency_skip_directions(runner).get(model_string) or {
+        "missing": total,
+        "protecting": 0,
+        "dependencies": {},
+    }
+    sentences = []
+    if buckets["missing"]:
+        named = ", ".join(buckets["dependencies"].get("missing", ())) or "a parent"
+        sentences.append(
+            f"{buckets['missing']} skipped because a NetBox parent is not synced "
+            f"yet (waiting on {named}). Enable the parent sync first; for DLM "
+            "hardware notices with the alias-aware device query, use the "
+            "'Forward DLM Hardware Notices with NetBox Aliases' map."
+        )
+    if buckets["protecting"]:
+        named = ", ".join(buckets["dependencies"].get("protecting", ())) or "a child"
+        sentences.append(
+            f"{buckets['protecting']} skipped because a surviving NetBox child "
+            f"still references a row this run would delete (still referenced by "
+            f"{named}). These are refused deletes, not missing parents: the row "
+            "is kept until the referencing rows are removed by their own "
+            "model's reconciliation."
+        )
     message = (
-        f"{total} {model_string} row(s) skipped because their NetBox parent "
-        f"is not synced yet ({remainder} beyond the first {limit} shown "
-        f"individually).{remedy}"
+        f"{total} {model_string} row(s) skipped ({remainder} beyond the first "
+        f"{limit} shown individually). " + " ".join(sentences)
     )
     context = {
         "dependency_skip_summary": True,
         "dependency_skip_count": total,
         "detail_limit": limit,
+        "missing_parent_count": buckets["missing"],
+        "protected_delete_count": buckets["protecting"],
     }
     from ..models import ForwardIngestionIssue
 
@@ -344,6 +428,7 @@ def record_issue(
     ):
         seen = runner._dependency_skip_issue_counts.get(model_string, 0) + 1
         runner._dependency_skip_issue_counts[model_string] = seen
+        _record_dependency_skip_direction(runner, model_string, exception)
         if seen > runner.DEPENDENCY_SKIP_ISSUE_DETAIL_LIMIT:
             samples = runner._dependency_skip_issue_samples.setdefault(model_string, [])
             example = str(
@@ -448,16 +533,40 @@ def record_issue(
     # exactly the message it recorded before, byte for byte.
     netbox_pk = getattr(exception, "netbox_pk", None) if exception is not None else None
     identity_sentence = f" Affected NetBox row: pk {netbox_pk}." if netbox_pk else ""
+    # The last per-row issue before the cap says the cap is here. A panel
+    # showing exactly ten rows used to be indistinguishable from one showing
+    # ten of many: the rollup issue that carries the rest is a separate row an
+    # operator has to know to look for.
+    cap_sentence = (
+        " Further rows for this model are rolled up into one summary issue."
+        if dependency_skip_detail_number is not None
+        and dependency_skip_detail_number == runner.DEPENDENCY_SKIP_ISSUE_DETAIL_LIMIT
+        else ""
+    )
     message = (
         message
         if is_dependency_skip_summary
-        else f"{model_string} row processing {outcome_word} ({detail}).{identity_sentence}"
+        else (
+            f"{model_string} row processing {outcome_word} ({detail})."
+            f"{identity_sentence}{cap_sentence}"
+        )
     )
     context_data = (
         json_safe_value(context or {})
         if is_dependency_skip_summary
         else diagnostic_shape(dict(context or {}))
     )
+    if (
+        exception_name == "ForwardDependencySkipError"
+        and not is_dependency_skip_summary
+    ):
+        # The catalogued reason, persisted where the per-row vocabulary never
+        # reached before. A schema-derived token, never a value.
+        context_data = {
+            **context_data,
+            "skip_reason": dependency_skip_reason(exception),
+            "skip_direction": dependency_skip_direction(exception),
+        }
     defaults_data = diagnostic_shape(dict(defaults or {}))
     # Row shape plus the schema-level diagnosis. The keys are disjoint
     # (`type`/`fields` vs `exception_type`/`constraint_name`/...), so this stays


### PR DESCRIPTION
## Summary

`emit_dependency_skip_issue_summary` hard-coded *"their NetBox parent is not synced yet"* and recommended enabling the parent sync for **every** skip in a model — including a protected-delete skip, where a surviving child is refusing the prune and the remedy is the opposite. A customer's `netbox_dlm.softwareversion` skips were exactly that, and the rollup told him to sync a parent that was already there. The per-row path had learned the difference in 2.8.x (`dependency_phrase`); the rollup had not. Carried as open through three release plans.

**Now:** skips are bucketed by `dependency_is_protecting` as they are recorded (up to five distinct dependency models per direction); the rollup renders one sentence per non-empty bucket, each with its own remedy, and persists `missing_parent_count` / `protected_delete_count`.

**Two smaller closures ride along:**
- The catalogued skip reason (`missing-device`, `still-referenced-by-inventoryitemsoftware`, …) now reaches `ForwardIngestionIssue.coalesce_fields` as `skip_reason` / `skip_direction`. Derived from the two attributes 24 of 27 raisers already set rather than taught to each site; the three that name nothing persist `dependency-unnamed`, which is honest about the gap.
- The last per-row issue before the cap says further rows are rolled up, so a panel showing ten cannot masquerade as the count. The cap trigger stays `> limit` — at exactly the cap nothing is suppressed, so the survey's `>=` suggestion was wrong and is not taken.

## Validation

131 tests OK: `test_skip_rollup_direction` (6 new), `test_dlm_integration`, `test_issue_diagnosis`, `test_skip_names_netbox_row`, `test_health`, `test_module_readiness_rollup`. `invoke harness-check` ✓.

Plan: `docs/03_Plans/active/2026-09-02-skip-rollup-direction.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa
