### PR TITLE
feat: measure the last three drift models, and isolate the preview per model

### DIFF
--- a/docs/03_Plans/active/2026-09-02-drift-last-models-and-preview-isolation.md
+++ b/docs/03_Plans/active/2026-09-02-drift-last-models-and-preview-isolation.md
@@ -1,0 +1,83 @@
+# The last two drift models, and a preview that survives one model failing
+
+## Goal
+
+Measure `dcim.virtualchassis`, `netbox_dlm.inventoryitemsoftware` and
+`netbox_dlm.inventoryitemroleplatform`, so every fetched model has a
+comparison; and stop one model's comparison failure from taking the whole
+dependency preview down.
+
+## Why
+
+After slice nine, three fetched models still reported the workload upper
+bound: `virtualchassis` because the bulk path declined to answer, and the two
+DLM inventory-item models because slice six left their chains unaudited. And
+`2026-08-20-preview-runner-priming-contract.md` recorded that one missing
+attribute killed the whole preview - every model "Not measured", the report
+empty - and that per-model isolation would have turned that outage into a
+single cell.
+
+## Constraints
+
+- `virtualchassis` is compared through its ADAPTER, because that is the
+  production path: syncs run in a branch, and the bulk path defers to
+  `apply_dcim_virtualchassis` whenever one is active.
+- The leaf rule for the DLM pair: a software version the row would create is
+  `softwareversion`'s drift; the inventory-item row is an update if it exists
+  and a create if not.
+- A job timeout is never caught by the isolation. The worker is being torn
+  down; swallowing it would let the job look finished.
+- The recorded error is an exception NAME, never a message.
+
+## Touched Surfaces
+
+- `sync_device.py` - `preview` on `apply_dcim_virtualchassis`.
+- `sync_dlm.py` - `preview` on the two inventory-item applies; the
+  role-platform ensure returns `(None, None)` for an absent platform instead of
+  matching the role's mapping to another platform; per-key outcomes beside the
+  cache.
+- `drift_comparison.py` - `_compare_dcim_virtualchassis`; the DLM registry.
+- `views.py` - `_compare_rows_by_model`, `comparison_error` on the summary.
+- `drift_report.py` and the drift report template - the cell says why.
+- The dependency preview page header: "Dependency Preview", the one place it
+  was still called a dry run.
+
+## Approach
+
+The virtualchassis adapter classifies row by row: an absent chassis is a
+create outright (the membership cannot exist yet), a member whose chassis or
+position differs is an update, a member in place takes the chassis's own
+upsert verdict, and the one direct ORM write - the membership update - is
+answered before rather than shimmed. The DLM chain needed one guard, in the
+ensure: an absent platform under preview must not let the role-keyed mapping
+lookup match the role's mapping to some other platform - the same
+absent-parent trap the routing and ACI slices hit.
+
+The preview loop is factored into `_compare_rows_by_model`, which catches per
+model, records the exception name, logs with traceback, and continues.
+
+## Validation
+
+`test_virtualchassis_drift_comparison.py`, `test_dlm_inventoryitem_drift_
+comparison.py`, `test_preview_isolation.py`; `test_empty_comparison_is_not_a_
+measurement` flips its virtualchassis assertion to measured. Adjacent:
+`test_dlm_drift_comparison`, `test_dlm_integration`, `test_drift_report`,
+`test_sync_device`. Full Django suite.
+
+## Rollback
+
+Revert. The three models return to the upper bound; one failing comparison
+again fails the preview.
+
+## Decision Log
+
+- **The adapter is the comparison for virtualchassis**, not a preview mode on
+  the two-phase bulk path. The bulk path's answer would only ever describe a
+  branch-less run, which production never is.
+- **Outcomes beside the cache, not in it.** Two callers unpack the cached
+  `(platform, mapping)` pair; changing its shape for one preview flag is the
+  kind of edit that breaks the apply to help the preview.
+
+## Open
+
+- Nothing.

--- a/forward_netbox/templates/forward_netbox/forwardsync_dependency_preview.html
+++ b/forward_netbox/templates/forward_netbox/forwardsync_dependency_preview.html
@@ -17,7 +17,7 @@
 <div class="row mb-3">
   <div class="col col-md-5">
     <div class="card">
-      <h5 class="card-header">{% trans "Dependency Dry Run" %}</h5>
+      <h5 class="card-header">{% trans "Dependency Preview" %}</h5>
       <div class="card-body">
         <table class="table table-hover attr-table">
           <tr>

--- a/forward_netbox/templates/forward_netbox/forwardsync_drift_report.html
+++ b/forward_netbox/templates/forward_netbox/forwardsync_drift_report.html
@@ -273,7 +273,7 @@
             <td>{{ row.pending_removes }}</td>
             <td>{{ row.estimated_apply_work }}</td>
             <td>{% if row.comparison_available %}{% if row.drift %}<strong class="text-warning">{{ row.drift }}</strong>{% else %}0{% endif %}{% else %}{% trans "Not measured" %}{% endif %}</td>
-            <td>{% if not row.comparison_available %}<span class="badge text-bg-secondary">{% trans "Not measured" %}</span>{% elif row.in_sync %}<span class="badge text-bg-success">{% trans "Yes" %}</span>{% else %}<span class="badge text-bg-warning">{% trans "No" %}</span>{% endif %}</td>
+            <td>{% if not row.comparison_available %}<span class="badge text-bg-secondary"{% if row.comparison_error %} title="{% blocktrans with error=row.comparison_error %}The comparison for this model raised {{ error }}; the other models were still measured.{% endblocktrans %}"{% endif %}>{% trans "Not measured" %}{% if row.comparison_error %} ({{ row.comparison_error }}){% endif %}</span>{% elif row.in_sync %}<span class="badge text-bg-success">{% trans "Yes" %}</span>{% else %}<span class="badge text-bg-warning">{% trans "No" %}</span>{% endif %}</td>
           </tr>
         {% empty %}
           <tr><td colspan="7" class="text-muted">{% trans "No model results in the preview." %}</td></tr>

--- a/forward_netbox/tests/test_dlm_drift_comparison.py
+++ b/forward_netbox/tests/test_dlm_drift_comparison.py
@@ -193,14 +193,15 @@ class DlmPreviewTest(TestCase):
 
     # --- the two that decline ------------------------------------------------
 
-    def test_the_unaudited_dlm_models_report_no_comparison(self):
-        # Absence from `_ADAPTER_COMPARISONS` is the documented answer, and it
-        # must stay that until their dependency chains are audited.
+    def test_the_once_unaudited_dlm_models_are_now_measured(self):
+        # Their chains were audited after this slice and wired up; see
+        # `test_dlm_inventoryitem_drift_comparison`. Pinned here so the
+        # stand-in cannot rot the way `softwareversion` did for slice six.
         for model_string in (
             "netbox_dlm.inventoryitemsoftware",
             "netbox_dlm.inventoryitemroleplatform",
         ):
-            self.assertIsNone(
-                compare_model_rows(None, model_string, [self._row()]),
+            self.assertIsNotNone(
+                compare_model_rows(None, model_string, []),
                 model_string,
             )

--- a/forward_netbox/tests/test_dlm_inventoryitem_drift_comparison.py
+++ b/forward_netbox/tests/test_dlm_inventoryitem_drift_comparison.py
@@ -1,0 +1,155 @@
+# The two netbox-dlm models slice six left unmeasured: `inventoryitemsoftware`
+# and `inventoryitemroleplatform`. Deferred because their chains had not been
+# audited for the writes-behind-a-runner-call trap; the audit found two reads
+# that raise a dependency skip, a platform ensure and an upsert the preview
+# overrides, and the same software-version upsert already previewed - and one
+# guard to add, in the ensure, for the absent-platform case.
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import InventoryItem
+from dcim.models import InventoryItemRole
+from dcim.models import Manufacturer
+from dcim.models import Platform
+from dcim.models import Site
+from django.apps import apps
+from django.test import TestCase
+
+from forward_netbox.utilities.drift_comparison import compare_model_rows
+
+SOFTWARE = "netbox_dlm.inventoryitemsoftware"
+MAPPING = "netbox_dlm.inventoryitemroleplatform"
+
+
+def _dlm(name):
+    return apps.get_model("netbox_dlm", name)
+
+
+class InventoryItemSoftwarePreviewTest(TestCase):
+    def setUp(self):
+        site = Site.objects.create(name="IIS Site", slug="iis-site")
+        mfr = Manufacturer.objects.create(name="IIS Mfr", slug="iis-mfr")
+        dtype = DeviceType.objects.create(
+            manufacturer=mfr, model="IIS DT", slug="iis-dt"
+        )
+        role = DeviceRole.objects.create(name="IIS Role", slug="iis-role")
+        self.device = Device.objects.create(
+            name="iis-dev", site=site, device_type=dtype, role=role, status="active"
+        )
+        self.item_role = InventoryItemRole.objects.create(
+            name="MANAGEMENT CONTROLLER", slug="management-controller"
+        )
+        self.item = InventoryItem.objects.create(
+            device=self.device, name="CIMC", role=self.item_role
+        )
+
+    def _row(self, **extra):
+        return {
+            "device": "iis-dev",
+            "inventory_item": "CIMC",
+            "role": "MANAGEMENT CONTROLLER",
+            "role_slug": "management-controller",
+            "platform": "CIMC",
+            "platform_slug": "cimc",
+            "version": "4.3(2.230270)",
+            **extra,
+        }
+
+    def _existing(self, version="4.3(2.230270)"):
+        platform = Platform.objects.create(name="CIMC", slug="cimc")
+        _dlm("InventoryItemRolePlatform").objects.create(
+            role=self.item_role, platform=platform
+        )
+        software_version = _dlm("SoftwareVersion").objects.create(
+            platform=platform, version=version
+        )
+        return _dlm("InventoryItemSoftware").objects.create(
+            inventory_item=self.item, software_version=software_version
+        )
+
+    def _counts(self):
+        return {
+            name: _dlm(name).objects.count()
+            for name in (
+                "InventoryItemSoftware",
+                "InventoryItemRolePlatform",
+                "SoftwareVersion",
+            )
+        }
+
+    def test_a_preview_writes_nothing(self):
+        before = (self._counts(), Platform.objects.count())
+        counts = compare_model_rows(None, SOFTWARE, [self._row()])
+        self.assertEqual(counts["creates"], 1)
+        self.assertEqual((self._counts(), Platform.objects.count()), before)
+
+    def test_everything_absent_is_one_create_under_this_model(self):
+        # Platform, mapping and software version would all be created; each is
+        # another model's drift. This row is one create here.
+        counts = compare_model_rows(None, SOFTWARE, [self._row()])
+        self.assertEqual(
+            counts, {"creates": 1, "updates": 0, "unchanged": 0, "rejected": 0}
+        )
+
+    def test_an_existing_row_on_the_same_version_is_unchanged(self):
+        self._existing()
+        counts = compare_model_rows(None, SOFTWARE, [self._row()])
+        self.assertEqual(counts["unchanged"], 1)
+
+    def test_a_version_change_is_an_update(self):
+        self._existing(version="4.1(3f)")
+        counts = compare_model_rows(None, SOFTWARE, [self._row()])
+        self.assertEqual(counts["updates"], 1)
+
+    def test_a_new_platform_on_an_existing_row_is_an_update_not_a_sibling_match(self):
+        """The guard. The mapping is keyed on the role alone, so an absent
+        platform dropped from the lookup would match the role's mapping to
+        SOME OTHER platform and the row could read unchanged."""
+        self._existing()
+        counts = compare_model_rows(
+            None, SOFTWARE, [self._row(platform="APIC", platform_slug="apic")]
+        )
+        self.assertEqual(counts["updates"], 1)
+        self.assertEqual(counts["unchanged"], 0)
+
+    def test_a_missing_inventory_item_is_rejected_not_drift(self):
+        counts = compare_model_rows(None, SOFTWARE, [self._row(inventory_item="NOPE")])
+        self.assertEqual(counts["rejected"], 1)
+        self.assertEqual(counts["creates"], 0)
+
+    def test_a_missing_device_is_rejected(self):
+        counts = compare_model_rows(None, SOFTWARE, [self._row(device="nope")])
+        self.assertEqual(counts["rejected"], 1)
+
+
+class InventoryItemRolePlatformPreviewTest(InventoryItemSoftwarePreviewTest):
+    def test_an_absent_mapping_is_a_create(self):
+        Platform.objects.create(name="CIMC", slug="cimc")
+        counts = compare_model_rows(None, MAPPING, [self._row()])
+        self.assertEqual(counts["creates"], 1)
+
+    def test_an_absent_platform_is_a_create_too(self):
+        counts = compare_model_rows(None, MAPPING, [self._row()])
+        self.assertEqual(counts["creates"], 1)
+
+    def test_an_existing_mapping_is_unchanged(self):
+        self._existing()
+        counts = compare_model_rows(None, MAPPING, [self._row()])
+        self.assertEqual(counts["unchanged"], 1)
+
+    def test_a_repeated_row_is_unchanged_because_the_apply_writes_it_once(self):
+        # The ensure caches by (role, platform); the apply performs one upsert
+        # for the first row and none for the rest. The preview says the same.
+        # The platform exists, so the ensure reaches its upsert and its cache.
+        Platform.objects.create(name="CIMC", slug="cimc")
+        counts = compare_model_rows(None, MAPPING, [self._row(), self._row()])
+        self.assertEqual(counts["creates"], 1)
+        self.assertEqual(counts["unchanged"], 1)
+
+    def test_a_platform_change_on_the_role_is_an_update(self):
+        self._existing()
+        Platform.objects.create(name="APIC", slug="apic")
+        counts = compare_model_rows(
+            None, MAPPING, [self._row(platform="APIC", platform_slug="apic")]
+        )
+        self.assertEqual(counts["updates"], 1)

--- a/forward_netbox/tests/test_drift_comparison.py
+++ b/forward_netbox/tests/test_drift_comparison.py
@@ -131,18 +131,18 @@ class UncoveredModelsReportNoComparisonTest(TestCase):
     failure mode here that leads somewhere bad.
     """
 
-    def test_the_unaudited_bespoke_paths_return_none_under_preview(self):
-        """The one path still without a comparison.
+    def test_the_once_unaudited_bespoke_path_is_now_measured(self):
+        """`virtualchassis` no longer declines to answer.
 
-        `virtualchassis` creates VirtualChassis rows and then reads their pks
-        back to assign devices, so skipping the first phase leaves the second
-        unclassifiable - there is no verdict to shortcut to, the way there was
-        for `interface`. Until that is handled it must decline to answer rather
-        than answer wrongly.
+        The bulk path still cannot preview it - its second phase reads the
+        first phase's pk - but that is the bulk path's problem, not the
+        model's: production syncs run in a branch, where the bulk path defers
+        to `apply_dcim_virtualchassis`, and the comparison now goes through
+        that adapter. See `test_virtualchassis_drift_comparison`.
         """
-        self.assertIsNone(
+        self.assertIsNotNone(
             compare_model_rows(None, "dcim.virtualchassis", [{"name": "x"}]),
-            "virtualchassis has no comparison yet and must not claim one",
+            "virtualchassis is compared through its adapter",
         )
 
     def test_an_empty_row_set_is_zero_drift_rather_than_unmeasured(self):

--- a/forward_netbox/tests/test_empty_comparison_is_not_a_measurement.py
+++ b/forward_netbox/tests/test_empty_comparison_is_not_a_measurement.py
@@ -59,10 +59,10 @@ class AnUncomparableModelNeverReportsZeroTest(TestCase):
         self.assertIsNotNone(compare_model_rows(None, "netbox_dlm.softwareversion", []))
         self.assertIsNotNone(compare_model_rows(None, "netbox_cisco_aci.acitenant", []))
 
-    def test_a_model_that_declines_on_purpose_still_declines_when_empty(self):
-        # virtualchassis returns None deliberately; an empty list must not
-        # promote it to measured.
-        self.assertIsNone(compare_model_rows(None, "dcim.virtualchassis", []))
+    def test_the_model_that_declined_on_purpose_is_now_measured(self):
+        # virtualchassis returned None deliberately through the bulk path; it
+        # is now compared through its adapter, so an empty list is a real zero.
+        self.assertIsNotNone(compare_model_rows(None, "dcim.virtualchassis", []))
 
     def test_an_unknown_model_is_not_measured(self):
         self.assertIsNone(compare_model_rows(None, "nonexistent.model", []))

--- a/forward_netbox/tests/test_preview_isolation.py
+++ b/forward_netbox/tests/test_preview_isolation.py
@@ -1,0 +1,61 @@
+# One model's comparison must not take the whole dependency preview down.
+#
+# 2.8.8's regression: one missing attribute in one model's classification
+# raised out of the preview loop and failed the job - every model "Not
+# measured", the report empty. Its plan recorded per-model isolation as the fix
+# that would have turned the outage into a single cell.
+from unittest.mock import patch
+
+from django.test import TestCase
+from rq.timeouts import JobTimeoutException
+
+from forward_netbox.views import _compare_rows_by_model
+
+
+def _boom(sync, model_string, rows):
+    if model_string == "broken.model":
+        raise AttributeError(
+            "'PreviewRunner' object has no attribute '_optional_model'"
+        )
+    return {"creates": len(rows), "updates": 0, "unchanged": 0, "rejected": 0}
+
+
+class PreviewIsolationTest(TestCase):
+    def test_one_failing_model_is_a_single_cell_not_an_outage(self):
+        rows = {
+            "dcim.site": [{"name": "a"}],
+            "broken.model": [{}],
+            "dcim.vrf": [{}, {}],
+        }
+        with patch(
+            "forward_netbox.utilities.drift_comparison.compare_model_rows",
+            side_effect=_boom,
+        ):
+            result = _compare_rows_by_model(None, rows)
+
+        self.assertEqual(result["comparison"]["dcim.site"]["creates"], 1)
+        self.assertEqual(result["comparison"]["dcim.vrf"]["creates"], 2)
+        self.assertIsNone(result["comparison"]["broken.model"])
+        self.assertEqual(result["errors"], {"broken.model": "AttributeError"})
+        # Cost is still recorded for the model that failed, so a slow failure
+        # is visible as such.
+        self.assertIn("broken.model", result["runtime_ms"])
+
+    def test_the_error_is_a_name_not_a_message(self):
+        with patch(
+            "forward_netbox.utilities.drift_comparison.compare_model_rows",
+            side_effect=_boom,
+        ):
+            result = _compare_rows_by_model(None, {"broken.model": [{}]})
+        self.assertNotIn("_optional_model", result["errors"]["broken.model"])
+
+    def test_a_job_timeout_is_not_swallowed(self):
+        def timeout(sync, model_string, rows):
+            raise JobTimeoutException("torn down")
+
+        with patch(
+            "forward_netbox.utilities.drift_comparison.compare_model_rows",
+            side_effect=timeout,
+        ):
+            with self.assertRaises(JobTimeoutException):
+                _compare_rows_by_model(None, {"dcim.site": [{}]})

--- a/forward_netbox/tests/test_virtualchassis_drift_comparison.py
+++ b/forward_netbox/tests/test_virtualchassis_drift_comparison.py
@@ -1,0 +1,122 @@
+# The last spec-driven model that declined to answer: `dcim.virtualchassis`.
+#
+# The bulk path returns None under preview because its second phase reads the
+# first phase's pk. Production syncs run in a branch, where the bulk path defers
+# to `apply_dcim_virtualchassis`, and that adapter's decisions ARE classifiable
+# row by row: an absent chassis is a create outright, a member out of place is
+# an update, a member in place takes the chassis's own verdict. So the
+# comparison goes through the adapter, exactly as the apply does in a branch.
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import Manufacturer
+from dcim.models import Site
+from dcim.models import VirtualChassis
+from django.test import TestCase
+
+from forward_netbox.utilities.drift_comparison import compare_model_rows
+
+MODEL = "dcim.virtualchassis"
+
+
+class VirtualChassisPreviewTest(TestCase):
+    def setUp(self):
+        site = Site.objects.create(name="VC Site", slug="vc-site")
+        mfr = Manufacturer.objects.create(name="VC Mfr", slug="vc-mfr")
+        dtype = DeviceType.objects.create(manufacturer=mfr, model="VC DT", slug="vc-dt")
+        role = DeviceRole.objects.create(name="VC Role", slug="vc-role")
+        self.member = Device.objects.create(
+            name="stack-1", site=site, device_type=dtype, role=role, status="active"
+        )
+        self.other = Device.objects.create(
+            name="stack-2", site=site, device_type=dtype, role=role, status="active"
+        )
+
+    def _row(self, **extra):
+        return {"vc_name": "STACK", "vc_domain": "", **extra}
+
+    def _existing(self, *, domain=""):
+        return VirtualChassis.objects.create(name="STACK", domain=domain)
+
+    def test_a_preview_writes_nothing(self):
+        before = (
+            VirtualChassis.objects.count(),
+            Device.objects.filter(virtual_chassis__isnull=False).count(),
+        )
+        counts = compare_model_rows(
+            None, MODEL, [self._row(device="stack-1", vc_position=1)]
+        )
+        self.assertEqual(counts["creates"], 1)
+        after = (
+            VirtualChassis.objects.count(),
+            Device.objects.filter(virtual_chassis__isnull=False).count(),
+        )
+        self.assertEqual(after, before)
+
+    def test_an_absent_chassis_is_a_create(self):
+        counts = compare_model_rows(None, MODEL, [self._row()])
+        self.assertEqual(counts["creates"], 1)
+
+    def test_an_existing_chassis_is_unchanged(self):
+        self._existing()
+        counts = compare_model_rows(None, MODEL, [self._row()])
+        self.assertEqual(counts["unchanged"], 1)
+
+    def test_a_domain_change_is_an_update(self):
+        self._existing(domain="old")
+        counts = compare_model_rows(None, MODEL, [self._row(vc_domain="new")])
+        self.assertEqual(counts["updates"], 1)
+
+    def test_a_member_not_yet_in_the_chassis_is_an_update(self):
+        self._existing()
+        counts = compare_model_rows(
+            None, MODEL, [self._row(device="stack-1", vc_position=1)]
+        )
+        self.assertEqual(counts["updates"], 1)
+
+    def test_a_member_in_place_takes_the_chassis_verdict(self):
+        vc = self._existing()
+        Device.objects.filter(pk=self.member.pk).update(
+            virtual_chassis=vc, vc_position=1
+        )
+        counts = compare_model_rows(
+            None, MODEL, [self._row(device="stack-1", vc_position=1)]
+        )
+        self.assertEqual(counts["unchanged"], 1)
+
+    def test_a_member_at_the_wrong_position_is_an_update(self):
+        vc = self._existing()
+        Device.objects.filter(pk=self.member.pk).update(
+            virtual_chassis=vc, vc_position=2
+        )
+        counts = compare_model_rows(
+            None, MODEL, [self._row(device="stack-1", vc_position=1)]
+        )
+        self.assertEqual(counts["updates"], 1)
+
+    def test_a_member_row_without_a_position_is_rejected(self):
+        # The apply skips it with an aggregated warning; the preview says the
+        # same thing, in the count the report keeps apart from drift.
+        counts = compare_model_rows(None, MODEL, [self._row(device="stack-1")])
+        self.assertEqual(counts["rejected"], 1)
+        self.assertEqual(counts["creates"], 0)
+
+    def test_an_unknown_member_device_is_rejected(self):
+        self._existing()
+        counts = compare_model_rows(
+            None, MODEL, [self._row(device="nope", vc_position=1)]
+        )
+        self.assertEqual(counts["rejected"], 1)
+
+    def test_a_position_conflict_is_rejected_not_drift(self):
+        vc = self._existing()
+        Device.objects.filter(pk=self.other.pk).update(
+            virtual_chassis=vc, vc_position=1
+        )
+        counts = compare_model_rows(
+            None, MODEL, [self._row(device="stack-1", vc_position=1)]
+        )
+        self.assertEqual(counts["rejected"], 1)
+
+    def test_the_model_is_now_measured_when_empty(self):
+        self.assertIsNotNone(compare_model_rows(None, MODEL, []))

--- a/forward_netbox/utilities/apply_engine_bulk.py
+++ b/forward_netbox/utilities/apply_engine_bulk.py
@@ -543,6 +543,11 @@ def bulk_orm_apply_simple_models(
     # So it declines to answer. That is a worse report and a better number than
     # the alternative.
     if model_string == "dcim.virtualchassis":
+        # The bulk path cannot preview this model (its second phase reads the
+        # first's pk), and it no longer needs to: `drift_comparison` routes
+        # the comparison through `apply_dcim_virtualchassis`, the adapter that
+        # IS the production path whenever a branch is active. `None` here is
+        # reached only by a caller bypassing the dispatcher.
         return None if preview else bulk_orm_apply_virtualchassis(runner, rows)
     if model_string == "dcim.interface":
         return bulk_orm_apply_interface(runner, rows, preview=preview)

--- a/forward_netbox/utilities/drift_comparison.py
+++ b/forward_netbox/utilities/drift_comparison.py
@@ -814,16 +814,20 @@ def _compare_netbox_dlm(model_string, apply_function):
 def _dlm_comparisons():
     """The netbox-dlm sub-models that can be compared, and those that cannot.
 
-    Five of the seven are wired. `inventoryitemsoftware` and
-    `inventoryitemroleplatform` are NOT: they resolve through
-    `_lookup_inventory_item` and `ensure_dlm_inventory_item_role_platform`,
-    which have their own dependency chains that have not been audited for the
-    writes-behind-a-runner-call trap. Absence from the mapping is the
-    documented "no comparison" answer, so they keep their upper bound.
+    All seven are wired. `inventoryitemsoftware` and `inventoryitemroleplatform`
+    were the last two, deferred in slice six because their chains had not been
+    audited for the writes-behind-a-runner-call trap. The audit: two reads that
+    raise a dependency skip, a platform ensure and an upsert the preview
+    overrides, and the same software-version upsert the `softwareversion` slice
+    already previews. One guard was needed - an absent platform must not let
+    the role-keyed mapping lookup match the role's mapping to some OTHER
+    platform - and it is in the ensure itself.
     """
     from .sync_dlm import apply_netbox_dlm_cve
     from .sync_dlm import apply_netbox_dlm_devicesoftware
     from .sync_dlm import apply_netbox_dlm_hardwarenotice
+    from .sync_dlm import apply_netbox_dlm_inventoryitemroleplatform
+    from .sync_dlm import apply_netbox_dlm_inventoryitemsoftware
     from .sync_dlm import apply_netbox_dlm_softwareversion
     from .sync_dlm import apply_netbox_dlm_vulnerability
 
@@ -833,6 +837,10 @@ def _dlm_comparisons():
         "netbox_dlm.devicesoftware": apply_netbox_dlm_devicesoftware,
         "netbox_dlm.cve": apply_netbox_dlm_cve,
         "netbox_dlm.vulnerability": apply_netbox_dlm_vulnerability,
+        "netbox_dlm.inventoryitemsoftware": apply_netbox_dlm_inventoryitemsoftware,
+        "netbox_dlm.inventoryitemroleplatform": (
+            apply_netbox_dlm_inventoryitemroleplatform
+        ),
     }
 
 
@@ -931,12 +939,29 @@ def _compare_dcim_inventoryitem(runner, rows):
 # means auditing its `runner.` calls, not just grepping it for ORM writes - the
 # writes that matter in these paths hide behind `_ensure_*` and `_upsert_*`,
 # and in `dcim.cable`'s case inside NetBox core's own `Cable.save()`.
+def _compare_dcim_virtualchassis(runner, rows):
+    """The last model that declined to answer, now measured through its adapter.
+
+    The bulk path returns `None` under preview because its second phase reads
+    the first phase's pk. That is the bulk path's problem, not the model's:
+    production syncs run in a branch, where the bulk path defers to
+    `apply_dcim_virtualchassis`, and that function's decisions are
+    classifiable row by row - an absent chassis is a create outright, a member
+    out of place is an update. So the comparison goes through the adapter,
+    exactly as the apply does in a branch.
+    """
+    from .sync_device import apply_dcim_virtualchassis
+
+    return _compare_adapter_rows(runner, rows, apply_dcim_virtualchassis)
+
+
 _ADAPTER_COMPARISONS = {
     "extras.taggeditem": _compare_extras_taggeditem,
     "dcim.cable": _compare_dcim_cable,
     "dcim.inventoryitem": _compare_dcim_inventoryitem,
     "ipam.fhrpgroup": _compare_ipam_fhrpgroup,
     "dcim.module": _compare_dcim_module,
+    "dcim.virtualchassis": _compare_dcim_virtualchassis,
 }
 
 

--- a/forward_netbox/utilities/drift_report.py
+++ b/forward_netbox/utilities/drift_report.py
@@ -252,6 +252,7 @@ def compute_drift_report(payload):
                 "estimated_apply_work": apply_work,
                 "change_estimate_kind": estimate_kind,
                 "comparison_available": comparison_available,
+                "comparison_error": str(result.get("comparison_error") or ""),
                 "drift": drift,
                 "in_sync": in_sync,
                 "comparison_runtime_ms": result.get("comparison_runtime_ms"),

--- a/forward_netbox/utilities/sync_device.py
+++ b/forward_netbox/utilities/sync_device.py
@@ -92,7 +92,19 @@ def delete_dcim_virtualchassis(runner, row):
     return runner._delete_by_coalesce(VirtualChassis, [{"name": name}])
 
 
-def apply_dcim_virtualchassis(runner, row):
+def apply_dcim_virtualchassis(runner, row, *, preview=False):
+    """Ensure the chassis, then the member device's position in it.
+
+    ``preview`` classifies without writing. This is the production path for
+    the model: syncs run in a branch, and the bulk engine defers to this
+    adapter whenever a branch is active, so the preview mirrors THIS function's
+    decisions rather than the bulk path's. A chassis the row would create is a
+    create; a member whose chassis or position differs is an update; a member
+    already in place takes the chassis's own upsert verdict. The two-phase
+    shape that made the bulk path decline to answer - the second phase reads
+    the first's pk - does not arise here, because an absent chassis means the
+    membership cannot exist yet and the row is a create outright.
+    """
     from dcim.models import Device
     from dcim.models import VirtualChassis
 
@@ -122,6 +134,10 @@ def apply_dcim_virtualchassis(runner, row):
             [("name",)],
         ),
     )
+    if preview and vc is None:
+        # Chassis absent, so the apply would create it - and any membership
+        # below it. One create under this model.
+        return "creates"
     if row.get("device"):
         try:
             device = runner._get_device_by_name(row["device"])
@@ -164,8 +180,17 @@ def apply_dcim_virtualchassis(runner, row):
             device.virtual_chassis_id == vc.pk
             and device.vc_position == row["vc_position"]
         ):
+            if preview:
+                return "updates" if runner.last_upsert_would_change else "unchanged"
             return vc
+        if preview:
+            # The membership write below is a direct ORM update - the one write
+            # in this function not behind a runner call - so the preview must
+            # answer before it.
+            return "updates"
         Device.objects.filter(pk=device.pk).update(**defaults)
+    if preview:
+        return "updates" if runner.last_upsert_would_change else "unchanged"
     return vc
 
 

--- a/forward_netbox/utilities/sync_dlm.py
+++ b/forward_netbox/utilities/sync_dlm.py
@@ -318,7 +318,14 @@ def ensure_dlm_inventory_item_role_platform(runner, inventory_item, row):
         "InventoryItemRolePlatform",
         "netbox_dlm.inventoryitemroleplatform",
     )
-    mapping, _ = runner._upsert_values_from_defaults(
+    if platform is None:
+        # Preview only: the real `_ensure_platform` upserts and never returns
+        # None. An absent platform means the mapping cannot exist yet, and
+        # looking it up by role alone would match the role's mapping to some
+        # OTHER platform - the absent-parent trap the ACI and routing slices
+        # both hit. Cache nothing: the answer is "create", per row.
+        return None, None
+    mapping, created = runner._upsert_values_from_defaults(
         "netbox_dlm.inventoryitemroleplatform",
         InventoryItemRolePlatform,
         values=runner._model_field_values(
@@ -328,10 +335,38 @@ def ensure_dlm_inventory_item_role_platform(runner, inventory_item, row):
         coalesce_sets=[("role",)],
     )
     cache[cache_key] = (platform, mapping)
+    # The mapping's own verdict, for a preview of `inventoryitemroleplatform`.
+    # Kept beside the cache rather than in it, because two callers unpack the
+    # cached pair. A cache hit on a later row means the apply writes nothing
+    # for that row, which is what "unchanged" says.
+    outcomes = getattr(runner, "_dlm_inventory_item_role_platform_outcomes", None)
+    if not isinstance(outcomes, dict):
+        outcomes = runner._dlm_inventory_item_role_platform_outcomes = {}
+    outcomes[cache_key] = (
+        "creates"
+        if mapping is None
+        else (
+            "updates"
+            if getattr(runner, "last_upsert_would_change", False)
+            else "unchanged"
+        )
+    )
     return cache[cache_key]
 
 
-def apply_netbox_dlm_inventoryitemsoftware(runner, row):
+def apply_netbox_dlm_inventoryitemsoftware(runner, row, *, preview=False):
+    """Record which firmware an inventory item runs, or classify it.
+
+    The chain the DLM slice left unaudited: `_lookup_inventory_item` is two
+    reads (`_get_device_by_name`, `_get_unique_or_raise`) that raise a
+    dependency skip when absent; `ensure_dlm_inventory_item_role_platform` is
+    a platform ensure and one upsert, both behind runner calls the preview
+    overrides; `ensure_dlm_software_version` is the same upsert the
+    `softwareversion` slice already previews. The leaf is one upsert keyed on
+    the inventory item, so the leaf rule applies: a software version the row
+    would create is `softwareversion`'s drift, and this row is an update if it
+    exists (its version pointer changes) and a create if it does not.
+    """
     InventoryItemSoftware = _dlm_model(
         runner, "InventoryItemSoftware", "netbox_dlm.inventoryitemsoftware"
     )
@@ -339,12 +374,19 @@ def apply_netbox_dlm_inventoryitemsoftware(runner, row):
     # count as a dependency skip, not create an unattached DLM catalogue row.
     inventory_item = _lookup_inventory_item(runner, row)
     platform, _ = ensure_dlm_inventory_item_role_platform(runner, inventory_item, row)
+    if platform is None:
+        # Preview only, see the ensure. The platform - and so the version - is
+        # a create; this row is whatever it is without them.
+        existing = runner._get_unique_or_raise(
+            InventoryItemSoftware, {"inventory_item": inventory_item}
+        )
+        return "updates" if existing is not None else "creates"
     software_version = ensure_dlm_software_version(
         runner,
         {**row, "platform": platform.name, "platform_slug": platform.slug},
         with_dates=False,
     )
-    inventory_item_software, _ = runner._upsert_values_from_defaults(
+    inventory_item_software, created = runner._upsert_values_from_defaults(
         "netbox_dlm.inventoryitemsoftware",
         InventoryItemSoftware,
         values=runner._model_field_values(
@@ -356,13 +398,31 @@ def apply_netbox_dlm_inventoryitemsoftware(runner, row):
         ),
         coalesce_sets=[("inventory_item",)],
     )
+    if preview:
+        return _preview_outcome(runner, created)
     return inventory_item_software
 
 
-def apply_netbox_dlm_inventoryitemroleplatform(runner, row):
+def apply_netbox_dlm_inventoryitemroleplatform(runner, row, *, preview=False):
     """The mapping is an atomic side effect of InventoryItemSoftware rows."""
     inventory_item = _lookup_inventory_item(runner, row)
     _, mapping = ensure_dlm_inventory_item_role_platform(runner, inventory_item, row)
+    if preview:
+        role = inventory_item.role
+        cache_key = (role.pk, str(row.get("platform_slug") or "").strip())
+        # The apply writes each (role, platform) mapping ONCE per run and
+        # answers every later row for the same key from its cache. The preview
+        # reports the verdict once, on the first row, and "unchanged" for the
+        # rest - whatever the first verdict was, including the absent-platform
+        # case where the ensure never reaches its upsert or its cache.
+        seen = getattr(runner, "_dlm_role_platform_preview_seen", None)
+        if not isinstance(seen, set):
+            seen = runner._dlm_role_platform_preview_seen = set()
+        if cache_key in seen:
+            return "unchanged"
+        seen.add(cache_key)
+        outcomes = getattr(runner, "_dlm_inventory_item_role_platform_outcomes", {})
+        return outcomes.get(cache_key, "creates")
     return mapping
 
 

--- a/forward_netbox/views.py
+++ b/forward_netbox/views.py
@@ -481,6 +481,7 @@ def _dependency_model_result_summary(
     comparison_runtime_ms=None,
     comparison_queries=None,
     comparison_sql_ms=None,
+    comparison_error="",
 ):
     # ``fetcher.model_results`` are ForwardModelResult dataclasses, not dicts —
     # calling result.get(...) on them raised AttributeError and errored the whole
@@ -523,6 +524,10 @@ def _dependency_model_result_summary(
         "change_estimate_kind": (
             "exact_comparison" if comparison else "workload_upper_bound"
         ),
+        # WHY this model is not measured, when a comparison exists for it and
+        # raised. Empty for a model with no comparison, and for one that was
+        # measured. An exception name, never a message: messages carry values.
+        "comparison_error": str(comparison_error or ""),
         # Rows the comparison could not classify because they carry no usable
         # identity. Reported rather than folded into drift, which would read as
         # a difference between the two systems when it is a defect in the row.
@@ -548,6 +553,60 @@ def _dependency_model_result_summary(
         # source identifiers into the preview job payload.
         "durable_workload_state": durable_state,
     }
+
+
+def _compare_rows_by_model(sync, rows_by_model):
+    """Compare every model, one at a time, and never let one kill the rest.
+
+    One missing attribute in one model's classification used to raise out of
+    this loop and fail the whole preview job - every model read "Not measured"
+    and the report showed nothing. That was 2.8.8's regression, and its plan
+    recorded per-model isolation as the fix that would have turned the outage
+    into a single cell. A model whose comparison raises is recorded as not
+    measured WITH the exception's name, so the cell says why, and the loop
+    moves on. A job timeout is the one thing not caught: the worker is being
+    torn down, and swallowing it would let the job look finished.
+    """
+    from rq.timeouts import JobTimeoutException
+
+    from .utilities.diagnostics import exception_type
+    from .utilities.drift_comparison import compare_model_rows
+
+    result = {
+        "comparison": {},
+        "runtime_ms": {},
+        "queries": {},
+        "sql_ms": {},
+        "rows": {},
+        "errors": {},
+    }
+    for model_string, rows in rows_by_model.items():
+        meter = _QueryMeter()
+        started = time.perf_counter()
+        try:
+            with connection.execute_wrapper(meter):
+                result["comparison"][model_string] = compare_model_rows(
+                    sync, model_string, rows
+                )
+        except JobTimeoutException:
+            raise
+        except Exception as exc:  # noqa: BLE001 - one model, not the preview
+            result["comparison"][model_string] = None
+            result["errors"][model_string] = exception_type(exc)
+            logger.warning(
+                "Dependency preview could not compare %s (%s); reported as not "
+                "measured.",
+                model_string,
+                exception_type(exc),
+                exc_info=True,
+            )
+        result["runtime_ms"][model_string] = round(
+            (time.perf_counter() - started) * 1000, 1
+        )
+        result["queries"][model_string] = meter.count
+        result["sql_ms"][model_string] = round(meter.seconds * 1000, 1)
+        result["rows"][model_string] = len(rows)
+    return result
 
 
 class _QueryMeter:
@@ -625,7 +684,6 @@ def _dependency_dry_run_payload(sync, *, client=None):
     # never did; it costs no Forward calls, because the Forward half is already
     # in `workloads`. Models with no comparison yet return None and keep their
     # upper-bound estimate rather than reporting a confident zero.
-    from .utilities.drift_comparison import compare_model_rows
 
     # Measure against the rows the fetch produced, NOT against `workloads`.
     #
@@ -666,24 +724,13 @@ def _dependency_dry_run_payload(sync, *, client=None):
     # `connection.queries` is only populated when DEBUG is on, so the count is
     # taken from the cursor-execution wrapper instead, which is always active
     # and adds one integer increment per query.
-    comparison_by_model = {}
-    comparison_runtime_ms_by_model = {}
-    comparison_queries_by_model = {}
-    comparison_sql_ms_by_model = {}
-    comparison_rows_by_model_count = {}
-    for model_string, rows in rows_by_model.items():
-        meter = _QueryMeter()
-        started = time.perf_counter()
-        with connection.execute_wrapper(meter):
-            comparison_by_model[model_string] = compare_model_rows(
-                sync, model_string, rows
-            )
-        comparison_runtime_ms_by_model[model_string] = round(
-            (time.perf_counter() - started) * 1000, 1
-        )
-        comparison_queries_by_model[model_string] = meter.count
-        comparison_sql_ms_by_model[model_string] = round(meter.seconds * 1000, 1)
-        comparison_rows_by_model_count[model_string] = len(rows)
+    compared = _compare_rows_by_model(sync, rows_by_model)
+    comparison_by_model = compared["comparison"]
+    comparison_runtime_ms_by_model = compared["runtime_ms"]
+    comparison_queries_by_model = compared["queries"]
+    comparison_sql_ms_by_model = compared["sql_ms"]
+    comparison_rows_by_model_count = compared["rows"]
+    comparison_error_by_model = compared["errors"]
     measured_models = sum(
         1 for value in comparison_by_model.values() if value is not None
     )
@@ -773,6 +820,9 @@ def _dependency_dry_run_payload(sync, *, client=None):
                 ),
                 comparison_sql_ms=comparison_sql_ms_by_model.get(
                     (result.as_dict().get("model") or "")
+                ),
+                comparison_error=comparison_error_by_model.get(
+                    (result.as_dict().get("model") or ""), ""
                 ),
             )
             for result in fetcher.model_results


### PR DESCRIPTION
## Summary

Closes the #206 residue: after this, **every fetched model has a comparison**.

**`dcim.virtualchassis`** was the last spec-driven model that declined to answer — the bulk path's second phase reads the first phase's pk, so it returned `None` under preview. That is the bulk path's problem, not the model's: production syncs run in a branch, where the bulk path defers to `apply_dcim_virtualchassis`, whose decisions *are* classifiable row by row. The comparison now goes through that adapter: an absent chassis is a create outright, a member out of place is an update, a member in place takes the chassis's own verdict, and the one direct ORM write (the membership update) is answered before rather than shimmed.

**`netbox_dlm.inventoryitemsoftware` / `inventoryitemroleplatform`** were the two models slice six left unaudited. The audit: two reads that raise a dependency skip, a platform ensure and an upsert the preview overrides, and the same software-version upsert already previewed. One guard was needed, in the ensure — an absent platform must not let the role-keyed mapping lookup match the role's mapping to *another* platform — the same absent-parent trap the routing and ACI slices hit.

**Per-model isolation.** 2.8.8's regression was one missing attribute raising out of the preview loop and failing the whole job — every model "Not measured", the report empty. The loop is factored into `_compare_rows_by_model`, which catches per model, records the exception **name** (never a message — messages carry values), logs with traceback, and moves on. The drift-report cell reads `Not measured (AttributeError)` with a title explaining the other models were still measured. `JobTimeoutException` is never caught.

Also: the dependency preview page header no longer calls it a "Dry Run" — the one place the feature still had a third name.

## Validation

Targeted suites OK: `test_virtualchassis_drift_comparison` (11), `test_dlm_inventoryitem_drift_comparison` (12), `test_preview_isolation` (3), plus `test_empty_comparison_is_not_a_measurement`, `test_dlm_drift_comparison`, `test_dlm_integration`, `test_drift_comparison`, `test_apply_engine`. Two stand-in assertions from earlier slices flipped to *measured* and say why. `invoke harness-check` ✓.

Plan: `docs/03_Plans/active/2026-09-02-drift-last-models-and-preview-isolation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa
