### PR TITLE
feat: the diagnostics batch - eight small open items, answered in place

### DIFF
--- a/docs/03_Plans/active/2026-09-02-diagnostics-batch.md
+++ b/docs/03_Plans/active/2026-09-02-diagnostics-batch.md
@@ -1,0 +1,74 @@
+# Diagnostics batch: what a customer has had to be asked for, answered in place
+
+## Goal
+
+Close eight small open items in one reviewed change: the full-list CLI, the
+quarantine cadence in Health, the RQ registry regression test, the ChangeDiff
+corruption audit, the platform-name producer/consumer mismatch, the APIC CIMC
+lifecycle map, the opt-in unmanaged config-backup prefix, and a dead code arm.
+
+## Why
+
+Each was recorded as open in a shipped plan and each is small enough that its
+own pull request would be mostly ceremony. Together they are one theme: the
+things a customer has been asked to run, read or explain by hand.
+
+## Constraints
+
+- Console output may carry device names; persisted diagnostics never do. The
+  `--full` output goes to stdout and nowhere else. The ChangeDiff audit reports
+  key NAMES, never payload values.
+- The APIC CIMC software map is opt-in and full-only, for the same reasons
+  the APIC CIMC inventory map is.
+- The unmanaged prefix is opt-in and off by default: on, the config fetch is
+  unscoped, which is the cost the 2.9.0 plan scoped the fetch to avoid.
+
+## Touched Surfaces
+
+- `forward_device_scope_reconciliation_audit --full`;
+  `scope_reconciliation.py` exposes `_missing_in_netbox` beside its siblings.
+- `health.py` `_quarantine_cadence_summary` and its Health card.
+- `test_jobs.py` - a `KeyError` re-raises, so RQ's failed registry sees it.
+- `changediff_audit.py`, `forward_changediff_audit`.
+- `forward_platforms.nqe` derives the platform name with
+  `normalizeDevicePlatformName(device)`, as every consumer does.
+- `forward_dlm_apic_cimc_inventory_item_software.nqe`, registered opt-in and
+  full-only; alias-variant exemption recorded.
+- `config_backup.py` `UNMANAGED_BACKUP_REPO_PREFIX`,
+  `config_backup_include_unmanaged` on the source form.
+- The dead `slugify(name.replace(".", "-"))` arm at its three call sites.
+
+## Approach
+
+Nothing here changes a sync's behaviour by default. The platform NQE change
+is the one exception: a fabric whose `platform.os` does not say "aci" now
+produces its platform row under "ACI", the name every consumer already looked
+for - so the consumers' rows stop skipping as missing a parent. That is the
+one code-verifiable inconsistency the `softwareversion` skip diagnosis had
+left, and it moves the bundled query's hash, so deployments on a pinned org
+query see local drift until they republish; that is the normal flow.
+
+## Validation
+
+`test_scope_audit_full`, `test_quarantine_cadence`, `test_changediff_audit`,
+the new `test_jobs` case, `test_config_backup` (three new), `test_query_registry`
+(the new map's registration and exemption), `test_health`, `test_tag_contracts`
+and the ownership suites for the slug arm. Full Django suite.
+
+## Rollback
+
+Revert. Each item is independent; a partial revert is one hunk.
+
+## Decision Log
+
+- **The changediff audit is a scan, not a repair.** Its plan asked whether
+  damage exists; deleting rows is the operator's call once the answer is known.
+- **Two foreign keys is the flag threshold.** One stray key is a serializer
+  quirk; a Device snapshot under an IPAddress diff carries several.
+- **The unmanaged prefix is a sibling of `configs/`, not a child**, because
+  Validity binds `configs/<name>.cfg` to NetBox devices and an unmanaged device
+  has none.
+
+## Open
+
+- Nothing.

--- a/forward_netbox/forms.py
+++ b/forward_netbox/forms.py
@@ -511,6 +511,17 @@ class ForwardSourceForm(NetBoxModelForm):
                 "secrets, so treat the repository as access-controlled."
             ),
         )
+        self.fields["config_backup_include_unmanaged"] = forms.BooleanField(
+            required=False,
+            label="Config Backup Includes Unmanaged Devices",
+            help_text=(
+                "Also archive configurations for devices Forward collected "
+                "that this sync does not manage, under a separate "
+                "`unmanaged/` prefix named by their Forward device name. Off, "
+                "the fetch is scoped to this sync's devices and nothing else "
+                "is transferred. On, the fetch is the whole collected estate."
+            ),
+        )
         self.fields["sync_device_tags"] = FlexibleMultipleChoiceField(
             required=False,
             choices=(),
@@ -637,6 +648,9 @@ class ForwardSourceForm(NetBoxModelForm):
         self.fields["config_backup_data_source"].initial = (
             parameters.get("config_backup_data_source") or None
         )
+        self.fields["config_backup_include_unmanaged"].initial = bool(
+            parameters.get("config_backup_include_unmanaged")
+        )
         self.fields["sync_generic_endpoints"].initial = bool(
             parameters.get("sync_generic_endpoints")
         )
@@ -714,6 +728,7 @@ class ForwardSourceForm(NetBoxModelForm):
                     "sync_generic_endpoints",
                     "scope_endpoints_by_include_tags",
                     "config_backup_data_source",
+                    "config_backup_include_unmanaged",
                     name="Parameters",
                 )
             )
@@ -749,6 +764,7 @@ class ForwardSourceForm(NetBoxModelForm):
                     "sync_generic_endpoints",
                     "scope_endpoints_by_include_tags",
                     "config_backup_data_source",
+                    "config_backup_include_unmanaged",
                     name="Parameters",
                 )
             )
@@ -905,6 +921,9 @@ class ForwardSourceForm(NetBoxModelForm):
                 cleaned["config_backup_data_source"].pk
                 if cleaned.get("config_backup_data_source")
                 else None
+            ),
+            "config_backup_include_unmanaged": bool(
+                cleaned.get("config_backup_include_unmanaged")
             ),
             "sync_generic_endpoints": bool(cleaned.get("sync_generic_endpoints")),
             "scope_endpoints_by_include_tags": bool(

--- a/forward_netbox/management/commands/forward_changediff_audit.py
+++ b/forward_netbox/management/commands/forward_changediff_audit.py
@@ -1,0 +1,26 @@
+import json
+
+from django.core.management.base import BaseCommand
+
+from forward_netbox.utilities.changediff_audit import audit_change_diffs
+
+
+class Command(BaseCommand):
+    help = (
+        "Read-only audit of netbox_branching ChangeDiff rows whose serialized "
+        "payload belongs to a different model than their object_type - the "
+        "2.8.6 mixed-model corruption. Its plan expected no persistent damage in "
+        "main; this measures it. Reports key NAMES only, never values."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=25,
+            help="Flagged rows listed. Counts are always exact; 0 lists none.",
+        )
+
+    def handle(self, *args, **options):
+        payload = audit_change_diffs(sample_limit=int(options.get("limit") or 0))
+        self.stdout.write(json.dumps(payload, indent=2, default=str))

--- a/forward_netbox/management/commands/forward_device_scope_reconciliation_audit.py
+++ b/forward_netbox/management/commands/forward_device_scope_reconciliation_audit.py
@@ -59,6 +59,16 @@ class Command(BaseCommand):
             ),
         )
 
+        parser.add_argument(
+            "--full",
+            action="store_true",
+            help=(
+                "Print every device name in each bucket, not the 25-name sample "
+                "the panel shows. Names are customer data: they go to this "
+                "console and nowhere else."
+            ),
+        )
+
     def handle(self, *args, **options):
         if options["sync_id"] and options["sync_name"]:
             raise CommandError("Use either --sync-id or --sync-name, not both.")
@@ -111,6 +121,19 @@ class Command(BaseCommand):
             )
         )
 
+        if options["full"]:
+            # The whole sets, straight from the report's internal keys. The
+            # persisted payload keeps names capped at the sample size because
+            # it is a diagnostic; a console is not, and "which ones" is the
+            # question an operator runs this command to answer.
+            payload["full"] = {
+                "out_of_scope": sorted(out_of_scope),
+                "tagged_but_backfilled": sorted(report.get("_present_backfilled") or ()),
+                "owned_uncovered": sorted(report.get("_owned_untagged") or ()),
+                "in_scope_missing_from_netbox": sorted(
+                    report.get("_missing_in_netbox") or ()
+                ),
+            }
         if options["prune_orphans"]:
             payload["prune_requested"] = True
             payload["prune_applied"] = False

--- a/forward_netbox/queries/forward_dlm_apic_cimc_inventory_item_software.nqe
+++ b/forward_netbox/queries/forward_dlm_apic_cimc_inventory_item_software.nqe
@@ -1,0 +1,46 @@
+/**
+ * @intent Forward ACI APIC CIMC Inventory Item Software (netbox-dlm)
+ * @description The firmware running on each APIC server's CIMC management
+ * controller, for the optional netbox-dlm plugin's InventoryItemSoftware model.
+ * The version is the cimcVersion the APIC eqptCh custom command already
+ * reports - the same source, and the same regex, the Forward ACI APIC CIMC
+ * Inventory map reads its label and description from - so this map requests
+ * no additional collection. Rows attach to the inventory items that map
+ * creates, which must be enabled alongside this one. An APIC whose chassis
+ * output carries no cimcVersion yields no row: a controller is never reported
+ * as running a version that was not actually read.
+ */
+
+apicNodeRegex = re`(?:^|\R)\s*ID\s*:\s*(?<node_id:Integer>\d+)(?:\*)?\s*\R(?:\s*Role\s*:\s*(?<role>\S+)\s*\R)?\s*Name\s*:\s*(?<node_name>\S+)\s*\R\s*Pod I[Dd]\s*:\s*(?<pod_id:Integer>\d+)\s*\R\s*Address\s*:\s*(?<address>\S+)\s*\R\s*(?:In-Band V4 Address|In-Band IPv4 Address)\s*:\s*(?<inb_mgmt_addr>\S+)\s*\R\s*(?:In-Band V6 Address|In-Band IPv6 Address)\s*:\s*(?<inb_mgmt_addr6>\S+)\s*\R\s*(?:OOB V4 Address|OOB IPv4 Address)\s*:\s*(?<oob_mgmt_addr>\S+)\s*\R\s*(?:OOB V6 Address|OOB IPv6 Address)\s*:\s*(?<oob_mgmt_addr6>\S+)\s*\R\s*Serial Number\s*:\s*(?<serial_number>\S+)\s*\R\s*Version\s*:\s*(?<version>\S+)(?:\s*\R\s*Up Time\s*:\s*(?<up_time>\S+))?(?:\s*\R\s*Fabric State\s*:\s*(?<fabric_state>\S+))?(?:\s*\R\s*State\s*:\s*(?<state>\S+))?`;
+
+chassisRegex = re`(?:^|\R)#\s+eqpt\.Ch\s*\R\s*bootSource\s*:\s*\S+\s*\R\s*childAction\s*:\s*.*\R\s*cimcVersion\s*:\s*(?<cimc_version>\S+)\s*\R\s*configRole\s*:\s*.*\R\s*descr\s*:\s*(?<description>[^\r\n]*)\R\s*dn\s*:\s*topology/pod-(?<pod_id:Integer>\d+)/node-(?<node_id:Integer>\d+)/sys/ch\s*\R(?:\s*[^\r\n]*\R)*?\s*model\s*:\s*(?<model>\S+)\s*\R(?:\s*[^\r\n]*\R)*?\s*role\s*:\s*(?<role>\S+)\s*\R\s*ser\s*:\s*(?<serial>\S+)\s*\R(?:\s*[^\r\n]*\R)*?\s*vendor\s*:\s*(?<vendor>[^\r\n]+)`;
+
+@query
+f(forward_netbox_shard_keys: List<String>) =
+foreach device in network.devices
+where device.snapshotInfo.result == DeviceSnapshotResult.completed
+where device.platform.vendor != Vendor.FORWARD_CUSTOM
+foreach controller_command in device.outputs.commands
+where controller_command.commandType == CommandType.CISCO_APIC_CONTROLLER_DETAIL
+foreach node_match in regexMatches(controller_command.response, apicNodeRegex)
+let node = node_match.data
+foreach chassis_command in device.outputs.commands
+where chassis_command.commandType == CommandType.CUSTOM
+where matches(toLowerCase(chassis_command.commandText), "moquery -c eqptch*")
+foreach chassis_match in regexMatches(chassis_command.response, chassisRegex)
+let chassis = chassis_match.data
+where chassis.pod_id == node.pod_id
+where chassis.node_id == node.node_id
+where length(chassis.cimc_version) > 0
+where isEmpty(forward_netbox_shard_keys)
+  || device.name in forward_netbox_shard_keys
+  || node.node_name in forward_netbox_shard_keys
+select distinct {
+  device: node.node_name,
+  inventory_item: "CIMC",
+  role: "MANAGEMENT CONTROLLER",
+  role_slug: "management-controller",
+  platform: "CIMC",
+  platform_slug: "cimc",
+  version: if length(chassis.cimc_version) <= 50 then chassis.cimc_version else substring(chassis.cimc_version, 0, 50)
+};

--- a/forward_netbox/queries/forward_platforms.nqe
+++ b/forward_netbox/queries/forward_platforms.nqe
@@ -10,8 +10,14 @@ f(forward_netbox_shard_keys: List<String>) =
 foreach device in network.devices
 where device.snapshotInfo.result == DeviceSnapshotResult.completed
 where device.platform.vendor != Vendor.FORWARD_CUSTOM
-let platform_os_version = if isPresent(device.platform.osVersion) then device.platform.osVersion else ""
-let platform_name = normalizePlatformName(toString(device.platform.os), platform_os_version)
+/* Every CONSUMER of a platform name - devices, software versions, the DLM
+ * maps - derives it with normalizeDevicePlatformName(device), which also
+ * resolves APIC controllers and ACI switches from their command outputs. This
+ * PRODUCER used the OS-and-version form, so a fabric whose platform.os did not
+ * say "aci" produced a platform row under one name while every consumer looked
+ * for it under "ACI", and the consumers' rows skipped as missing a parent. One
+ * derivation, on both sides. */
+let platform_name = normalizeDevicePlatformName(device)
 let platform_slug = slugify(platform_name)
 let manufacturer_name = canonicalManufacturerName(device.platform.vendor)
 group manufacturer_name as manufacturers by {

--- a/forward_netbox/templates/forward_netbox/forwardsync_health.html
+++ b/forward_netbox/templates/forward_netbox/forwardsync_health.html
@@ -597,6 +597,31 @@
       </div>
     </div>
     <div class="card">
+      <h5 class="card-header">{% trans "Absence Quarantine" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Thresholds" %}</th>
+            <td>{% blocktrans with runs=health.quarantine_cadence.required_runs hours=health.quarantine_cadence.required_hours %}{{ runs }} runs and {{ hours }} hours{% endblocktrans %}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Effective protection" %}</th>
+            <td>
+              {% if health.quarantine_cadence.effective_hours %}
+                {% blocktrans with hours=health.quarantine_cadence.effective_hours binding=health.quarantine_cadence.binding %}about {{ hours }} hours ({{ binding }} threshold binds){% endblocktrans %}
+              {% else %}
+                <span class="text-muted">{% trans "no recurrence interval" %}</span>
+              {% endif %}
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Status" %}</th>
+            <td>{{ health.quarantine_cadence.message }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+    <div class="card">
       <h5 class="card-header">{% trans "Density Learning" %}</h5>
       <div class="card-body">
         <table class="table table-hover attr-table">

--- a/forward_netbox/tests/test_changediff_audit.py
+++ b/forward_netbox/tests/test_changediff_audit.py
@@ -1,0 +1,91 @@
+# The 2.8.6 mixed-model ChangeDiff corruption was fixed at the sink and its
+# plan recorded "no persistent damage is expected in main" - an expectation.
+# This is the measurement that makes it answerable against a real database.
+from dcim.models import Device
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+from ipam.models import IPAddress
+
+from forward_netbox.utilities.changediff_audit import classify_change_diff
+from forward_netbox.utilities.changediff_audit import foreign_payload_keys
+
+DEVICE_SNAPSHOT = {
+    "id": 5,
+    "name": "leaf-1",
+    "device_type": 3,
+    "role": 2,
+    "site": 1,
+    "status": "active",
+    "custom_fields": {},
+    "tags": [],
+}
+ADDRESS_SNAPSHOT = {
+    "id": 9,
+    "address": "10.0.0.1/24",
+    "vrf": None,
+    "status": "active",
+    "assigned_object_type": None,
+    "assigned_object_id": None,
+    "custom_fields": {},
+    "tags": [],
+}
+
+
+class ChangeDiffClassificationTest(TestCase):
+    def test_a_device_payload_under_an_address_diff_is_flagged(self):
+        # The exact corruption: object_type says IPAddress, original holds a
+        # serialized Device - the devices snapshot()-ed by the primary-IP
+        # release, grouped into an IPAddress batch.
+        findings = classify_change_diff(
+            ContentType.objects.get_for_model(IPAddress),
+            {"original": DEVICE_SNAPSHOT, "modified": None, "current": None},
+        )
+        self.assertEqual(set(findings), {"original"})
+        self.assertIn("device_type", findings["original"])
+        self.assertIn("site", findings["original"])
+
+    def test_a_payload_that_fits_its_model_is_clean(self):
+        self.assertEqual(
+            classify_change_diff(
+                ContentType.objects.get_for_model(IPAddress),
+                {"original": ADDRESS_SNAPSHOT, "modified": ADDRESS_SNAPSHOT, "current": None},
+            ),
+            {},
+        )
+        self.assertEqual(
+            classify_change_diff(
+                ContentType.objects.get_for_model(Device),
+                {"original": DEVICE_SNAPSHOT, "modified": None, "current": None},
+            ),
+            {},
+        )
+
+    def test_one_stray_key_is_not_a_finding(self):
+        # A serializer quirk, not another model. Two or more foreign keys is
+        # the threshold; one alone stays unreported.
+        payload = {**ADDRESS_SNAPSHOT, "unexpected": 1}
+        self.assertEqual(
+            classify_change_diff(
+                ContentType.objects.get_for_model(IPAddress), {"original": payload}
+            ),
+            {},
+        )
+
+    def test_serializer_keys_are_never_foreign(self):
+        self.assertEqual(
+            foreign_payload_keys(IPAddress, {"id": 1, "display": "x", "url": "y", "tags": []}),
+            set(),
+        )
+
+    def test_values_are_never_reported(self):
+        findings = classify_change_diff(
+            ContextTypeStub.address(),
+            {"original": DEVICE_SNAPSHOT},
+        )
+        self.assertNotIn("leaf-1", str(findings))
+
+
+class ContextTypeStub:
+    @staticmethod
+    def address():
+        return ContentType.objects.get_for_model(IPAddress)

--- a/forward_netbox/tests/test_config_backup.py
+++ b/forward_netbox/tests/test_config_backup.py
@@ -264,6 +264,86 @@ class ConfigBackupTest(TestCase):
         _text, entries = _read_config_blob(self.tmp.name, "router-1.cfg")
         self.assertEqual(entries, [b"router-1.cfg"])
 
+    def _read_root_tree(self):
+        from dulwich.repo import Repo
+
+        with Repo(self.tmp.name) as repo:
+            head = repo.refs[repo.refs.follow(b"HEAD")[0][1]]
+            commit = repo.object_store[head]
+            root = repo.object_store[commit.tree]
+            entries = {}
+            for name, _mode, sha in root.iteritems():
+                tree = repo.object_store[sha]
+                entries[name.decode()] = sorted(
+                    child.decode() for child, _m, _s in tree.iteritems()
+                )
+            return entries
+
+    def test_unmanaged_devices_are_not_transferred_by_default(self):
+        # The fetch is scoped to this sync's devices; the stray row here is
+        # what a real estate returns only when the scope is lifted.
+        result, client = self._run(
+            [
+                {"name": "fwd-router-1", "config": "hostname router-1"},
+                {"name": "fwd-unmanaged", "config": "hostname unmanaged"},
+            ]
+        )
+        self.assertEqual(
+            client.calls[0]["parameters"]["forward_netbox_shard_keys"],
+            ["fwd-router-1", "fwd-router-2"],
+        )
+        self.assertEqual(result.unmapped, 1)
+        self.assertEqual(result.unmanaged_written, 0)
+        self.assertNotIn("unmanaged", self._read_root_tree())
+
+    def test_opting_in_archives_unmanaged_devices_under_their_own_prefix(self):
+        """The product question the 2.9.0 plan left open, answered as an opt-in.
+
+        Off is the default because the fetch is otherwise scoped. On, the fetch
+        is the whole estate and the surplus lands under `unmanaged/`, named by
+        Forward name - apart from `configs/`, which Validity binds to NetBox
+        device names an unmanaged device does not have.
+        """
+        self.sync.source.parameters["config_backup_include_unmanaged"] = True
+        self.sync.source.save()
+        result, client = self._run(
+            [
+                {"name": "fwd-router-1", "config": "hostname router-1"},
+                {"name": "fwd-unmanaged", "config": "hostname unmanaged"},
+            ]
+        )
+        self.assertEqual(client.calls[0]["parameters"]["forward_netbox_shard_keys"], [])
+        self.assertEqual(result.written, 1)
+        self.assertEqual(result.unmanaged_written, 1)
+        self.assertEqual(result.unmapped, 0)
+        tree = self._read_root_tree()
+        self.assertEqual(tree["configs"], ["router-1.cfg"])
+        self.assertEqual(tree["unmanaged"], ["fwd-unmanaged.cfg"])
+        self.assertIn("unmanaged_written", result.as_dict())
+
+        # A second run with the same content commits nothing new.
+        again, _client = self._run(
+            [
+                {"name": "fwd-router-1", "config": "hostname router-1"},
+                {"name": "fwd-unmanaged", "config": "hostname unmanaged"},
+            ],
+            snapshot_id="snap-2",
+        )
+        self.assertEqual(again.unmanaged_unchanged, 1)
+        self.assertEqual(again.skipped_reason, "no configuration changed")
+
+    def test_an_unmanaged_name_never_becomes_repository_structure_either(self):
+        self.sync.source.parameters["config_backup_include_unmanaged"] = True
+        self.sync.source.save()
+        result, _client = self._run(
+            [
+                {"name": "fwd-router-1", "config": "hostname router-1"},
+                {"name": "../etc/passwd", "config": "x"},
+            ]
+        )
+        self.assertEqual(result.unmanaged_written, 0)
+        self.assertEqual(result.unmapped, 1)
+
     def test_the_result_payload_never_carries_configuration_text(self):
         marker = "SECRET-CONFIG-LINE-DO-NOT-EXPORT"
         result, _client = self._run(

--- a/forward_netbox/tests/test_jobs.py
+++ b/forward_netbox/tests/test_jobs.py
@@ -197,6 +197,30 @@ class ForwardJobsTest(TestCase):
         self.assertEqual(self.sync.status, ForwardSyncStatusChoices.TIMEOUT)
         overlays.assert_not_called()
 
+    def test_an_unexpected_exception_registers_with_rq(self):
+        """A `KeyError` is re-raised, so RQ's failed-job registry records it.
+
+        A deployment's registry had recorded no plugin failure since June
+        despite three errored syncs, and `expected_failure` covers only the
+        three exception types the job anticipates - so anything else MUST
+        re-raise for the registry to see it. This pins that it does, and that
+        the job row is still errored with a redacted message first.
+        """
+        job = self._sync_job("sync-keyerror")
+        with (
+            patch.object(ForwardSync, "sync", side_effect=KeyError("secret-key")),
+            patch("forward_netbox.jobs._enqueue_post_sync_overlays") as overlays,
+            self.assertRaises(KeyError),
+        ):
+            sync_forwardsync(job, adhoc=True)
+        job.refresh_from_db()
+        self.sync.refresh_from_db()
+        self.assertEqual(job.status, JobStatusChoices.STATUS_ERRORED)
+        self.assertIn("KeyError", job.error)
+        self.assertNotIn("secret-key", job.error)
+        self.assertEqual(self.sync.status, ForwardSyncStatusChoices.FAILED)
+        overlays.assert_not_called()
+
     def test_scope_tag_reconciliation_enqueues_after_completed_sync(self):
         from forward_netbox.jobs import _maybe_enqueue_backfilled_tag_refresh
 

--- a/forward_netbox/tests/test_quarantine_cadence.py
+++ b/forward_netbox/tests/test_quarantine_cadence.py
@@ -1,0 +1,54 @@
+# The absence quarantine's defaults - three runs AND 72 hours - were a guess at
+# one deployment's cadence, recorded as such in three release plans. Nothing
+# showed an operator what they add up to on their own interval. This does.
+from django.test import TestCase
+
+from forward_netbox.models import ForwardSource
+from forward_netbox.models import ForwardSync
+from forward_netbox.utilities.health import sync_health_summary
+
+
+class QuarantineCadenceTest(TestCase):
+    def _sync(self, *, interval=None, **parameters):
+        source = ForwardSource.objects.create(
+            name=f"cadence-src-{interval}",
+            type="saas",
+            url="https://fwd.app",
+            status="ready",
+            parameters={"network_id": "net-1", **parameters},
+        )
+        return ForwardSync.objects.create(
+            name=f"cadence-sync-{interval}", source=source, interval=interval
+        )
+
+    def test_an_hourly_sync_is_bound_by_the_hours_threshold(self):
+        cadence = sync_health_summary(self._sync(interval=60))["quarantine_cadence"]
+        self.assertEqual(cadence["binding"], "hours")
+        self.assertEqual(cadence["effective_hours"], 72.0)
+        self.assertIn("3 runs is 3.0 hours", cadence["message"])
+        self.assertIn("hours threshold binds", cadence["message"])
+
+    def test_a_weekly_sync_is_bound_by_the_runs_threshold(self):
+        cadence = sync_health_summary(self._sync(interval=7 * 24 * 60))["quarantine_cadence"]
+        self.assertEqual(cadence["binding"], "runs")
+        self.assertEqual(cadence["effective_hours"], 504.0)
+        self.assertIn("runs threshold binds", cadence["message"])
+
+    def test_operator_thresholds_are_read_from_the_source(self):
+        cadence = sync_health_summary(
+            self._sync(
+                interval=60,
+                device_tag_prune_absence_runs=1,
+                device_tag_prune_absence_hours=6,
+            )
+        )["quarantine_cadence"]
+        self.assertEqual(cadence["required_runs"], 1)
+        self.assertEqual(cadence["required_hours"], 6)
+        self.assertEqual(cadence["effective_hours"], 6.0)
+
+    def test_a_manual_sync_says_so_rather_than_guessing(self):
+        cadence = sync_health_summary(self._sync(interval=None))["quarantine_cadence"]
+        self.assertIsNone(cadence["effective_hours"])
+        self.assertIsNone(cadence["binding"])
+        self.assertIn("no recurrence interval", cadence["message"])
+        self.assertEqual(cadence["status"], "info")

--- a/forward_netbox/tests/test_query_registry.py
+++ b/forward_netbox/tests/test_query_registry.py
@@ -1028,27 +1028,30 @@ class QueryRegistryTest(TestCase):
         )
 
     def test_platform_queries_normalize_aci_apic_and_cimc_platforms(self):
-        # Forward Devices queries delegate to normalizeDevicePlatformName; the
-        # platform query calls normalizePlatformName directly (more robust for
-        # unsupported vendor/OS combos that lack a full device context).
-        device_query_names = [
+        """Producer and consumers derive the platform name the same way.
+
+        This test used to require the opposite: that Forward Platforms call
+        `normalizePlatformName(os, version)` directly while every consumer
+        called `normalizeDevicePlatformName(device)`. The two disagree for
+        exactly the devices ACI is about - a fabric switch whose `platform.os`
+        is NXOS and whose ACI-ness is visible only in its command outputs got
+        an "NXOS" platform row from the producer and an "ACI" reference from
+        every consumer, so the consumers' rows skipped as missing a parent.
+        `2026-08-03-alias-variant-coverage-guard.md` recorded that mismatch as
+        the one code-verifiable lead behind a customer's softwareversion skips.
+        One derivation, on both sides.
+        """
+        for model_string, query_name in (
             ("dcim.device", "Forward Devices"),
             ("dcim.device", "Forward Devices with NetBox Device Type Aliases"),
-        ]
-        for model_string, query_name in device_query_names:
+            ("dcim.platform", "Forward Platforms"),
+        ):
             spec = get_seeded_builtin_query_spec(model_string, query_name)
-            if model_string == "dcim.platform":
-                self.assertIn(
-                    "normalizePlatformName(toString(device.platform.os), device.platform.osVersion)",
-                    spec.query,
-                    msg=f"{query_name} no longer normalizes forward platform OS values.",
-                )
-            else:
-                self.assertIn(
-                    "normalizeDevicePlatformName(device)",
-                    spec.query,
-                    msg=f"{query_name} no longer normalizes forward platform OS values.",
-                )
+            self.assertIn(
+                "normalizeDevicePlatformName(device)",
+                spec.query,
+                msg=f"{query_name} no longer normalizes forward platform OS values.",
+            )
             self.assertNotIn(
                 'replace(toString(device.platform.os), "OS.", "")',
                 spec.query,
@@ -1057,24 +1060,6 @@ class QueryRegistryTest(TestCase):
 
         platform_spec = get_seeded_builtin_query_spec(
             "dcim.platform", "Forward Platforms"
-        )
-        # Forward Platforms calls normalizePlatformName directly so it works for
-        # ACI/APIC/CIMC devices whose vendor enum may not resolve via device context.
-        self.assertIn(
-            "let platform_os_version = if isPresent(device.platform.osVersion) "
-            'then device.platform.osVersion else ""',
-            platform_spec.query,
-            msg="Forward Platforms must default an absent OS version before normalization.",
-        )
-        self.assertIn(
-            "normalizePlatformName(toString(device.platform.os), platform_os_version)",
-            platform_spec.query,
-            msg="Forward Platforms should not use normalizeDevicePlatformName — it must call normalizePlatformName directly.",
-        )
-        self.assertNotIn(
-            "normalizeDevicePlatformName(device)",
-            platform_spec.query,
-            msg="Forward Platforms should not use normalizeDevicePlatformName — it must call normalizePlatformName directly.",
         )
         utilities = read_builtin_query_source("netbox_utilities.nqe")
         self.assertIn(
@@ -2547,6 +2532,7 @@ select {name: "vendor", slug: "vendor"}
                 "Forward DLM Hardware Notices with NetBox Aliases",
                 "Forward DLM Device Software",
                 "Forward CIMC Inventory Item Software",
+                "Forward ACI APIC CIMC Inventory Item Software",
                 "Forward DLM CVEs",
                 "Forward DLM Vulnerabilities",
             },

--- a/forward_netbox/tests/test_scope_audit_full.py
+++ b/forward_netbox/tests/test_scope_audit_full.py
@@ -1,0 +1,68 @@
+# The scope audit CLI printed the same 25-name sample the panel shows, so a
+# customer with 552 uncovered devices had no way, in the UI or on a shell, to
+# list them. `--full` prints every name in every bucket, to the console only.
+import json
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from forward_netbox.models import ForwardSource
+from forward_netbox.models import ForwardSync
+
+
+def _report():
+    return {
+        "sync_id": 1,
+        "netbox_out_of_scope": 2,
+        "forward_missing_in_netbox": 1,
+        "out_of_scope_sample": ["orphan-a"],
+        "unmanaged": {"owned_untagged_sample": ["gone-a"]},
+        "out_of_scope_absence": {"available": False},
+        "_out_of_scope": {"orphan-a", "orphan-b"},
+        "_tagged_names": {"in-scope"},
+        "_device_tagged_names": {"in-scope"},
+        "_present_backfilled": {"backfilled-a"},
+        "_owned_untagged": {"gone-a", "gone-b", "gone-c"},
+        "_missing_in_netbox": {"missing-a"},
+        "_out_of_scope_pks": [],
+    }
+
+
+class ScopeAuditFullTest(TestCase):
+    def setUp(self):
+        source = ForwardSource.objects.create(
+            name="audit-full-src",
+            type="saas",
+            url="https://fwd.app",
+            status="ready",
+            parameters={"network_id": "net-1"},
+        )
+        self.sync = ForwardSync.objects.create(name="audit-full-sync", source=source)
+
+    def _run(self, *arguments):
+        out = StringIO()
+        with patch(
+            "forward_netbox.management.commands.forward_device_scope_reconciliation_audit.compute_scope_reconciliation",
+            return_value=_report(),
+        ):
+            call_command(
+                "forward_device_scope_reconciliation_audit",
+                f"--sync-id={self.sync.pk}",
+                *arguments,
+                stdout=out,
+            )
+        return json.loads(out.getvalue())
+
+    def test_the_default_output_stays_sampled(self):
+        payload = self._run()
+        self.assertNotIn("full", payload)
+        self.assertNotIn("_owned_untagged", payload)
+
+    def test_full_prints_every_bucket_in_full(self):
+        payload = self._run("--full")
+        self.assertEqual(payload["full"]["out_of_scope"], ["orphan-a", "orphan-b"])
+        self.assertEqual(payload["full"]["tagged_but_backfilled"], ["backfilled-a"])
+        self.assertEqual(payload["full"]["owned_uncovered"], ["gone-a", "gone-b", "gone-c"])
+        self.assertEqual(payload["full"]["in_scope_missing_from_netbox"], ["missing-a"])

--- a/forward_netbox/utilities/apply_engine_bulk.py
+++ b/forward_netbox/utilities/apply_engine_bulk.py
@@ -2332,7 +2332,7 @@ def bulk_orm_apply_device(runner, rows: list[dict[str, Any]], *, preview=False):
         updated = []
         resolved = {}
         for name in sorted(scope_names):
-            slug = slugify(name) or slugify(name.replace(".", "-"))
+            slug = slugify(name)
             if not slug:
                 resolved[name] = None
                 continue

--- a/forward_netbox/utilities/changediff_audit.py
+++ b/forward_netbox/utilities/changediff_audit.py
@@ -1,0 +1,97 @@
+"""Find ChangeDiff rows whose payload does not belong to their object type.
+
+2.8.6 root-caused a customer's merge `KeyError` to `_sync_branch_change_diffs`
+grouping a mixed-model batch by its first change's type, so a diff whose
+`object_type` said IPAddress could carry a serialized Device in `original`.
+The sink was fixed. Whether any such row survives in that deployment's
+database was never checked: its plan recorded "confined to per-ingestion
+branches, discarded on retry; no persistent damage is expected in main", and
+an expectation is not a measurement.
+
+This is the measurement. Read-only, computed on demand, persisted nowhere. A
+row is flagged when its serialized payload carries field names the object
+type's model does not have - a Device snapshot under an IPAddress diff has
+`device_type` and `site`, which no IPAddress has. Payload VALUES are never
+read or reported; only key names, which are schema identifiers.
+"""
+
+# Keys NetBox's serializer adds to every snapshot regardless of model.
+_SERIALIZER_KEYS = frozenset(
+    {"id", "custom_fields", "custom_field_data", "tags", "display", "url", "created", "last_updated"}
+)
+
+
+def foreign_payload_keys(model_class, payload):
+    """Keys in ``payload`` that are not fields of ``model_class``."""
+    if not isinstance(payload, dict) or model_class is None:
+        return set()
+    field_names = {field.name for field in model_class._meta.get_fields()}
+    field_names |= {
+        getattr(field, "attname", "")
+        for field in model_class._meta.get_fields()
+        if getattr(field, "attname", "")
+    }
+    return {key for key in payload if key not in field_names and key not in _SERIALIZER_KEYS}
+
+
+def classify_change_diff(object_type, payloads):
+    """Return the foreign key names per payload slot, or an empty dict when clean.
+
+    ``payloads`` is ``{"original": ..., "modified": ..., "current": ...}``. A
+    single foreign key can be a serializer quirk; two or more on one slot is a
+    payload from another model.
+    """
+    model_class = object_type.model_class() if object_type is not None else None
+    findings = {}
+    for slot, payload in payloads.items():
+        foreign = foreign_payload_keys(model_class, payload)
+        if len(foreign) >= 2:
+            findings[slot] = sorted(foreign)
+    return findings
+
+
+def audit_change_diffs(*, sample_limit=25):
+    """Every ChangeDiff whose payload belongs to another model."""
+    from netbox_branching.models import ChangeDiff
+
+    scanned = 0
+    flagged = []
+    by_object_type = {}
+    for diff in ChangeDiff.objects.select_related("object_type").iterator(chunk_size=500):
+        scanned += 1
+        findings = classify_change_diff(
+            diff.object_type,
+            {"original": diff.original, "modified": diff.modified, "current": diff.current},
+        )
+        if not findings:
+            continue
+        label = diff.object_type.model_class()._meta.label_lower if diff.object_type else "?"
+        by_object_type[label] = by_object_type.get(label, 0) + 1
+        if len(flagged) < max(int(sample_limit or 0), 0):
+            flagged.append(
+                {
+                    "pk": diff.pk,
+                    "branch": diff.branch_id,
+                    "object_type": label,
+                    "object_id": diff.object_id,
+                    "action": diff.action,
+                    "foreign_keys": findings,
+                }
+            )
+    payload = {
+        "scanned": scanned,
+        "flagged_count": sum(by_object_type.values()),
+        "flagged_by_object_type": dict(sorted(by_object_type.items())),
+        "sample_limit": max(int(sample_limit or 0), 0),
+        "sample": flagged,
+    }
+    if payload["flagged_count"]:
+        payload["remediation"] = (
+            "These rows carry a serialized payload from a different model than "
+            "their object_type - the 2.8.6 mixed-model corruption. The sink was "
+            "fixed in 2.8.6; a flagged row predates it or came from a branch "
+            "that was never retried. Delete the flagged ChangeDiff rows (they are "
+            "branch bookkeeping, not NetBox data) or discard their branch, then "
+            "re-run this audit."
+        )
+    return payload

--- a/forward_netbox/utilities/config_backup.py
+++ b/forward_netbox/utilities/config_backup.py
@@ -50,6 +50,12 @@ CONFIG_BACKUP_QUERY_FILENAME = "forward_config_backup.nqe"
 # one measured outlier (20 MB) cannot repeat often enough per page to matter.
 CONFIG_BACKUP_PAGE_SIZE = 100
 CONFIG_BACKUP_REPO_PREFIX = "configs"
+# Where configurations for devices this sync does NOT manage go, when the
+# operator opts in. Kept apart from `configs/` on purpose: Validity's golden-
+# config checks read `configs/<netbox device name>.cfg`, and an unmanaged
+# device has no NetBox row for such a check to bind to. These files are named
+# by their Forward name, because that is the only name they have.
+UNMANAGED_BACKUP_REPO_PREFIX = "unmanaged"
 _COMMIT_AUTHOR = b"Forward NetBox Plugin <forward-netbox-plugin@localhost>"
 _COMMIT_MESSAGE_PREFIX = "Forward config backup: snapshot "
 
@@ -62,6 +68,8 @@ class ConfigBackupResult:
     written: int = 0
     unchanged: int = 0
     unmapped: int = 0
+    unmanaged_written: int = 0
+    unmanaged_unchanged: int = 0
     skipped_reason: str = ""
     commit: str = ""
     pushed: bool = False
@@ -77,6 +85,8 @@ class ConfigBackupResult:
             "written": self.written,
             "unchanged": self.unchanged,
             "unmapped": self.unmapped,
+            "unmanaged_written": self.unmanaged_written,
+            "unmanaged_unchanged": self.unmanaged_unchanged,
             "skipped_reason": self.skipped_reason,
             "commit": self.commit,
             "pushed": self.pushed,
@@ -288,6 +298,21 @@ def run_config_backup(sync, *, snapshot_id, logger=None):
                 config_entries = _tree_entries(repo, root_entries[prefix][1])
             else:
                 config_entries = {}
+            unmanaged_prefix = UNMANAGED_BACKUP_REPO_PREFIX.encode("ascii")
+            if unmanaged_prefix in root_entries:
+                unmanaged_entries = _tree_entries(repo, root_entries[unmanaged_prefix][1])
+            else:
+                unmanaged_entries = {}
+            # The product question the 2.9.0 plan left open - whether devices
+            # Forward collected but this sync does not manage should be
+            # archived too - is answered as an opt-in. Off, the fetch stays
+            # scoped to this sync's devices and the surplus is never
+            # transferred. On, the fetch is the whole collected estate and the
+            # surplus lands under its own prefix, apart from the files
+            # Validity binds to NetBox devices.
+            include_unmanaged = bool(
+                (sync.source.parameters or {}).get("config_backup_include_unmanaged")
+            )
 
             offset = 0
             # Scope the FETCH, not just the write. The identity table is this
@@ -296,7 +321,7 @@ def run_config_backup(sync, *, snapshot_id, logger=None):
             # returns configurations only for devices that have somewhere to
             # go. Unscoped, the query returns the whole collected estate and
             # the surplus is transferred only to be discarded.
-            shard_keys = sorted(name_map)
+            shard_keys = [] if include_unmanaged else sorted(name_map)
             while True:
                 rows = client.run_nqe_query(
                     query=query,
@@ -314,6 +339,22 @@ def run_config_backup(sync, *, snapshot_id, logger=None):
                     netbox_name = name_map.get(forward_name)
                     file_name = _safe_file_name(netbox_name)
                     if not netbox_name or not file_name or text is None:
+                        if (
+                            include_unmanaged
+                            and text is not None
+                            and not netbox_name
+                            and _safe_file_name(forward_name)
+                        ):
+                            unmanaged_blob = Blob.from_string(str(text).encode("utf-8"))
+                            unmanaged_name = _safe_file_name(forward_name).encode("utf-8")
+                            existing = unmanaged_entries.get(unmanaged_name)
+                            if existing is not None and existing[1] == unmanaged_blob.id:
+                                result.unmanaged_unchanged += 1
+                                continue
+                            repo.object_store.add_object(unmanaged_blob)
+                            unmanaged_entries[unmanaged_name] = (0o100644, unmanaged_blob.id)
+                            result.unmanaged_written += 1
+                            continue
                         result.unmapped += 1
                         continue
                     blob = Blob.from_string(str(text).encode("utf-8"))
@@ -348,7 +389,7 @@ def run_config_backup(sync, *, snapshot_id, logger=None):
                     "config backup fetched no configurations; refusing to "
                     "commit an empty snapshot."
                 )
-            if result.written == 0:
+            if result.written == 0 and result.unmanaged_written == 0:
                 result.skipped_reason = "no configuration changed"
                 return result
 
@@ -359,6 +400,13 @@ def run_config_backup(sync, *, snapshot_id, logger=None):
             repo.object_store.add_object(config_tree)
             root_tree = Tree()
             root_entries[prefix] = (0o040000, config_tree.id)
+            if unmanaged_entries:
+                unmanaged_tree = Tree()
+                for entry_name in sorted(unmanaged_entries):
+                    mode, sha = unmanaged_entries[entry_name]
+                    unmanaged_tree.add(entry_name, mode, sha)
+                repo.object_store.add_object(unmanaged_tree)
+                root_entries[unmanaged_prefix] = (0o040000, unmanaged_tree.id)
             for entry_name in sorted(root_entries):
                 mode, sha = root_entries[entry_name]
                 root_tree.add(entry_name, mode, sha)
@@ -405,9 +453,15 @@ def run_config_backup(sync, *, snapshot_id, logger=None):
 
     result.duration_seconds = time.monotonic() - started
     if logger is not None:
+        unmanaged_note = (
+            f", {result.unmanaged_written} unmanaged written, "
+            f"{result.unmanaged_unchanged} unmanaged unchanged"
+            if result.unmanaged_written or result.unmanaged_unchanged
+            else ""
+        )
         logger.log_info(
             f"Config backup: {result.written} written, {result.unchanged} "
-            f"unchanged, {result.unmapped} unmapped across {result.rows} "
-            f"Forward rows ({result.pages} pages)."
+            f"unchanged, {result.unmapped} unmapped{unmanaged_note} across "
+            f"{result.rows} Forward rows ({result.pages} pages)."
         )
     return result

--- a/forward_netbox/utilities/health.py
+++ b/forward_netbox/utilities/health.py
@@ -524,6 +524,7 @@ def sync_health_summary(sync):
     collection_gap = _collection_gap_summary(sync)
     out_of_scope = _out_of_scope_summary(sync)
     uncovered = _uncovered_summary(sync)
+    quarantine_cadence = _quarantine_cadence_summary(sync)
     latest_ingestion_summary = _ingestion_summary(latest_ingestion) or {}
     dependency_lookup_cache = latest_ingestion_summary.get(
         "dependency_lookup_cache", {}
@@ -621,6 +622,7 @@ def sync_health_summary(sync):
         "collection_gap": collection_gap,
         "out_of_scope": out_of_scope,
         "uncovered": uncovered,
+        "quarantine_cadence": quarantine_cadence,
         "ownership_finalization": ownership_finalization,
         "dependency_lookup_cache": dependency_lookup_cache,
         "dependency_parent_coverage": dependency_parent_coverage,
@@ -1223,6 +1225,62 @@ def _out_of_scope_summary(sync):
             "none of the sync's included Forward tags. Review and remove them via "
             "Scope Reconciliation -> Prune orphans, or filter the device list by "
             f"the forward-out-of-scope tag.{trend_note}"
+        ),
+    }
+
+
+def _quarantine_cadence_summary(sync):
+    """What the absence quarantine actually means on THIS sync's schedule.
+
+    The defaults - three runs AND 72 hours - were a guess at one deployment's
+    cadence, recorded as such in three release plans. They are tunable per
+    source without a release, but nothing showed an operator what they add up
+    to on their own interval: on an hourly sync the runs threshold is met in
+    three hours and the 72-hour one binds; on a weekly sync three runs is three
+    weeks and the runs threshold binds. This says which, and how long a
+    disabled device is actually protected before the prune will believe it is
+    gone. Informational: nothing here is a defect, and a schedule with no
+    interval (manual runs only) says so rather than guessing.
+    """
+    from .scope_reconciliation import absence_quarantine_thresholds
+
+    runs, hours = absence_quarantine_thresholds(sync)
+    interval_minutes = getattr(sync, "interval", None)
+    if not interval_minutes:
+        return {
+            "available": True,
+            "status": "info",
+            "required_runs": runs,
+            "required_hours": hours,
+            "interval_minutes": None,
+            "effective_hours": None,
+            "binding": None,
+            "message": (
+                f"The prune believes an absence after {runs} consecutive runs "
+                f"AND {hours} hours. This sync has no recurrence interval, so "
+                "the runs half depends on when syncs are started by hand; the "
+                f"{hours}-hour half always applies."
+            ),
+        }
+    runs_hours = round(runs * int(interval_minutes) / 60, 1)
+    effective = max(float(hours), runs_hours)
+    binding = "hours" if float(hours) >= runs_hours else "runs"
+    return {
+        "available": True,
+        "status": "info",
+        "required_runs": runs,
+        "required_hours": hours,
+        "interval_minutes": int(interval_minutes),
+        "effective_hours": effective,
+        "binding": binding,
+        "message": (
+            f"The prune believes an absence after {runs} consecutive runs AND "
+            f"{hours} hours. At this sync's {int(interval_minutes)}-minute "
+            f"interval, {runs} runs is {runs_hours} hours, so the "
+            f"{'hours' if binding == 'hours' else 'runs'} threshold binds and a "
+            f"device disabled in Forward is protected for about {effective} "
+            "hours before it becomes prune-eligible. Both thresholds are source "
+            "parameters (device_tag_prune_absence_runs / _hours)."
         ),
     }
 

--- a/forward_netbox/utilities/query_registry.py
+++ b/forward_netbox/utilities/query_registry.py
@@ -610,6 +610,16 @@ BUILTIN_OPTIONAL_QUERY_MAPS = [
         "enabled": False,
     },
     {
+        # The same lifecycle treatment for the APIC servers' CIMC, sourced from
+        # the eqptCh custom command the APIC CIMC inventory map already reads
+        # rather than from SNMP. Opt-in like every lifecycle map, and full-only
+        # for the same reason the inventory map is.
+        "model_string": "netbox_dlm.inventoryitemsoftware",
+        "name": "Forward ACI APIC CIMC Inventory Item Software",
+        "filename": "forward_dlm_apic_cimc_inventory_item_software.nqe",
+        "enabled": False,
+    },
+    {
         "model_string": "netbox_dlm.cve",
         "name": "Forward DLM CVEs",
         "filename": "forward_dlm_cves.nqe",
@@ -1138,11 +1148,15 @@ def _query_diff_ownership_mode(filename: str) -> str:
         # Until exact collision and endpoint feature parity are live-proven,
         # neither the base nor aliases variant may enter the diff path.
         return "feature_state_full_only"
-    if filename == "forward_aci_apic_cimc_inventory.nqe":
+    if filename in (
+        "forward_aci_apic_cimc_inventory.nqe",
+        "forward_dlm_apic_cimc_inventory_item_software.nqe",
+    ):
         # The parameterless draft exposes contributor selectors before a
         # select-distinct reduction. A changed contributor delta cannot prove
         # that an unchanged alternate controller does not preserve the final
-        # inventory row, so this map must remain full-only.
+        # inventory row, so these maps must remain full-only. The software map
+        # reads the same contributors through the same reduction.
         return "unsafe_contributor_reduction"
     return "global"
 
@@ -1769,6 +1783,13 @@ ALIAS_VARIANT_EXEMPT_QUERY_FILENAMES = {
         'Emits the hardcoded Platform "CIMC", which its own apply adapter '
         "creates alongside the InventoryItemRolePlatform mapping. The value "
         "never comes from Forward's device model, so no alias mapping applies."
+    ),
+    "forward_dlm_apic_cimc_inventory_item_software.nqe": (
+        'Emits the hardcoded Platform "CIMC" for APIC servers, exactly as the '
+        "SNMP CIMC software map does; its apply adapter creates that platform "
+        "and the InventoryItemRolePlatform mapping itself. The device name is "
+        "the APIC node name, which the APIC CIMC inventory map also uses "
+        "unmapped, so no alias mapping applies to either."
     ),
 }
 

--- a/forward_netbox/utilities/scope_reconciliation.py
+++ b/forward_netbox/utilities/scope_reconciliation.py
@@ -531,6 +531,7 @@ def compute_scope_reconciliation(sync, *, snapshot_id=None) -> dict:
         "_forward_site_slugs": forward_site_slugs,
         "_out_of_scope": out_of_scope,
         "_owned_untagged": owned_untagged_names,
+        "_missing_in_netbox": missing_in_netbox,
         "_out_of_scope_pks": out_of_scope_pks,
         "_present_backfilled": present_backfilled,
         "_matched_include_tags_by_name": present_scope_tags_by_name,

--- a/forward_netbox/utilities/sync_device.py
+++ b/forward_netbox/utilities/sync_device.py
@@ -219,7 +219,7 @@ def _ensure_scope_tag(runner, name):
     from django.utils.text import slugify
     from extras.models import Tag
 
-    slug = slugify(name) or slugify(name.replace(".", "-"))
+    slug = slugify(name)
     if not slug:
         cache[name] = None
         return None

--- a/forward_netbox/utilities/tag_contracts.py
+++ b/forward_netbox/utilities/tag_contracts.py
@@ -21,9 +21,17 @@ RESERVED_STATUS_TAG_SLUGS = frozenset(
 
 
 def normalized_managed_tag_slug(value):
-    """The slug a managed tag is CREATED with. One name, one slug."""
+    """The slug a managed tag is CREATED with. One name, one slug.
+
+    This used to fall back to `slugify(name.replace(".", "-"))`, which can
+    never differ from `slugify(name)`: `slugify` drops a dot rather than
+    replacing it, and a name with no ASCII word characters slugifies to the
+    empty string either way. The arm was dead at four call sites and read
+    as if it handled a case it did not; `candidate_managed_tag_slugs` is where
+    the dotted-name RESOLUTION actually happens.
+    """
     name = str(value or "").strip()
-    return slugify(name) or slugify(name.replace(".", "-"))
+    return slugify(name)
 
 
 def candidate_managed_tag_slugs(value):


### PR DESCRIPTION
## Summary

Eight small open items, each recorded in a shipped plan, with one theme: the things a customer has been asked to run, read or explain by hand.

| item | what landed |
|---|---|
| **B2** | `forward_device_scope_reconciliation_audit --full` prints every name in every bucket (out-of-scope, backfilled, owned-uncovered, in-scope-missing) to the console; the persisted payload stays capped at 25 |
| **B3** | Health "Absence Quarantine" card: what `3 runs AND 72 h` adds up to on *this* sync's interval, and which threshold binds |
| **D2** | regression test: a `KeyError` from a sync re-raises, so RQ's failed-job registry records it (the registry mystery had no pin) |
| **D3** | `forward_changediff_audit` — read-only scan for the 2.8.6 mixed-model ChangeDiff corruption; reports key **names**, never values; two foreign keys is the threshold |
| **D5** | `forward_platforms.nqe` now derives the platform name with `normalizeDevicePlatformName(device)`, as every consumer does. A registry test required the opposite ("must call normalizePlatformName directly"); it is rewritten and its docstring records why — the mismatch was the one code-verifiable lead behind a customer's softwareversion skips (`2026-08-03-alias-variant-coverage-guard.md`). **Moves the bundled query's hash**: pinned org queries show local drift until republished |
| **D6** | `forward_dlm_apic_cimc_inventory_item_software.nqe` — APIC servers' CIMC firmware into `InventoryItemSoftware` from the `eqptCh` output the APIC CIMC inventory map already reads; opt-in, full-only for the same contributor-reduction reason |
| **E2** | `config_backup_include_unmanaged`: archive configurations Forward collected for devices this sync does not manage under a sibling `unmanaged/` prefix (named by Forward name — Validity binds `configs/` to NetBox names an unmanaged device lacks). Off by default because on, the fetch is the whole estate |
| **E4** | the dead `slugify(name.replace(".", "-"))` arm removed at all three sites; `candidate_managed_tag_slugs` is where dotted-name resolution actually lives |

## Validation

`test_scope_audit_full`, `test_quarantine_cadence`, `test_changediff_audit`, `test_jobs`, `test_config_backup` (+3), `test_query_registry`, `test_health`, `test_dlm_integration`, the ownership suites — OK. `invoke harness-check` ✓.

Plan: `docs/03_Plans/active/2026-09-02-diagnostics-batch.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa
