### PR TITLE
fix: a refused delete is retried, not recorded as done

### DIFF
--- a/docs/03_Plans/active/2026-08-21-refused-deletes-are-not-staged.md
+++ b/docs/03_Plans/active/2026-08-21-refused-deletes-are-not-staged.md
@@ -87,17 +87,26 @@ from a delete set.
 
 ## Open
 
-- **The deeper defect is untouched.** Both sweeps still delete on "absent from
-  the current Forward result", with ownership claims as the only gate - and a
+- **The deeper defect is untouched for the CATALOGUE sweep only.** The device
+  sweep was quarantined and shrink-guarded in 2.8.9, and the software-version
+  catalogue sweep was scoped to attributable rows on 2026-09-02 (#318). What
+  follows described both when it was written. Both sweeps deleted on "absent
+  from the current Forward result", with ownership claims as the only gate - and a
   device absent from Forward LOSES its scope claim on the first run that
   observes the absence, so the guard evaporates exactly one run before the
   delete fires. A device with no protecting child is still removed unattended,
   without the prune gate or the 25% shrink guard that
   `full_removal_reconciliation.py` says device removal is supposed to sit
   behind. This change makes such a removal honest, not gated.
-- A delete that fails for a reason OTHER than protection is still tombstoned
-  optimistically.
-- `DEPENDENCY_SKIP_ISSUE_DETAIL_LIMIT = 10` means a report of exactly ten skips
-  may be the cap rather than the count.
-- `emit_dependency_skip_issue_summary`'s wording ("their NetBox parent is not
-  synced yet") describes the opposite of a protected-delete skip.
+- ~~A delete that fails for a reason OTHER than protection is still tombstoned
+  optimistically.~~ **Closed 2026-09-02** in
+  `2026-09-02-refused-deletes-are-retried.md`: every non-success path in
+  `delete_model_rows` records the identity, it travels on the ingestion, and
+  promotion drops the entry so the next delta recomputes the delete.
+- ~~`DEPENDENCY_SKIP_ISSUE_DETAIL_LIMIT = 10` means a report of exactly ten
+  skips may be the cap rather than the count.~~ **Closed 2026-09-02** (#319):
+  ten IS the count at the cap, and the tenth per-row issue now says further
+  rows are rolled up.
+- ~~`emit_dependency_skip_issue_summary`'s wording ("their NetBox parent is not
+  synced yet") describes the opposite of a protected-delete skip.~~ **Closed
+  2026-09-02** (#319): one sentence per direction, each with its own remedy.

--- a/docs/03_Plans/active/2026-09-02-refused-deletes-are-retried.md
+++ b/docs/03_Plans/active/2026-09-02-refused-deletes-are-retried.md
@@ -1,0 +1,75 @@
+# A refused delete is retried, not recorded as done
+
+## Goal
+
+Stop the durable workload state from promoting a delete the apply refused, so
+the row is retried on the next run instead of silently diverging.
+
+## Why
+
+The state is staged BEFORE the branch applies and promoted at merge, so it
+records the deletes the DELTA computed rather than the ones that happened.
+`newly_explicit_deletes` treats a previous `delete` entry as settled, so a
+refused delete was skipped on every subsequent run: the row stayed in NetBox,
+the plugin believed it was gone, nothing retried, and the report went quiet.
+
+2.8.9 closed the PROTECT half by never staging a delete a surviving child
+holds. Its plan recorded the rest as open: "a delete that fails for a reason
+OTHER than protection is still tombstoned optimistically."
+
+## Constraints
+
+- Identities only, never rows. The canonical identity is derived from the
+  model's coalesce fields, which is what the state is keyed by already.
+- An ordinary run must do no extra work: no decode/encode when nothing was
+  refused.
+- A refusal must never remove an UPSERT entry for the same identity - the run
+  may have written the row and refused a delete of something else keyed alike.
+
+## Touched Surfaces
+
+- `sync_reporting.py` - `record_refused_delete` at every non-success path in
+  `delete_model_rows` (falsy return, dependency skip, search/query error,
+  validation/integrity error, and the generic catch);
+  `persist_refused_delete_identities`.
+- `single_branch_executor.py` - the refusals travel on the ingestion's
+  `snapshot_info`, saved with the model results.
+- `workload_state.py` - `refused_delete_identities`,
+  `_without_refused_deletes`, applied in `promote_workload_states_locked`.
+
+## Approach
+
+Dropping the entry, not marking it. An identity absent from the promoted
+state is exactly the state the delta reads as "not yet deleted", so the next
+run recomputes the delete and tries again - no new action type, no new field,
+and the existing `newly_explicit_deletes` logic does the retry unchanged.
+
+The refusals travel on `snapshot_info` because promotion happens in a
+different transaction at merge time, in `ingestion_merge`, which has the
+ingestion and not the runner.
+
+## Validation
+
+`test_refused_deletes_are_retried.py`: a refused delete is absent from the
+promoted state while a successful one stays; an upsert entry is never dropped;
+an ordinary run promotes byte-identical; nothing is persisted when nothing was
+refused; the recorded identity IS the state key; an unkeyable row is recorded
+harmlessly. Adjacent: `test_workload_state`, `test_sync`, `test_dlm_integration`.
+Full Django suite.
+
+## Rollback
+
+Revert. Refused deletes are tombstoned again.
+
+## Decision Log
+
+- **Drop the entry rather than record a failed action.** A third action would
+  need every reader of the state taught about it; absence already means
+  exactly what is wanted.
+- **Every non-success path, not just the exceptions.** A handler returning
+  falsy is a refusal too - that is the protected-delete shape - and it was the
+  one most likely to be silent.
+
+## Open
+
+- Nothing.

--- a/forward_netbox/tests/test_refused_deletes_are_retried.py
+++ b/forward_netbox/tests/test_refused_deletes_are_retried.py
@@ -1,0 +1,136 @@
+# A delete the apply refused was still promoted as done.
+#
+# The durable workload state is staged BEFORE the branch applies and promoted
+# at merge, so it recorded every delete the delta computed rather than every
+# delete that happened. `newly_explicit_deletes` then treats a previous
+# `delete` entry as settled, so the next run skipped it: the row stayed in
+# NetBox, the plugin believed it was gone, nothing retried, and the report went
+# quiet. 2.8.9 closed the PROTECT half by never staging those; this closes the
+# rest, for a delete refused by any cause.
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from django.test import TestCase
+
+from forward_netbox.models import ForwardIngestion
+from forward_netbox.models import ForwardSource
+from forward_netbox.models import ForwardSync
+from forward_netbox.models import ForwardWorkloadState
+from forward_netbox.utilities.sync_reporting import persist_refused_delete_identities
+from forward_netbox.utilities.sync_reporting import record_refused_delete
+from forward_netbox.utilities.sync_reporting import REFUSED_DELETE_IDENTITIES_KEY
+from forward_netbox.utilities.workload_state import build_state_entries
+from forward_netbox.utilities.workload_state import decode_state_entries
+from forward_netbox.utilities.workload_state import encode_state_entries
+from forward_netbox.utilities.workload_state import promote_workload_states_locked
+from forward_netbox.utilities.workload_state import refused_delete_identities
+
+MODEL = "netbox_dlm.softwareversion"
+COALESCE = [["platform_slug", "version"]]
+
+
+class RefusedDeleteTest(TestCase):
+    def setUp(self):
+        source = ForwardSource.objects.create(
+            name="refused-src", type="saas", url="https://fwd.app", status="ready"
+        )
+        self.sync = ForwardSync.objects.create(name="refused-sync", source=source)
+        self.ingestion = ForwardIngestion.objects.create(
+            sync=self.sync, snapshot_id="snap-1"
+        )
+
+    def _runner(self):
+        return SimpleNamespace(
+            logger=Mock(),
+            _model_coalesce_fields={MODEL: COALESCE},
+        )
+
+    def _row(self, version="1.0"):
+        return {"platform_slug": "ios", "version": version}
+
+    def _stage(self, *, deletes, upserts=()):
+        entries = build_state_entries(MODEL, list(upserts), COALESCE)
+        entries.update(
+            build_state_entries(MODEL, list(deletes), COALESCE, action="delete")
+        )
+        payload, checksum = encode_state_entries(entries)
+        return ForwardWorkloadState.objects.create(
+            sync=self.sync,
+            ingestion=self.ingestion,
+            model_string=MODEL,
+            parameter_hash="p",
+            identity_contract_hash="c",
+            payload=payload,
+            payload_checksum=checksum,
+            row_count=len(entries),
+            snapshot_id="snap-1",
+            is_current=False,
+        )
+
+    def _promoted_entries(self):
+        state = ForwardWorkloadState.objects.get(sync=self.sync, is_current=True)
+        return decode_state_entries(state.payload, state.payload_checksum)
+
+    def test_a_refused_delete_is_absent_from_the_promoted_state(self):
+        runner = self._runner()
+        record_refused_delete(runner, MODEL, self._row("1.0"))
+        persist_refused_delete_identities(runner, self.ingestion)
+        self.ingestion.save(update_fields=["snapshot_info"])
+        self._stage(deletes=[self._row("1.0"), self._row("2.0")])
+
+        promote_workload_states_locked(self.ingestion)
+
+        entries = self._promoted_entries()
+        # 2.0 was deleted and stays recorded; 1.0 was refused and is absent, so
+        # the next delta recomputes it as a fresh delete and retries.
+        self.assertEqual(len(entries), 1)
+        self.assertNotIn("1.0", str(entries))
+        self.assertIn("2.0", str(entries))
+
+    def test_an_upsert_entry_is_never_dropped(self):
+        runner = self._runner()
+        record_refused_delete(runner, MODEL, self._row("1.0"))
+        persist_refused_delete_identities(runner, self.ingestion)
+        self.ingestion.save(update_fields=["snapshot_info"])
+        # Same identity, upsert action: a refusal must not remove a row the
+        # run actually wrote.
+        self._stage(deletes=[], upserts=[self._row("1.0")])
+
+        promote_workload_states_locked(self.ingestion)
+
+        self.assertEqual(len(self._promoted_entries()), 1)
+
+    def test_an_ordinary_run_promotes_untouched(self):
+        state = self._stage(deletes=[self._row("1.0")])
+        before = (state.payload_checksum, state.row_count)
+
+        promote_workload_states_locked(self.ingestion)
+
+        state.refresh_from_db()
+        self.assertEqual((state.payload_checksum, state.row_count), before)
+        self.assertTrue(state.is_current)
+
+    def test_nothing_is_persisted_when_no_delete_was_refused(self):
+        runner = self._runner()
+        self.assertEqual(persist_refused_delete_identities(runner, self.ingestion), 0)
+        self.assertNotIn(
+            REFUSED_DELETE_IDENTITIES_KEY, self.ingestion.snapshot_info or {}
+        )
+
+    def test_the_recorded_identity_is_the_state_key_not_a_row(self):
+        runner = self._runner()
+        record_refused_delete(runner, MODEL, self._row("1.0"))
+        persist_refused_delete_identities(runner, self.ingestion)
+        recorded = refused_delete_identities(self.ingestion)[MODEL]
+        entries = build_state_entries(
+            MODEL, [self._row("1.0")], COALESCE, action="delete"
+        )
+        self.assertEqual(recorded, set(entries))
+
+    def test_an_unkeyable_row_is_recorded_as_empty_and_ignored(self):
+        # A row with no usable coalesce key cannot be tombstoned either, so it
+        # must not crash the recorder or match a real identity.
+        runner = self._runner()
+        record_refused_delete(runner, MODEL, {})
+        persist_refused_delete_identities(runner, self.ingestion)
+        self.assertEqual(refused_delete_identities(self.ingestion).get(MODEL), set())

--- a/forward_netbox/utilities/single_branch_executor.py
+++ b/forward_netbox/utilities/single_branch_executor.py
@@ -16,6 +16,7 @@ from .executor_base import ForwardExecutorBase
 from .primary_ip import apply_primary_ip_from_mgmt_tags
 from .primary_ip import primary_ip_from_mgmt_tag_enabled
 from .query_fetch import ForwardQueryFetcher
+from .sync_reporting import persist_refused_delete_identities
 from .validation import ForwardValidationRunner
 from .workload_state import stage_and_promote_noop_workload_states
 from .workload_state import stage_workload_states
@@ -280,7 +281,12 @@ class ForwardSingleBranchExecutor(ForwardExecutorBase):
 
         ingestion.sync_mode = self._sync_mode()
         ingestion.model_results = self.last_model_results
-        ingestion.save(update_fields=["sync_mode", "model_results"])
+        # Which staged deletes this run did NOT perform. Promotion happens in a
+        # different transaction at merge, so the refusals have to travel with
+        # the ingestion; without them the state promotes a refused delete as
+        # done and nothing ever retries it.
+        persist_refused_delete_identities(self, ingestion)
+        ingestion.save(update_fields=["sync_mode", "model_results", "snapshot_info"])
 
         # Optional: set device primary_ip4/6 from Forward Mgmt_<iface> tags. Runs
         # in the branch after every workload is staged (interfaces + IPs exist),

--- a/forward_netbox/utilities/sync_reporting.py
+++ b/forward_netbox/utilities/sync_reporting.py
@@ -882,6 +882,67 @@ def _record_dependency_parent_coverage_issue(runner, model_string, summary):
     )
 
 
+REFUSED_DELETE_IDENTITIES_KEY = "refused_delete_identities"
+
+
+def record_refused_delete(runner, model_string, row):
+    """Remember a delete this run did NOT perform, so it is not tombstoned.
+
+    The durable workload state is staged before the branch applies and promoted
+    at merge, so it records every delete the DELTA computed - not every delete
+    that happened. A refused one was therefore written as `delete` in the
+    promoted state, `newly_explicit_deletes` skipped it on the next run
+    because the state already said `delete`, and nothing ever retried it: the
+    row stayed in NetBox, the plugin believed it was gone, and the report went
+    quiet. 2.8.9 closed the PROTECT half by never staging those; this closes
+    the rest, for a delete refused by any cause at all.
+
+    Identities only - the same canonical identity the state is keyed by, which
+    is derived from the model's coalesce fields and carries no free-text values
+    beyond them. Held on the runner and persisted with the ingestion, because
+    promotion happens in a different transaction at merge time.
+    """
+    identities = getattr(runner, "_refused_delete_identities", None)
+    if identities is None:
+        identities = runner._refused_delete_identities = {}
+    identities.setdefault(model_string, set()).add(
+        _row_identity(runner, model_string, row)
+    )
+
+
+def persist_refused_delete_identities(runner, ingestion):
+    """Carry this run's refused deletes on the ingestion, for promotion.
+
+    Sets `snapshot_info` on the instance; the caller saves it alongside its
+    own fields. Writes nothing when no delete was refused, so an ordinary run
+    leaves the payload untouched.
+    """
+    identities = getattr(runner, "_refused_delete_identities", None)
+    if not identities or ingestion is None:
+        return 0
+    snapshot_info = dict(getattr(ingestion, "snapshot_info", None) or {})
+    recorded = {
+        model_string: sorted(values)
+        for model_string, values in identities.items()
+        if values
+    }
+    if not recorded:
+        return 0
+    snapshot_info[REFUSED_DELETE_IDENTITIES_KEY] = recorded
+    ingestion.snapshot_info = snapshot_info
+    return sum(len(values) for values in recorded.values())
+
+
+def _row_identity(runner, model_string, row):
+    from .workload_state import canonical_row_identity
+
+    coalesce_fields = getattr(runner, "_model_coalesce_fields", {}).get(model_string)
+    try:
+        return canonical_row_identity(model_string, row, coalesce_fields or [])
+    except Exception:  # noqa: BLE001 - an unkeyable row cannot be tombstoned anyway
+        return ""
+
+
 def delete_model_rows(runner, model_string, rows):
     rows = list(rows)
     handler_name = f"_delete_{model_string.replace('.', '_')}"
@@ -918,10 +979,12 @@ def delete_model_rows(runner, model_string, rows):
                     pending_deleted = 0
             else:
                 runner.logger.increment_statistics(model_string, outcome="skipped")
+                record_refused_delete(runner, model_string, row)
         except ForwardDependencySkipError as exc:
             runner.events_clearer.restore(pre_row_events)
             logger.info("Skipped deleting %s row due to dependency", model_string)
             runner.logger.increment_statistics(model_string, outcome="skipped")
+            record_refused_delete(runner, model_string, row)
             record_issue(
                 runner,
                 model_string,
@@ -940,6 +1003,7 @@ def delete_model_rows(runner, model_string, rows):
                 exception_type(exc),
             )
             runner.logger.increment_statistics(model_string, outcome="failed")
+            record_refused_delete(runner, model_string, row)
             record_issue(
                 runner,
                 model_string,
@@ -957,6 +1021,7 @@ def delete_model_rows(runner, model_string, rows):
                 exception_type(exc),
             )
             runner.logger.increment_statistics(model_string, outcome="failed")
+            record_refused_delete(runner, model_string, row)
             record_issue(
                 runner,
                 model_string,
@@ -974,6 +1039,7 @@ def delete_model_rows(runner, model_string, rows):
                 exception_type(exc),
             )
             runner.logger.increment_statistics(model_string, outcome="failed")
+            record_refused_delete(runner, model_string, row)
             record_issue(
                 runner,
                 model_string,

--- a/forward_netbox/utilities/workload_state.py
+++ b/forward_netbox/utilities/workload_state.py
@@ -1211,15 +1211,66 @@ def stage_workload_states(ingestion, pending_states):
     return len(pending_states)
 
 
+def refused_delete_identities(ingestion):
+    """The delete identities this ingestion staged but did not perform."""
+    from .sync_reporting import REFUSED_DELETE_IDENTITIES_KEY
+
+    recorded = (getattr(ingestion, "snapshot_info", None) or {}).get(
+        REFUSED_DELETE_IDENTITIES_KEY
+    ) or {}
+    return {
+        model_string: {identity for identity in identities if identity}
+        for model_string, identities in recorded.items()
+        if isinstance(identities, (list, tuple, set))
+    }
+
+
+def _without_refused_deletes(state, refused):
+    """Drop the delete entries this run did not actually perform.
+
+    The state is staged before the branch applies and promoted at merge, so it
+    records the deletes the DELTA computed rather than the ones that happened.
+    Promoting a refused delete as done is what made the next run skip it -
+    `newly_explicit_deletes` treats a previous `delete` entry as settled - so
+    the row stayed in NetBox, the plugin believed it was gone, and nothing
+    retried. Dropping the entry instead leaves the identity absent from the
+    promoted state, which is exactly the state the delta reads as "not yet
+    deleted": the next run recomputes the delete and tries again.
+
+    Returns the state unchanged when nothing was refused, so the ordinary path
+    does no decode/encode work.
+    """
+    if not refused:
+        return state
+    entries = decode_state_entries(state.payload, state.payload_checksum)
+    kept = {
+        identity: value
+        for identity, value in entries.items()
+        if not (value["action"] == "delete" and identity in refused)
+    }
+    if len(kept) == len(entries):
+        return state
+    payload, checksum = encode_state_entries(kept)
+    state.payload = payload
+    state.payload_checksum = checksum
+    state.row_count = len(kept)
+    state.save(update_fields=["payload", "payload_checksum", "row_count"])
+    return state
+
+
 def promote_workload_states_locked(ingestion):
     from ..models import ForwardWorkloadState
 
+    refused_by_model = refused_delete_identities(ingestion)
     pending = list(
         ForwardWorkloadState.objects.select_for_update()
         .filter(ingestion=ingestion)
         .order_by("model_string")
     )
     for state in pending:
+        state = _without_refused_deletes(
+            state, refused_by_model.get(state.model_string)
+        )
         old_states = (
             ForwardWorkloadState.objects.select_for_update()
             .filter(


### PR DESCRIPTION
## Summary

A delete the apply refused was still promoted as **done**.

The durable workload state is staged *before* the branch applies and promoted at merge, so it recorded the deletes the **delta computed** rather than the ones that **happened**. `newly_explicit_deletes` treats a previous `delete` entry as settled, so a refused delete was skipped on every later run: the row stayed in NetBox, the plugin believed it was gone, nothing retried, and the report went quiet.

2.8.9 closed the PROTECT half by never staging a delete a surviving child holds. Its plan recorded the rest as open — *"a delete that fails for a reason OTHER than protection is still tombstoned optimistically."*

**Now:** every non-success path in `delete_model_rows` records the row's canonical identity — including a **falsy handler return**, which is the protected-delete shape and the one most likely to be silent. The identities travel on the ingestion's `snapshot_info` (promotion runs in a different transaction at merge, which has the ingestion and not the runner), and promotion drops those `delete` entries from the state.

**Dropping, not marking.** An identity absent from the promoted state is exactly what the delta reads as "not yet deleted", so the next run recomputes the delete and retries — no new action type, no reader to teach, and the existing retry logic unchanged.

## Guarantees pinned

- an upsert entry for the same identity is never dropped;
- a run that refused nothing promotes byte-identical (no decode/encode work);
- the recorded identity *is* the state key, not a row;
- an unkeyable row is recorded harmlessly and matches nothing.

## Validation

389 tests OK: `test_refused_deletes_are_retried` (6 new), `test_workload_state`, `test_sync`, `test_dlm_integration`. `invoke harness-check` ✓. Also updates the 2.8.9 plan's `## Open`, striking the three items closed since (this one, plus the skip-cap and rollup-wording items from #319) and narrowing the "deeper defect" note to the catalogue sweep alone, now that #318 scoped it.

Plan: `docs/03_Plans/active/2026-09-02-refused-deletes-are-retried.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa
