### PR TITLE
fix: two diagnostics that could not be read back

### DIFF
--- a/docs/03_Plans/active/2026-09-02-diagnostics-readback.md
+++ b/docs/03_Plans/active/2026-09-02-diagnostics-readback.md
@@ -1,0 +1,70 @@
+# Two diagnostics that could not be read back
+
+## Goal
+
+Stop `Job.error` sentences that carry no exception from exporting as
+`<redacted diagnostic>`, and stop a reworded message from silently losing its
+failure-reason slug.
+
+## Why
+
+Both were recorded as open by `2026-08-04-expose-failure-reasons.md`. The
+first is a customer reading their own job page and being told nothing about a
+sentence that was safe in full. The second is a slow rot: the catalogue is
+matched against message TEXT, so any rewording drops a reason to
+`unrecognized-fetch-failure` with nothing to notice it.
+
+## Constraints
+
+- The shape allowlist pins WHOLE wording and constrains its one interpolated
+  value to the enum it comes from. A reworded message must stop matching -
+  redacted is the safe direction - rather than admit arbitrary text.
+- The needle test may only assert against messages the PLUGIN composes.
+  Transport needles ("timed out", "connection refused") come from libraries
+  whose wording this repository does not control.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/diagnostics.py` - `_SAFE_JOB_ERROR_SHAPES`,
+  `_safe_job_error_shape`, consulted by `safe_job_error_summary` only when no
+  classifier was recovered.
+- `forward_netbox/tests/test_diagnostics_readback.py`.
+
+## Approach
+
+The needle test reads the plugin's string literals with `ast`, not with a text
+search. That is not a detail: its first version reported
+`full-execution-not-contractually-safe` and `unsafe-full-contract` as dead
+slugs, and both messages were intact - the needles span an implicit string
+concatenation (`"... is not " f"contractually safe ({code})."`), which Python
+merges into one constant at runtime and a grep does not. A test that reports
+two false positives on its first run is a test that would have been silenced.
+f-string parts stay separate, because an interpolated value sits between them
+at runtime and a needle cannot span one there either.
+
+## Validation
+
+`test_diagnostics_readback.py`: every plugin-authored needle matches a literal
+the plugin composes; both readers are asserted non-empty; the implicit-
+concatenation case is pinned directly; every sync status survives readback;
+the interrupted-merge sentence survives; a reworded sentence and a
+customer-shaped value are both redacted; an ordinary classified error is
+unchanged. Adjacent: `test_issue_diagnosis`, `test_failed_run_model_evidence`.
+
+## Rollback
+
+Revert. The two sentences redact again and the needles are unasserted.
+
+## Decision Log
+
+- **Shapes, not sentences.** An allowlist of literal sentences would admit
+  whatever a future edit put in them; a pattern that constrains the variable
+  to `[a-z_]+` cannot carry a device name, an address or a tenant label.
+- **The two remaining items in the source plan are left open on purpose.**
+  The wording fallback's leading-word risk and the `redacted_message_shape`
+  convergence are judgement calls about a masking rule, not gaps in it.
+
+## Open
+
+- Nothing here. Two items remain open in
+  `docs/03_Plans/completed/2026-08-04-expose-failure-reasons.md` by decision.

--- a/docs/03_Plans/completed/2026-08-04-expose-failure-reasons.md
+++ b/docs/03_Plans/completed/2026-08-04-expose-failure-reasons.md
@@ -209,13 +209,12 @@ repairs a regression that predates this work.
 
 ## Open
 
-- `Job.error` messages that carry no exception at all - `Forward sync ended
-  with status {status}.`, `Forward merge cannot be retried after the
-  interrupted job; the authoritative branch state is {state}.` - still export
-  as `<redacted diagnostic>`. Both are plugin-authored sentences interpolating
-  a plugin-defined enum, so nothing in them is customer data, but recovering
-  them needs an allowlist of whole sentences rather than a classifier rule.
-  Left out deliberately; it is a different mechanism, not a wider one.
+- ~~`Job.error` messages that carry no exception at all still export as
+  `<redacted diagnostic>`.~~ **Closed 2026-09-02** in
+  `2026-09-02-diagnostics-readback.md`: `_SAFE_JOB_ERROR_SHAPES` is the
+  allowlist this predicted, of whole SHAPES rather than sentences - each pins
+  its wording and constrains the interpolated value to its enum, so a reworded
+  message is redacted rather than admitted.
 - The wording fallback can still emit a leading alphabetic word that happens to
   be customer data - a single-word tenant label at the very start of an
   otherwise uncatalogued message. The catalogue is the mitigation, and each
@@ -224,7 +223,10 @@ repairs a regression that predates this work.
 - `redacted_message_shape` (used for unrecognised validation rules) still keeps
   whole wording. It was not changed here because its inputs are a narrower
   population, but the two masking rules should probably converge.
-- The reason catalogue is matched against message text. A message reworded by
-  a future change silently stops resolving to its slug and falls back to
-  `unrecognized-fetch-failure`. That is visible rather than silent, but a test
-  that asserts each catalogued raise site still resolves would close it.
+- ~~The reason catalogue is matched against message text. A message reworded
+  by a future change silently stops resolving to its slug.~~ **Closed
+  2026-09-02**: `test_diagnostics_readback.py` asserts every plugin-authored
+  needle still matches a literal the plugin composes. Worth recording that the
+  first version of that test reported two slugs dead which were not - the
+  needles span an implicit string concatenation, which the runtime merges and
+  a text search does not, so the reader parses with `ast`.

--- a/forward_netbox/tests/test_diagnostics_readback.py
+++ b/forward_netbox/tests/test_diagnostics_readback.py
@@ -1,0 +1,147 @@
+# Two gaps the failure-reason work recorded and left open.
+#
+# 1. The reason catalogue is matched against MESSAGE TEXT, so a message
+#    reworded by a future change silently stops resolving to its slug and falls
+#    back to `unrecognized-fetch-failure`. Visible rather than silent, but
+#    nothing asserted the needles still match anything the plugin says.
+# 2. `Job.error` sentences composed with NO exception exported as
+#    `<redacted diagnostic>` - plugin-authored sentences interpolating a
+#    plugin-defined enum, so safe in full, but carrying no classifier for the
+#    recovery to find.
+import ast
+import re
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+from forward_netbox.choices import ForwardSyncStatusChoices
+from forward_netbox.utilities import diagnostics
+from forward_netbox.utilities.diagnostics import REDACTED_DIAGNOSTIC
+from forward_netbox.utilities.diagnostics import safe_job_error_summary
+
+# Where the plugin-authored needles begin. Everything before this slug comes
+# from a transport library's wording, which this repository does not control
+# and cannot assert against its own source.
+_FIRST_PLUGIN_AUTHORED_SLUG = "license-tier-denied"
+
+
+def _plugin_authored_needles():
+    rules = list(diagnostics._FAILURE_REASON_RULES)
+    start = next(
+        index
+        for index, (slug, _needle) in enumerate(rules)
+        if slug == _FIRST_PLUGIN_AUTHORED_SLUG
+    )
+    return rules[start:]
+
+
+def _plugin_message_literals():
+    """Every string literal the plugin composes, as the runtime sees it.
+
+    Parsed rather than grepped. Python merges implicit concatenation - the
+    `"... is not " f"contractually safe ({code})."` shape these messages are
+    written in - into ONE constant, so a needle spanning a line break is
+    present at runtime and invisible to a text search. Two slugs looked dead
+    for exactly that reason while their messages were intact.
+
+    f-string parts are kept separately: an interpolated value sits between
+    them at runtime, so a needle cannot span one there either.
+    """
+    root = Path(diagnostics.__file__).parent.parent
+    literals = []
+    for path in sorted(root.rglob("*.py")):
+        parts = set(path.parts)
+        if "tests" in parts or "migrations" in parts or path.name == "diagnostics.py":
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover - a file we cannot read is not evidence
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                literals.append(node.value)
+    return [re.sub(r"\s+", " ", literal.casefold()) for literal in literals]
+
+
+class EveryPluginAuthoredNeedleStillMatchesTest(SimpleTestCase):
+    """A slug whose needle matches nothing is a rename nobody noticed."""
+
+    def test_each_needle_appears_in_a_message_the_plugin_composes(self):
+        literals = _plugin_message_literals()
+        # The needle is matched against the casefolded exception text, so it is
+        # compared casefolded here too, with whitespace collapsed on both sides
+        # because these messages are wrapped across source lines.
+        missing = [
+            slug
+            for slug, needle in _plugin_authored_needles()
+            if not any(re.sub(r"\s+", " ", needle) in literal for literal in literals)
+        ]
+        self.assertEqual(
+            missing,
+            [],
+            "these failure-reason slugs match no message the plugin composes "
+            "any more, so the reasons they name now fall back to "
+            f"`unrecognized-fetch-failure`: {missing}",
+        )
+
+    def test_the_readers_find_something(self):
+        # A reader that silently found nothing would pass the test above.
+        needles = _plugin_authored_needles()
+        self.assertGreater(len(needles), 10)
+        self.assertEqual(needles[0][0], _FIRST_PLUGIN_AUTHORED_SLUG)
+        self.assertGreater(len(_plugin_message_literals()), 1000)
+
+    def test_implicit_concatenation_is_joined_the_way_the_runtime_joins_it(self):
+        # The bug this reader was written around: `"a " f"b{x}"` is ONE
+        # constant at runtime, so a needle spanning that break is present.
+        self.assertTrue(
+            any(
+                "not contractually safe" in literal
+                for literal in _plugin_message_literals()
+            )
+        )
+
+
+class ExceptionFreeJobErrorsReadBackTest(SimpleTestCase):
+    """Plugin-authored sentences with no classifier are safe in full."""
+
+    def test_a_sync_status_sentence_survives_readback(self):
+        for status, _label, _colour in ForwardSyncStatusChoices.CHOICES:
+            message = f"Forward sync ended with status {status}."
+            self.assertEqual(safe_job_error_summary(message), message, status)
+
+    def test_the_interrupted_merge_sentence_survives_readback(self):
+        message = (
+            "Forward merge cannot be retried after the interrupted job; "
+            "the authoritative branch state is missing."
+        )
+        self.assertEqual(safe_job_error_summary(message), message)
+
+    def test_a_reworded_sentence_is_redacted_rather_than_admitted(self):
+        # The safe direction: the allowlist pins whole wording, so a change to
+        # the message stops matching instead of widening what gets through.
+        self.assertEqual(
+            safe_job_error_summary("Forward sync ended with status failed today."),
+            REDACTED_DIAGNOSTIC,
+        )
+
+    def test_the_interpolated_value_cannot_carry_customer_data(self):
+        # The shape constrains the one variable to the enum's own vocabulary.
+        for value in ("Mgmt_Vl211", "leaf-101", "10.0.0.1", "tenant name"):
+            self.assertEqual(
+                safe_job_error_summary(f"Forward sync ended with status {value}."),
+                REDACTED_DIAGNOSTIC,
+                value,
+            )
+
+    def test_an_ordinary_classified_error_is_unchanged(self):
+        self.assertEqual(
+            safe_job_error_summary("Forward sync failed (ForwardQueryError)."),
+            "Job failed (ForwardQueryError).",
+        )
+
+    def test_an_arbitrary_message_is_still_redacted(self):
+        self.assertEqual(
+            safe_job_error_summary("something went wrong on leaf-101"),
+            REDACTED_DIAGNOSTIC,
+        )

--- a/forward_netbox/utilities/diagnostics.py
+++ b/forward_netbox/utilities/diagnostics.py
@@ -480,6 +480,34 @@ def recovered_classifiers(text) -> list[str]:
     return parts
 
 
+# `Job.error` sentences the plugin composes with NO exception at all. They
+# interpolate a plugin-defined enum and nothing else, so every token in them is
+# vocabulary this repository wrote - but they carry no classifier, so the
+# recovery below could only redact them wholesale and a customer's job page
+# read `<redacted diagnostic>` for a sentence that was safe in full.
+#
+# An allowlist of SHAPES, not of sentences: each pattern pins its whole wording
+# and constrains the one interpolated value to the enum it comes from, so a
+# reworded message stops matching (and is redacted, the safe direction) rather
+# than admitting arbitrary text. Deliberately narrow - a different mechanism
+# from the classifier rules, as the plan that recorded this said.
+_SAFE_JOB_ERROR_SHAPES = (
+    re.compile(r"^Forward sync ended with status ([a-z_]+)\.$"),
+    re.compile(
+        r"^Forward merge cannot be retried after the interrupted job; "
+        r"the authoritative branch state is ([a-z_]+)\.$"
+    ),
+)
+
+
+def _safe_job_error_shape(error: str) -> str:
+    """The message itself when it matches a plugin-authored, value-free shape."""
+    for pattern in _SAFE_JOB_ERROR_SHAPES:
+        if pattern.fullmatch(error):
+            return error
+    return ""
+
+
 def safe_job_error_summary(error) -> str:
     """Expose only an exception classifier from a persisted core Job error.
 
@@ -522,7 +550,7 @@ def safe_job_error_summary(error) -> str:
         )
     parts = recovered_classifiers(error)
     if not parts:
-        return REDACTED_DIAGNOSTIC
+        return _safe_job_error_shape(error) or REDACTED_DIAGNOSTIC
     return f"Job failed ({'; '.join(parts)})."
 
 


### PR DESCRIPTION
## Summary

Two items `2026-08-04-expose-failure-reasons.md` recorded as open.

**1. Exception-free `Job.error` sentences exported as `<redacted diagnostic>`.** `Forward sync ended with status {status}.` and the interrupted-merge sentence are plugin-authored, interpolating a plugin-defined enum — safe in full, but carrying no classifier for the recovery to find, so a customer's job page said nothing at all.

`_SAFE_JOB_ERROR_SHAPES` is the allowlist that plan predicted — of whole **shapes**, not sentences. Each pins its wording and constrains its one interpolated value to `[a-z_]+`, so a reworded message stops matching (redacted is the safe direction) and `Mgmt_Vl211`, `leaf-101` or `10.0.0.1` in that position cannot match at all. Both are asserted.

**2. A reworded message silently lost its failure-reason slug.** The catalogue is matched against message *text*, so any rewording drops the reason to `unrecognized-fetch-failure` with nothing to notice. A test now asserts every plugin-authored needle still matches a literal the plugin composes — transport needles are excluded, since this repository does not control a library's wording.

## The part worth reading

That test's **first version reported two slugs dead which were not**: `full-execution-not-contractually-safe` and `unsafe-full-contract`. Their needles span an implicit string concatenation — `"… is not " f"contractually safe ({code})."` — which Python merges into one constant at runtime and a `grep` does not. The reader now parses with `ast`, and the case is pinned directly. Recorded in the plan, because a test that reports two false positives on its first run is a test that would have been silenced rather than fixed.

## Validation

32 tests OK: `test_diagnostics_readback` (10 new), `test_issue_diagnosis`, `test_failed_run_model_evidence`. `invoke harness-check` ✓.

Plan: `docs/03_Plans/active/2026-09-02-diagnostics-readback.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa
