### PR TITLE
fix: three regressions the release gate caught before the tag

### DIFF
--- a/forward_netbox/tests/test_diagnostics_readback.py
+++ b/forward_netbox/tests/test_diagnostics_readback.py
@@ -110,6 +110,26 @@ class ExceptionFreeJobErrorsReadBackTest(SimpleTestCase):
             message = f"Forward sync ended with status {status}."
             self.assertEqual(safe_job_error_summary(message), message, status)
 
+    def test_every_shape_compiled(self):
+        """Zero shapes redacts everything, silently and plausibly.
+
+        The allowlist drops any shape whose enum it cannot read, which is
+        right when a plugin is absent and indistinguishable from having got
+        the enum's API wrong - `ChoiceSet.values` is a method, and reading it
+        as a list dropped every pattern. Assert the count, not just that one
+        sentence survives.
+        """
+        from forward_netbox.utilities.diagnostics import safe_job_error_shape_count
+
+        self.assertEqual(safe_job_error_shape_count(), 3)
+
+    def test_an_enum_value_outside_the_choice_set_is_redacted(self):
+        # The distinction the character class could not make.
+        self.assertEqual(
+            safe_job_error_summary("Forward sync ended with status finished."),
+            REDACTED_DIAGNOSTIC,
+        )
+
     def test_the_interrupted_merge_sentence_survives_readback(self):
         message = (
             "Forward merge cannot be retried after the interrupted job; "
@@ -126,8 +146,11 @@ class ExceptionFreeJobErrorsReadBackTest(SimpleTestCase):
         )
 
     def test_the_interpolated_value_cannot_carry_customer_data(self):
-        # The shape constrains the one variable to the enum's own vocabulary.
-        for value in ("Mgmt_Vl211", "leaf-101", "10.0.0.1", "tenant name"):
+        # The shape is built from the enum's own members, so it admits exactly
+        # the sentences the plugin can compose. `x` is here because the first
+        # spelling used `[a-z_]+` and admitted it - a lowercase token this code
+        # did not write - which an existing harness test caught before the tag.
+        for value in ("Mgmt_Vl211", "leaf-101", "10.0.0.1", "tenant name", "x"):
             self.assertEqual(
                 safe_job_error_summary(f"Forward sync ended with status {value}."),
                 REDACTED_DIAGNOSTIC,

--- a/forward_netbox/utilities/diagnostics.py
+++ b/forward_netbox/utilities/diagnostics.py
@@ -491,18 +491,98 @@ def recovered_classifiers(text) -> list[str]:
 # reworded message stops matching (and is redacted, the safe direction) rather
 # than admitting arbitrary text. Deliberately narrow - a different mechanism
 # from the classifier rules, as the plan that recorded this said.
-_SAFE_JOB_ERROR_SHAPES = (
-    re.compile(r"^Forward sync ended with status ([a-z_]+)\.$"),
-    re.compile(
-        r"^Forward merge cannot be retried after the interrupted job; "
-        r"the authoritative branch state is ([a-z_]+)\.$"
+# Built from the enum itself, not approximated by a character class. `[a-z_]+`
+# was the first spelling and it was wrong in the direction that matters: it
+# admitted `Forward sync ended with status x.` - any lowercase token, which is
+# a value this code did not write. An alternation of the enum's own members
+# admits exactly the sentences the plugin can compose and nothing else.
+_SAFE_JOB_ERROR_SHAPE_SOURCES = (
+    (
+        "Forward sync ended with status {value}.",
+        "forward_netbox.choices",
+        "ForwardSyncStatusChoices",
+    ),
+    (
+        "Forward merge cannot be retried after the interrupted job; "
+        "the authoritative branch state is {value}.",
+        "netbox_branching.choices",
+        "BranchStatusChoices",
     ),
 )
+_SAFE_JOB_ERROR_SHAPES = None
+
+
+def _safe_job_error_shapes():
+    """Compile the allowlist once, from each sentence's own enum.
+
+    Lazy because the enums live in Django apps: importing them at module scope
+    would make `diagnostics` unimportable before the registry is ready, and
+    this module is imported by nearly everything.
+
+    An enum that cannot be imported contributes NO pattern, so its sentence
+    stays redacted. Failing closed here costs a support question; failing open
+    would admit a sentence whose vocabulary this code could not verify.
+    """
+    global _SAFE_JOB_ERROR_SHAPES
+    if _SAFE_JOB_ERROR_SHAPES is not None:
+        return _SAFE_JOB_ERROR_SHAPES
+    import importlib
+
+    patterns = []
+    for template, module_name, enum_name in _SAFE_JOB_ERROR_SHAPE_SOURCES:
+        try:
+            enum = getattr(importlib.import_module(module_name), enum_name)
+            # NetBox's `ChoiceSet.values` is a METHOD; Django's `TextChoices`
+            # exposes a list under the same name. Reading it without calling
+            # it yielded a bound method, which is not iterable as strings - so
+            # every pattern was dropped and every sentence redacted. Silent,
+            # and caught only because a test asserts the sentences survive.
+            raw = enum.values
+            values = [str(value) for value in (raw() if callable(raw) else raw)]
+        except (ImportError, AttributeError, TypeError):
+            # Exactly the ways an enum can be unreadable: the module is absent
+            # (an optional plugin), the name moved, or `values` is not
+            # iterable. Named rather than caught broadly, so a worker teardown
+            # propagates instead of being absorbed into "admits nothing".
+            continue
+        if not values:
+            continue
+        alternation = "|".join(re.escape(value) for value in sorted(values))
+        patterns.append(
+            re.compile(
+                "^"
+                + re.escape(template).replace(
+                    re.escape("{value}"), f"(?:{alternation})"
+                )
+                + "$"
+            )
+        )
+    # `missing` is composed by the merge path itself when the branch has no
+    # status at all, so it is plugin vocabulary too and has no enum to come
+    # from.
+    patterns.append(
+        re.compile(
+            r"^Forward merge cannot be retried after the interrupted job; "
+            r"the authoritative branch state is missing\.$"
+        )
+    )
+    _SAFE_JOB_ERROR_SHAPES = tuple(patterns)
+    return _SAFE_JOB_ERROR_SHAPES
+
+
+def safe_job_error_shape_count() -> int:
+    """How many shapes compiled. For tests: zero means every one was dropped.
+
+    Failing closed is right when an enum is genuinely unavailable, and
+    indistinguishable from having got the enum's API wrong - which is exactly
+    what happened. A test asserts this is the full count.
+    """
+    return len(_safe_job_error_shapes())
 
 
 def _safe_job_error_shape(error: str) -> str:
     """The message itself when it matches a plugin-authored, value-free shape."""
-    for pattern in _SAFE_JOB_ERROR_SHAPES:
+    for pattern in _safe_job_error_shapes():
         if pattern.fullmatch(error):
             return error
     return ""

--- a/forward_netbox/utilities/sync_reporting.py
+++ b/forward_netbox/utilities/sync_reporting.py
@@ -939,6 +939,12 @@ def _row_identity(runner, model_string, row):
     coalesce_fields = getattr(runner, "_model_coalesce_fields", {}).get(model_string)
     try:
         return canonical_row_identity(model_string, row, coalesce_fields or [])
+    except JobTimeoutException:
+        # The worker is being torn down. Swallowing this to record a refusal
+        # would let the job look like it finished - the boundary rule every
+        # broad `except` in this module observes, and the one a helper added
+        # for a diagnostic is most likely to forget.
+        raise
     except Exception:  # noqa: BLE001 - an unkeyable row cannot be tombstoned anyway
         return ""
 


### PR DESCRIPTION
## Summary

The 2.9.2 release gate **refused at verify** with two harness failures. Fixing them surfaced a third. All three are mine, from #323 and #326, and none reached a tag.

**1. The safe-shape allowlist was too loose.** `_SAFE_JOB_ERROR_SHAPES` matched the interpolated value with `[a-z_]+`, so `Forward sync ended with status x.` passed — any lowercase token, not "the enum it comes from" as the comment claimed. An existing harness test asserted exactly that sentence redacts, and it was right. The shapes are now built from each sentence's own enum, admitting the sentences the plugin can compose and nothing else.

**2. `_row_identity` swallowed RQ timeouts.** A bare `except Exception` around the identity derivation caught `JobTimeoutException`, so a worker teardown mid-refusal would let the job look finished — the boundary rule every other broad `except` in that module observes, and the one a helper added for a *diagnostic* is easiest to forget. Caught by `test_worker_broad_exception_boundaries_propagate_rq_timeout`.

**3. Fixing (1) introduced a silent failure-closed.** NetBox's `ChoiceSet.values` is a **method**; Django's `TextChoices` exposes a list under the same name. Reading it without calling it yielded a bound method, the `TypeError` was caught, **every** pattern was dropped, and every sentence redacted — plausible, silent, and exactly what "an optional plugin is absent" looks like. It is now called when callable, and `safe_job_error_shape_count()` lets a test assert the **full count**, because "enum unavailable" and "enum API misread" are otherwise indistinguishable.

The enum import also narrowed from bare `Exception` to `ImportError`/`AttributeError`/`TypeError`, so a teardown propagates there too.

## Validation

`invoke harness-test` 375 OK; `test_diagnostics_readback` (+2), `test_refused_deletes_are_retried`, `test_issue_diagnosis`, `test_workload_state` — 64 OK. `invoke harness-check` ✓. The full gate runs next as part of the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa
