### PR TITLE
fix: give the device-analysis detail view the template it names

### DIFF
--- a/forward_netbox/templates/forward_netbox/forwarddeviceanalysis.html
+++ b/forward_netbox/templates/forward_netbox/forwarddeviceanalysis.html
@@ -1,0 +1,87 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+{% load i18n %}
+
+{% block content %}
+<div class="row mb-3">
+  <div class="col col-md-6">
+    <div class="card">
+      <h5 class="card-header">{% trans "Device Analysis" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Device" %}</th>
+            <td>{{ object.device|linkify }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Sync" %}</th>
+            <td>{{ object.sync|linkify }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Snapshot" %}</th>
+            <td>{{ object.snapshot_id|placeholder }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+    <div class="card">
+      <h5 class="card-header">{% trans "Collection" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Reachable" %}</th>
+            <td>{{ object.reachable|yesno:"Yes,No" }}</td>
+          </tr>
+          <tr>
+            {# The token says WHY an unreachable device failed, which a Yes/No cannot. #}
+            <th scope="row">{% trans "Collection Result" %}</th>
+            <td>{{ object.collection_result|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Detail" %}</th>
+            <td>{{ object.detail|placeholder }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div class="col col-md-6">
+    <div class="card">
+      <h5 class="card-header">{% trans "Operational" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Blast Radius" %}</th>
+            <td>{{ object.blast_radius }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Up Interfaces" %}</th>
+            <td>{{ object.up_interfaces }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "CVE Count" %}</th>
+            <td>{{ object.cve_count }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+    <div class="card">
+      <h5 class="card-header">{% trans "Confirmed Vulnerable CVEs" %}</h5>
+      <div class="card-body">
+        {% if object.cve_ids %}
+          {# The IDs behind the count, so the number is auditable rather than asserted. #}
+          <ul class="list-unstyled mb-0">
+            {% for cve_id in object.cve_ids %}
+              <li><code>{{ cve_id }}</code></li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p class="text-muted mb-0">
+            {% trans "No confirmed-vulnerable CVEs were recorded for this device." %}
+          </p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/forward_netbox/tests/test_model_view_routes.py
+++ b/forward_netbox/tests/test_model_view_routes.py
@@ -13,6 +13,8 @@
 # lists, and a model reachable only from its parent has no menu entry. So the
 # guard belongs here, over every registered model rather than every menu item.
 from django.apps import apps
+from django.template import TemplateDoesNotExist
+from django.template.loader import get_template
 from django.test import TestCase
 from django.urls import NoReverseMatch
 from django.urls import reverse
@@ -47,3 +49,63 @@ class EveryModelWithADetailViewCanReverseItsListTest(TestCase):
         # a customer reported and the sweep would also pass if the model stopped
         # exposing a detail view entirely.
         self.assertTrue(reverse("plugins:forward_netbox:forwardingestionissue_list"))
+
+
+class EveryDetailViewHasATemplateTest(TestCase):
+    """`generic.ObjectView` resolves a template by name, or raises at render.
+
+    A view registered without `template_name` falls back to
+    `<app_label>/<model_name>.html`. Nothing checks that the file exists until
+    someone opens the page, so a model can carry a registered, reversible,
+    linked-to detail route for releases while every visit is a 500.
+
+    `forwarddeviceanalysis` was exactly that: registered, reachable from its
+    list view, and with no template ever written. The release gate's
+    installed-route probe caught it only once that probe grew past menu lists
+    to registered detail views - which is late, and once per release at best.
+    The reverse-side of this is pinned above; this is the render side.
+    """
+
+    def test_each_registered_detail_view_resolves_a_template(self):
+        missing = []
+        for view in _plugin_detail_views():
+            name = getattr(view, "template_name", None) or (
+                f"{view.queryset.model._meta.app_label}/"
+                f"{view.queryset.model._meta.model_name}.html"
+            )
+            try:
+                get_template(name)
+            except TemplateDoesNotExist:
+                missing.append(name)
+        self.assertEqual(
+            missing,
+            [],
+            "these detail views name a template that does not exist, so every "
+            f"visit to them is a 500: {missing}",
+        )
+
+    def test_the_device_analysis_template_exists(self):
+        # Pinned by name as well as by the sweep, which would also pass if the
+        # model stopped exposing a detail view at all.
+        self.assertTrue(
+            get_template("forward_netbox/forwarddeviceanalysis.html"),
+        )
+
+
+def _plugin_detail_views():
+    """The view class behind `plugins:forward_netbox:<model>` for each model."""
+    from django.urls import resolve
+
+    views = []
+    for model in apps.get_app_config("forward_netbox").get_models():
+        name = model._meta.model_name
+        try:
+            url = reverse(f"plugins:forward_netbox:{name}", kwargs={"pk": 1})
+        except NoReverseMatch:
+            continue
+        view = resolve(url).func.view_class
+        # Only object views render an object template; delete/edit views carry
+        # their own generic confirmation templates from NetBox.
+        if getattr(view, "queryset", None) is not None:
+            views.append(view)
+    return views


### PR DESCRIPTION
## Summary

`ForwardDeviceAnalysisView` (`views.py:2769`) is a bare `generic.ObjectView`, so NetBox resolves `forward_netbox/forwarddeviceanalysis.html` — **a file that was never written**. The route is registered, reversible, and linked from its own list view, so every visit to a device-analysis detail page has been a 500 for as long as the model has existed.

The 2.9.2 release gate found it. Nothing before could: the installed-route probe rendered the plugin's *menu* lists, and this page is reachable only from its parent. It surfaced the moment that probe grew to cover registered detail views.

## The template

Follows the `forwardingestionissue.html` idiom and renders what the model actually carries:

- device, sync, snapshot;
- `reachable` **and** `collection_result` — the token exists precisely so the page can say *why* an unreachable device failed rather than a Yes/No;
- blast radius, up interfaces, CVE count;
- the `cve_ids` behind that count, so the number is auditable rather than asserted.

## The guard

`test_model_view_routes.py` already existed for the *reverse* side of this defect — a detail view whose breadcrumb reverse has no list route, which a customer hit on `forwardingestionissue`. The **render** side now joins it: every registered detail view must resolve the template it names, whether declared via `template_name` or defaulted to `<app>/<model>.html`.

Verified non-vacuous: with the new template removed the sweep fails and names it (`['forward_netbox/forwarddeviceanalysis.html']`).

## Validation

`test_model_view_routes` — 4 tests, OK. `invoke harness-check` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa
