### PR TITLE
fix: bind each probe route to its own model, not a prefix of it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Generated from the README compatibility table by `scripts/gen_changelog.py`. Do not edit by hand.
 
+## v2.9.2
+
+Release candidate; Drift is measured exactly for every fetched model, the uncovered-device count says why it grows and warns when it does, and five delete and diagnostic defects are closed.
+
 ## v2.9.1
 
 Accepts netbox-branching 1.1.3 and records the validated runtime in the lockfile.

--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ See the
 
 ## Release Compatibility
 
-The `2.9.1` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
+The `2.9.2` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
+| `v2.9.2` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Drift is measured exactly for every fetched model, the uncovered-device count says why it grows and warns when it does, and five delete and diagnostic defects are closed. |
 | `v2.9.1` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Accepts netbox-branching 1.1.3 and records the validated runtime in the lockfile. |
 | `v2.9.0` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.1`; Feature: back up device configurations from Forward into a git data source for Validity golden-config checks, plus the runtime-validation refactor and health check it required. |
 | `v2.8.9` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.0`; Fix: a sync deletes a device only on the same quarantined evidence the operator prune requires, and never stages a delete the database will refuse. |

--- a/docs/01_User_Guide/README.md
+++ b/docs/01_User_Guide/README.md
@@ -70,13 +70,14 @@ migrations, e.g. netbox-dlm `0.2.0+`; older builds need
 
 ## Release Compatibility
 
-The `2.9.1` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
+The `2.9.2` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
+| `v2.9.2` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Drift is measured exactly for every fetched model, the uncovered-device count says why it grows and warns when it does, and five delete and diagnostic defects are closed. |
 | `v2.9.1` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Accepts netbox-branching 1.1.3 and records the validated runtime in the lockfile. |
 | `v2.9.0` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.1`; Feature: back up device configurations from Forward into a git data source for Validity golden-config checks, plus the runtime-validation refactor and health check it required. |
 | `v2.8.9` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.0`; Fix: a sync deletes a device only on the same quarantined evidence the operator prune requires, and never stages a delete the database will refuse. |

--- a/docs/03_Plans/active/2026-09-02-release-2.9.2.md
+++ b/docs/03_Plans/active/2026-09-02-release-2.9.2.md
@@ -69,6 +69,29 @@ Revert to 2.9.1. No migration ships: the new `UNCOVERED` claim type is a
   undeletable ingestions (#45/#46), narrowed-head detection, and the ownership
   refusal banner. Each was already fixed and each plan still said otherwise,
   which is its own defect - a closure nobody can see gets re-investigated.
+- **Sensitive-pattern parity is UNVERIFIED for this run.**
+  `FORWARD_SENSITIVE_PATTERNS` is not available in this checkout, so the
+  release was prepared with `FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1`. The
+  local feed is therefore a subset of the one the gate applies: the gate uses
+  the superset feed and can still refuse the tag on content the local hooks
+  passed. That refusal is the mechanism working, not a transport failure, and
+  it burns the version number (`sensitive-pattern-feeds-differ`).
+
+- **The release plan reached `main` ahead of the version bump.** It was swept
+  into the whole-repo lint commit (#329), which took it out of the release
+  diff, and `check_harness` requires the plan for a high-risk change to be in
+  the same diff as the change. This entry is what puts it back there. A release
+  plan belongs in the release diff, not before it.
+
+- **A detail view with no template shipped for releases.** The gate refused
+  2.9.2 on `TemplateDoesNotExist: forward_netbox/forwarddeviceanalysis.html`:
+  `ForwardDeviceAnalysisView` is a bare `generic.ObjectView`, so NetBox
+  resolved a filename nobody had written, and every visit to that page was a
+  500. Fixed in #330 with the template and a sweep asserting every registered
+  detail view resolves the template it names. The route probe found this only
+  because it grew past menu lists this release; a page reachable only from its
+  parent had no other check.
+
 - **C7, C8 and C9 are deliberately not in this release.** All three change
   merge-path classification, and each plan says it needs its own blast-radius
   review. Adding them to the end of a long tranche is how a customer loses
@@ -80,3 +103,11 @@ Revert to 2.9.1. No migration ships: the new `UNCOVERED` claim type is a
   predictor) and C9 (re-pointed maps orphan rows), each with its own recorded
   design note.
 - NetBox 4.7, blocked on netbox-branching.
+- **`stage_prepare` is not idempotent and there is no way to resume.** Its
+  candidate-row guard refuses a second run (`a release candidate already
+  exists`), and `main()` has no `--start-at`, so any failure after prepare -
+  including the harness refusal this release hit - can only be retried by
+  resetting the tree and starting over. The Phase 1 plan promised the failure
+  path would print the step to resume from; it prints nothing. Either make
+  prepare a no-op when the surfaces already carry the target version, or add
+  the resume flag.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,13 +8,14 @@ Forward 26.6 is the baseline for async NQE.
 
 ## Release Compatibility
 
-The `2.9.1` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
+The `2.9.2` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
+| `v2.9.2` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Drift is measured exactly for every fetched model, the uncovered-device count says why it grows and warns when it does, and five delete and diagnostic defects are closed. |
 | `v2.9.1` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Accepts netbox-branching 1.1.3 and records the validated runtime in the lockfile. |
 | `v2.9.0` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.1`; Feature: back up device configurations from Forward into a git data source for Validity golden-config checks, plus the runtime-validation refactor and health check it required. |
 | `v2.8.9` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.0`; Fix: a sync deletes a device only on the same quarantined evidence the operator prune requires, and never stages a delete the database will refuse. |

--- a/forward_netbox/__init__.py
+++ b/forward_netbox/__init__.py
@@ -5,7 +5,7 @@ class NetboxForwardConfig(PluginConfig):
     name = "forward_netbox"
     verbose_name = "Forward"
     description = "Sync Forward data into NetBox using built-in NQE queries."
-    version = "2.9.1"
+    version = "2.9.2"
     base_url = "forward"
     min_version = "4.6.5"
     max_version = "4.6.99"

--- a/forward_netbox/tests/test_runtime_dependency_check.py
+++ b/forward_netbox/tests/test_runtime_dependency_check.py
@@ -23,7 +23,7 @@ class RuntimeDependencyCheckTest(SimpleTestCase):
         self.assertIsNotNone(_resolved_branching_version())
 
     def test_plugin_config_version_matches_package_release(self):
-        self.assertEqual(NetboxForwardConfig.version, "2.9.1")
+        self.assertEqual(NetboxForwardConfig.version, "2.9.2")
 
     def test_exact_runtime_passes(self):
         _check_runtime_dependencies()

--- a/forward_netbox/utilities/fast_baseline.py
+++ b/forward_netbox/utilities/fast_baseline.py
@@ -201,7 +201,7 @@ def _runtime_decision():
     expected = {
         "netbox_series": VALIDATED_NETBOX_SERIES,
         "branching_series": VALIDATED_BRANCHING_SERIES,
-        "forward_netbox": "2.9.1",
+        "forward_netbox": "2.9.2",
         # Each optional distribution lists every version validated against this
         # engine, not a single pin. An exact pin meant a customer upgrading one
         # optional plugin silently lost the fast baseline — no error, just a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "forward-netbox"
-version = "2.9.1"
+version = "2.9.2"
 description = "NetBox plugin to sync Forward data into NetBox via built-in NQE queries"
 authors = ["Craig Johnson <craigjohnson@forwardnetworks.com>"]
 license = "MIT"

--- a/scripts/tests/test_route_probe_fixture_binding.py
+++ b/scripts/tests/test_route_probe_fixture_binding.py
@@ -1,0 +1,76 @@
+# The artifact route probe binds each registered detail route to a fixture pk
+# by matching the route's short name against the fixture model names. It used
+# to take the FIRST match, and `forwardingestionissue` starts with
+# `forwardingestion` - so the issue's routes were requested with the
+# ingestion's pk, the object did not exist, and the probe failed the release
+# with `installed detail route ... returned HTTP 404`. It reads as a broken
+# route and is really a mis-addressed request.
+#
+# The probe module calls `django.setup()` against `/opt/netbox` at import, so
+# it can only be imported inside the container. The rule is compiled out of
+# the shipped source instead, which keeps the test on the real function rather
+# than a copy of it.
+import ast
+import unittest
+from pathlib import Path
+
+PROBE = Path(__file__).resolve().parents[1] / "validate_installed_routes.py"
+
+
+def _fixture_model_for():
+    tree = ast.parse(PROBE.read_text())
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "fixture_model_for":
+            namespace = {}
+            exec(compile(ast.Module([node], []), str(PROBE), "exec"), namespace)
+            return namespace["fixture_model_for"]
+    raise AssertionError("validate_installed_routes.fixture_model_for is gone")
+
+
+FIXTURES = {
+    "forwardsource": 1,
+    "forwardsync": 2,
+    "forwardingestion": 3,
+    "forwardingestionissue": 4,
+    "forwardvalidationrun": 5,
+    "forwarddeviceanalysis": 6,
+    "forwardnqemap": 7,
+    "forwarddriftpolicy": 8,
+}
+
+
+class RouteProbeFixtureBindingTest(unittest.TestCase):
+    """`invoke harness-test` runs `unittest discover`, so these are TestCases."""
+
+    def setUp(self):
+        self.fixture_model_for = _fixture_model_for()
+
+    def test_the_longer_model_name_wins_its_own_routes(self):
+        for route in (
+            "forwardingestionissue",
+            "forwardingestionissue_list",
+            "forwardingestionissue_delete",
+        ):
+            with self.subTest(route=route):
+                self.assertEqual(
+                    self.fixture_model_for(route, FIXTURES),
+                    "forwardingestionissue",
+                )
+
+    def test_the_shorter_model_keeps_its_own_routes(self):
+        for route in ("forwardingestion", "forwardingestion_delete"):
+            with self.subTest(route=route):
+                self.assertEqual(
+                    self.fixture_model_for(route, FIXTURES), "forwardingestion"
+                )
+
+    def test_an_unknown_route_binds_to_nothing(self):
+        self.assertIsNone(self.fixture_model_for("dcim_device", FIXTURES))
+
+    def test_every_fixture_name_resolves_to_itself(self):
+        # A new model whose name is a prefix of another must not silently take
+        # the other's pk; this fails the moment a fixture is added that cannot
+        # win its own exact route name.
+        for name in FIXTURES:
+            with self.subTest(model=name):
+                self.assertEqual(self.fixture_model_for(name, FIXTURES), name)

--- a/scripts/validate_installed_routes.py
+++ b/scripts/validate_installed_routes.py
@@ -25,6 +25,7 @@ from forward_netbox.choices import ForwardSyncStatusChoices  # noqa: E402
 from forward_netbox.models import ForwardDeviceAnalysis  # noqa: E402
 from forward_netbox.models import ForwardDriftPolicy  # noqa: E402
 from forward_netbox.models import ForwardIngestion  # noqa: E402
+from forward_netbox.models import ForwardIngestionIssue  # noqa: E402
 from forward_netbox.models import ForwardNQEMap  # noqa: E402
 from forward_netbox.models import ForwardSource  # noqa: E402
 from forward_netbox.models import ForwardSync  # noqa: E402
@@ -127,6 +128,11 @@ def main():
         device=device,
         snapshot_id="artifact-route-smoke",
     )
+    ingestion_issue = ForwardIngestionIssue.objects.create(
+        ingestion=ingestion,
+        message="artifact route smoke issue",
+        exception="ArtifactRouteSmoke",
+    )
 
     client = Client()
     client.force_login(user)
@@ -156,6 +162,7 @@ def main():
         "forwardsource": source.pk,
         "forwardsync": sync.pk,
         "forwardingestion": ingestion.pk,
+        "forwardingestionissue": ingestion_issue.pk,
         "forwardvalidationrun": validation_run.pk,
         "forwarddeviceanalysis": analysis.pk,
         "forwardnqemap": nqe_map.pk,
@@ -180,6 +187,21 @@ def main():
     )
 
 
+def fixture_model_for(route_short_name, fixtures):
+    """The fixture a route name belongs to: the LONGEST matching model prefix.
+
+    `forwardingestionissue` also starts with `forwardingestion`, so a
+    first-match rule binds the issue's routes to the ingestion's pk and asks
+    for an issue that does not exist. The probe then reports HTTP 404 and it
+    reads as a broken route rather than a mis-addressed request.
+    """
+    return max(
+        (candidate for candidate in fixtures if route_short_name.startswith(candidate)),
+        key=len,
+        default=None,
+    )
+
+
 def _detail_routes(fixtures):
     """Every `plugins:forward_netbox:<model>*` route that takes exactly a pk.
 
@@ -194,9 +216,7 @@ def _detail_routes(fixtures):
     for short in plugin.reverse_dict:
         if not isinstance(short, str):
             continue
-        model = next(
-            (candidate for candidate in fixtures if short.startswith(candidate)), None
-        )
+        model = fixture_model_for(short, fixtures)
         if model is None:
             continue
         for (


### PR DESCRIPTION
## Summary

The artifact route probe binds every registered detail route to a fixture pk by matching the route's short name against the fixture model names — and it took the **first** match. `forwardingestionissue` starts with `forwardingestion`, so the issue's routes were requested with the *ingestion's* pk, no such issue existed, and the probe failed the 2.9.2 release with:

```
installed detail route plugins:forward_netbox:forwardingestionissue returned HTTP 404
```

That reads as a broken route. It is really a mis-addressed request.

This was only reachable once #330 landed: `forwarddeviceanalysis` sorts earlier and aborted the sweep before it got here.

## Fix

- The rule is longest-match, and lives in a named `fixture_model_for` rather than inline.
- The probe grows the `ForwardIngestionIssue` fixture it never had, so the route is *exercised* rather than merely reached.

## The guard

The probe calls `django.setup()` against `/opt/netbox` at import, so it cannot be imported outside the container. The test compiles the rule out of the shipped source with `ast`, which keeps it on the real function instead of a copy that can drift.

Verified non-vacuous against the first-match rule: four subtests fail, every one of them `'forwardingestion' != 'forwardingestionissue'`, while the two tests that should be unaffected stay green.

Written as a `TestCase`: `invoke harness-test` runs `unittest discover`, which does not collect bare pytest functions — a pytest-style test here would silently never run.

## Validation

`invoke harness-test` exit 0; `unittest discover -p 'test_route_probe*.py'` — 4 tests OK. `invoke harness-check` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa
