### PR TITLE
release: ship v2.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Generated from the README compatibility table by `scripts/gen_changelog.py`. Do not edit by hand.
 
+## v2.9.2
+
+Release candidate; Drift is measured exactly for every fetched model, the uncovered-device count says why it grows and warns when it does, and five delete and diagnostic defects are closed.
+
 ## v2.9.1
 
 Accepts netbox-branching 1.1.3 and records the validated runtime in the lockfile.

--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ See the
 
 ## Release Compatibility
 
-The `2.9.1` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
+The `2.9.2` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
+| `v2.9.2` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Drift is measured exactly for every fetched model, the uncovered-device count says why it grows and warns when it does, and five delete and diagnostic defects are closed. |
 | `v2.9.1` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Accepts netbox-branching 1.1.3 and records the validated runtime in the lockfile. |
 | `v2.9.0` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.1`; Feature: back up device configurations from Forward into a git data source for Validity golden-config checks, plus the runtime-validation refactor and health check it required. |
 | `v2.8.9` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.0`; Fix: a sync deletes a device only on the same quarantined evidence the operator prune requires, and never stages a delete the database will refuse. |

--- a/docs/01_User_Guide/README.md
+++ b/docs/01_User_Guide/README.md
@@ -70,13 +70,14 @@ migrations, e.g. netbox-dlm `0.2.0+`; older builds need
 
 ## Release Compatibility
 
-The `2.9.1` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
+The `2.9.2` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
+| `v2.9.2` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Drift is measured exactly for every fetched model, the uncovered-device count says why it grows and warns when it does, and five delete and diagnostic defects are closed. |
 | `v2.9.1` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Accepts netbox-branching 1.1.3 and records the validated runtime in the lockfile. |
 | `v2.9.0` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.1`; Feature: back up device configurations from Forward into a git data source for Validity golden-config checks, plus the runtime-validation refactor and health check it required. |
 | `v2.8.9` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.0`; Fix: a sync deletes a device only on the same quarantined evidence the operator prune requires, and never stages a delete the database will refuse. |

--- a/docs/03_Plans/active/2026-09-02-release-2.9.2.md
+++ b/docs/03_Plans/active/2026-09-02-release-2.9.2.md
@@ -69,6 +69,45 @@ Revert to 2.9.1. No migration ships: the new `UNCOVERED` claim type is a
   undeletable ingestions (#45/#46), narrowed-head detection, and the ownership
   refusal banner. Each was already fixed and each plan still said otherwise,
   which is its own defect - a closure nobody can see gets re-investigated.
+- **Sensitive-pattern parity is UNVERIFIED for this run.**
+  `FORWARD_SENSITIVE_PATTERNS` is not available in this checkout, so the
+  release was prepared with `FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1`. The
+  local feed is therefore a subset of the one the gate applies: the gate uses
+  the superset feed and can still refuse the tag on content the local hooks
+  passed. That refusal is the mechanism working, not a transport failure, and
+  it burns the version number (`sensitive-pattern-feeds-differ`).
+
+- **The release plan reached `main` ahead of the version bump.** It was swept
+  into the whole-repo lint commit (#329), which took it out of the release
+  diff, and `check_harness` requires the plan for a high-risk change to be in
+  the same diff as the change. This entry is what puts it back there. A release
+  plan belongs in the release diff, not before it.
+
+- **A detail view with no template shipped for releases.** The gate refused
+  2.9.2 on `TemplateDoesNotExist: forward_netbox/forwarddeviceanalysis.html`:
+  `ForwardDeviceAnalysisView` is a bare `generic.ObjectView`, so NetBox
+  resolved a filename nobody had written, and every visit to that page was a
+  500. Fixed in #330 with the template and a sweep asserting every registered
+  detail view resolves the template it names. The route probe found this only
+  because it grew past menu lists this release; a page reachable only from its
+  parent had no other check.
+
+- **The route probe addressed one model with another's pk.** After the
+  template landed the gate refused again on
+  `installed detail route ... forwardingestionissue returned HTTP 404`: the
+  probe bound routes to fixtures by first prefix match, and
+  `forwardingestionissue` starts with `forwardingestion`. Fixed in #331
+  (longest match, plus the issue fixture the probe never had). Not a product
+  defect - but indistinguishable from one in the gate's output, which is its
+  own cost.
+
+- **`git add -A` put the release surfaces on main under a fix's title (#331),
+  and #332 took them back off.** The bump belongs to the release commit; main
+  carries the released version. Second occurrence of this exact mistake - the
+  first cost the 2.8.3 post-release bridge - and the trigger both times was an
+  interrupted release leaving prepare edits in the tree. Stage by path while a
+  release is mid-flight.
+
 - **C7, C8 and C9 are deliberately not in this release.** All three change
   merge-path classification, and each plan says it needs its own blast-radius
   review. Adding them to the end of a long tranche is how a customer loses
@@ -80,3 +119,11 @@ Revert to 2.9.1. No migration ships: the new `UNCOVERED` claim type is a
   predictor) and C9 (re-pointed maps orphan rows), each with its own recorded
   design note.
 - NetBox 4.7, blocked on netbox-branching.
+- **`stage_prepare` is not idempotent and there is no way to resume.** Its
+  candidate-row guard refuses a second run (`a release candidate already
+  exists`), and `main()` has no `--start-at`, so any failure after prepare -
+  including the harness refusal this release hit - can only be retried by
+  resetting the tree and starting over. The Phase 1 plan promised the failure
+  path would print the step to resume from; it prints nothing. Either make
+  prepare a no-op when the surfaces already carry the target version, or add
+  the resume flag.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,13 +8,14 @@ Forward 26.6 is the baseline for async NQE.
 
 ## Release Compatibility
 
-The `2.9.1` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
+The `2.9.2` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
+| `v2.9.2` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Drift is measured exactly for every fetched model, the uncovered-device count says why it grows and warns when it does, and five delete and diagnostic defects are closed. |
 | `v2.9.1` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Accepts netbox-branching 1.1.3 and records the validated runtime in the lockfile. |
 | `v2.9.0` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.1`; Feature: back up device configurations from Forward into a git data source for Validity golden-config checks, plus the runtime-validation refactor and health check it required. |
 | `v2.8.9` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.0`; Fix: a sync deletes a device only on the same quarantined evidence the operator prune requires, and never stages a delete the database will refuse. |

--- a/forward_netbox/__init__.py
+++ b/forward_netbox/__init__.py
@@ -5,7 +5,7 @@ class NetboxForwardConfig(PluginConfig):
     name = "forward_netbox"
     verbose_name = "Forward"
     description = "Sync Forward data into NetBox using built-in NQE queries."
-    version = "2.9.1"
+    version = "2.9.2"
     base_url = "forward"
     min_version = "4.6.5"
     max_version = "4.6.99"

--- a/forward_netbox/tests/test_runtime_dependency_check.py
+++ b/forward_netbox/tests/test_runtime_dependency_check.py
@@ -23,7 +23,7 @@ class RuntimeDependencyCheckTest(SimpleTestCase):
         self.assertIsNotNone(_resolved_branching_version())
 
     def test_plugin_config_version_matches_package_release(self):
-        self.assertEqual(NetboxForwardConfig.version, "2.9.1")
+        self.assertEqual(NetboxForwardConfig.version, "2.9.2")
 
     def test_exact_runtime_passes(self):
         _check_runtime_dependencies()

--- a/forward_netbox/utilities/fast_baseline.py
+++ b/forward_netbox/utilities/fast_baseline.py
@@ -201,7 +201,7 @@ def _runtime_decision():
     expected = {
         "netbox_series": VALIDATED_NETBOX_SERIES,
         "branching_series": VALIDATED_BRANCHING_SERIES,
-        "forward_netbox": "2.9.1",
+        "forward_netbox": "2.9.2",
         # Each optional distribution lists every version validated against this
         # engine, not a single pin. An exact pin meant a customer upgrading one
         # optional plugin silently lost the fast baseline — no error, just a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "forward-netbox"
-version = "2.9.1"
+version = "2.9.2"
 description = "NetBox plugin to sync Forward data into NetBox via built-in NQE queries"
 authors = ["Craig Johnson <craigjohnson@forwardnetworks.com>"]
 license = "MIT"


### PR DESCRIPTION
Production Release PR for v2.9.2. Required CI, CodeQL, and the trusted sensitive-content status must pass before squash merge.