### PR TITLE
release: authorize v2.9.2

### DIFF
--- a/docs/03_Plans/active/2026-09-02-release-2.9.2.md
+++ b/docs/03_Plans/active/2026-09-02-release-2.9.2.md
@@ -127,3 +127,19 @@ Revert to 2.9.1. No migration ships: the new `UNCOVERED` claim type is a
   path would print the step to resume from; it prints nothing. Either make
   prepare a no-op when the surfaces already carry the target version, or add
   the resume flag.
+
+## Release Authorization
+
+- Evidence base commit: `645e6362e62da449ceb3e3510d8846f80f4f4c53`
+
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.9.1 FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 invoke ci` passed on the final 2.9.2 tree with exit status 0: 379 tests OK, 70 tests OK, 2587 tests OK, 1 tests OK across 3037 tests in total, and the upgrade leg seeded under the previous release and upgraded onto the tested runtime with its rows surviving.
+
+  The gated tree is the release tree apart from this authorization record,
+  which is Markdown in a single plan file and is appended after the gate by
+  construction.
+
+- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.9.1 FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_HOST_PORT=47099 NETBOX_URL=http://127.0.0.1:47099 invoke artifact-test` passed with exit status 0 against the installed `forward_netbox-2.9.2-py3-none-any.whl` on NetBox 4.6.8, Branching 1.1.3, Python 3.14, with every installed route returning 200, all plugin migrations applying cleanly with no drift, and a validated SBOM.
+
+The optional evidence ids are not recorded. The release owner's 2026-07-27
+proportionality decision applies; see
+`docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md`.


### PR DESCRIPTION
Release Evidence PR for v2.9.2. Required CI, CodeQL, and the trusted sensitive-content status must pass before squash merge.