### PR TITLE
fix: skip the tag-time alert check the workflow token cannot run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,16 @@ jobs:
         # pulled in by Django with only a floor pin); Dependabot already scans
         # the full dependency graph, so this asks it instead of re-deriving
         # the closure.
+        #
+        # A workflow's GITHUB_TOKEN may not read `dependabot/alerts`: the
+        # endpoint answers 403 "Resource not accessible by integration", and
+        # `security-events: read` above does not cover it. That is reported as
+        # skipped rather than failed, because the same check runs - and fails
+        # closed - in the local preflight before the tag is pushed, on the
+        # operator's own credential. Treating it as a failure here made the
+        # step unpassable for any input and stopped the v2.9.2 publish after
+        # the tag existed. Only that one inaccessible-credential case is
+        # skipped; a real alert, a 404, or bad data still fails.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -124,8 +134,11 @@ jobs:
           sys.path.insert(0, 'scripts')
           from check_release_preflight import check_dependabot_alerts
           from check_release_preflight import PreflightError
+          from check_release_preflight import PreflightUnavailable
           try:
               print(check_dependabot_alerts())
+          except PreflightUnavailable as exc:
+              print(f'::notice::skipped: {exc}')
           except PreflightError as exc:
               print(f'::error::{exc}')
               sys.exit(1)

--- a/docs/03_Plans/active/2026-09-02-release-workflow-alert-skip.md
+++ b/docs/03_Plans/active/2026-09-02-release-workflow-alert-skip.md
@@ -1,0 +1,69 @@
+# Release workflow: a check that could never pass
+
+## Goal
+
+The tag-time Dependabot-alert step must stop failing the publish workflow for
+a reason no input could change, without giving up the check itself.
+
+## Constraints
+
+- A workflow's `GITHUB_TOKEN` may not read `dependabot/alerts`. The endpoint
+  answers `403 Resource not accessible by integration`, and the
+  `security-events: read` the workflow already grants does not cover it. No
+  permission a workflow can grant itself does.
+- The same check must keep failing closed in the local preflight, which runs
+  on the operator's own `gh` credential before the tag is pushed.
+- Only the inaccessible-credential case may be skipped. A real alert, a 404, a
+  5xx, or malformed data still fails.
+
+## Touched Surfaces
+
+- `.github/workflows/release.yml` - the `Check for open Dependabot alerts`
+  step.
+- `scripts/check_release_preflight.py` - a new `PreflightUnavailable`
+  subclass and the narrowed `except` around the alerts read.
+- `scripts/tests/test_release_preflight.py` - three cases.
+
+## Approach
+
+`PreflightUnavailable(PreflightError)` means "the check could not run",
+distinct from `PreflightError`, which means "the check ran and said no". It is
+raised only when the transport error carries BOTH `HTTP 403` and
+`not accessible by integration`; everything else keeps the existing behaviour.
+Because it subclasses `PreflightError`, every existing caller that does not
+name it keeps failing closed.
+
+The workflow catches `PreflightUnavailable` first and prints a `::notice::`
+instead of a `::error::`.
+
+## Validation
+
+`scripts/tests/test_release_preflight.py` - 34 tests OK, three of them new:
+the inaccessible-credential pair is `PreflightUnavailable`; a plain 403 is
+not; a 404 that happens to carry the same phrase is not. `invoke harness-test`
+and `invoke harness-check`.
+
+## Rollback
+
+Revert the three files. The step returns to failing on 403, which blocks
+publication after the tag is pushed.
+
+## Decision Log
+
+- **Skip, rather than a PAT.** A fine-grained token with `security_events`
+  read would keep the check real at tag time, but it is a stored credential to
+  mint, scope and rotate for a window the local preflight already covers - the
+  minutes between the preflight and the tag push. The release owner chose the
+  skip.
+- **Narrow on the message pair, not the status.** Matching `403` alone would
+  wave through a repository that genuinely refuses the read; matching the
+  phrase alone would wave through a 404. Both are pinned by their own test.
+- **Found after the tag existed.** v2.9.2 was tagged, the workflow failed at
+  its first step, and nothing was built or published. The check ran green in
+  the local preflight minutes earlier, so the failure was purely a credential
+  difference between the two places it runs.
+
+## Open
+
+- The tag-time window is now unguarded for Dependabot alerts opened between
+  the local preflight and the tag. Revisit if a PAT becomes acceptable.

--- a/scripts/check_release_preflight.py
+++ b/scripts/check_release_preflight.py
@@ -48,6 +48,20 @@ class PreflightError(Exception):
     """A release preflight check failed."""
 
 
+class PreflightUnavailable(PreflightError):
+    """The check could not run because this credential cannot reach the API.
+
+    Distinct from PreflightError, which means the check RAN and said no. The
+    Dependabot alerts endpoint refuses a workflow's GITHUB_TOKEN outright -
+    `security-events: read` does not cover it, and no permission a workflow can
+    grant itself does - so the tag-time run of this check could never pass for
+    any input, and it failed the v2.9.2 publish after the tag was already
+    pushed. A caller that has no better credential may report this as skipped;
+    the local preflight, which uses the operator's own `gh` auth, still fails
+    closed on it.
+    """
+
+
 def _read(path: Path) -> str:
     try:
         return path.read_text(encoding="utf-8")
@@ -322,6 +336,12 @@ def check_dependabot_alerts() -> str:
                 "page; extend it to follow the Link header before trusting it"
             )
     except provenance.ProvenanceError as exc:
+        # Narrow on purpose: this exact pair means "this credential may not
+        # read Dependabot alerts", not "the alerts are bad". Anything else -
+        # a 404, a 5xx, malformed data - stays a hard failure.
+        message = str(exc)
+        if "HTTP 403" in message and "not accessible by integration" in message:
+            raise PreflightUnavailable(f"could not read Dependabot alerts: {exc}")
         raise PreflightError(f"could not read Dependabot alerts: {exc}")
     unaccepted = [
         alert

--- a/scripts/tests/test_release_preflight.py
+++ b/scripts/tests/test_release_preflight.py
@@ -463,6 +463,50 @@ class DependabotAlertsTest(unittest.TestCase):
             with self.assertRaises(preflight.PreflightError):
                 preflight.check_dependabot_alerts()
 
+    def test_an_inaccessible_credential_is_unavailable_not_a_failure(self):
+        # A workflow's GITHUB_TOKEN gets exactly this from dependabot/alerts.
+        # It stopped the v2.9.2 publish AFTER the tag was pushed, and no
+        # permission a workflow can grant itself would have changed it.
+        with mock.patch.object(
+            preflight.provenance,
+            "_github_json",
+            side_effect=preflight.provenance.ProvenanceError(
+                "GitHub returned HTTP 403 for dependabot/alerts?state=open"
+                '&per_page=100: {"message":"Resource not accessible by '
+                'integration","status":"403"}'
+            ),
+        ):
+            with self.assertRaises(preflight.PreflightUnavailable):
+                preflight.check_dependabot_alerts()
+
+    def test_a_plain_forbidden_still_fails_closed(self):
+        # 403 alone is not enough: only the inaccessible-credential pair is
+        # skippable, so a repository that genuinely refuses the read is not
+        # quietly waved through.
+        with mock.patch.object(
+            preflight.provenance,
+            "_github_json",
+            side_effect=preflight.provenance.ProvenanceError(
+                "GitHub returned HTTP 403 for dependabot/alerts: forbidden"
+            ),
+        ):
+            with self.assertRaises(preflight.PreflightError) as caught:
+                preflight.check_dependabot_alerts()
+        self.assertNotIsInstance(caught.exception, preflight.PreflightUnavailable)
+
+    def test_a_not_found_still_fails_closed(self):
+        with mock.patch.object(
+            preflight.provenance,
+            "_github_json",
+            side_effect=preflight.provenance.ProvenanceError(
+                "GitHub returned HTTP 404 for dependabot/alerts: "
+                "not accessible by integration"
+            ),
+        ):
+            with self.assertRaises(preflight.PreflightError) as caught:
+                preflight.check_dependabot_alerts()
+        self.assertNotIsInstance(caught.exception, preflight.PreflightUnavailable)
+
     def test_a_transport_failure_is_translated_and_does_not_pass_silently(self):
         with mock.patch.object(
             preflight.provenance,


### PR DESCRIPTION
## Summary

The `v2.9.2` publish workflow **failed at its first step and built nothing** — PyPI upload and GitHub release artifacts were both skipped:

```
##[error]could not read Dependabot alerts: GitHub returned HTTP 403 for
dependabot/alerts?state=open&per_page=100:
{"message":"Resource not accessible by integration","status":"403"}
```

A workflow's `GITHUB_TOKEN` may not read `dependabot/alerts`. The `security-events: read` the workflow already grants does not cover that endpoint, and no permission a workflow can grant itself does — so **this step could not have passed for any input**, the same shape as the gate that burned v2.6.7 and v2.6.8.

The check ran green in the local preflight minutes earlier. The only difference was the credential.

## Fix

`PreflightUnavailable(PreflightError)` means *the check could not run*, as distinct from `PreflightError`, which means *it ran and said no*. Raised only when the transport error carries **both** `HTTP 403` **and** `not accessible by integration`.

Because it subclasses `PreflightError`, every caller that does not name it keeps failing closed — including the local preflight, which runs on the operator's own credential before the tag and is where this check actually blocks. The workflow catches it first and reports a `::notice::`.

## Negative space, pinned

- a plain `403` still fails closed;
- a `404` carrying the same phrase still fails closed;
- a transport failure still fails closed and does not pass silently (existing test, unchanged).

## What is given up

The window between the local preflight and the tag push. A stored PAT with `security_events` read would cover it; that was weighed and declined — a credential to mint, scope and rotate for a few minutes of exposure.

## Validation

`test_release_preflight` — 34 tests OK (3 new). `invoke harness-check` ✓, `pre-commit run --all-files` clean.

Plan: `docs/03_Plans/active/2026-09-02-release-workflow-alert-skip.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa
