### PR TITLE
release: retire the superseded v2.9.2 authorization

### DIFF
--- a/docs/03_Plans/active/2026-09-02-release-2.9.2.md
+++ b/docs/03_Plans/active/2026-09-02-release-2.9.2.md
@@ -108,6 +108,20 @@ Revert to 2.9.1. No migration ships: the new `UNCOVERED` claim type is a
   interrupted release leaving prepare edits in the tree. Stage by path while a
   release is mid-flight.
 
+- **The first v2.9.2 tag published nothing, so the authorization is
+  reissued.** The publish workflow failed at its first step: a workflow's
+  GITHUB_TOKEN may not read `dependabot/alerts`, so that check could not pass
+  for any input (#335 fixes it). Nothing was built or uploaded. The tag ruleset
+  forbids deletion, so it was suspended for one command, the tag removed, and
+  the ruleset restored - the release owner's call, taken to keep the version
+  number.
+
+  The previous authorization record is removed here rather than edited. It
+  attested a gate run on a tree that was never published and is no longer the
+  tree being tagged; the tree now carries the workflow fix. The replacement is
+  rendered against this commit by `--authorize`, which is what binds the
+  evidence to the tagged tree.
+
 - **C7, C8 and C9 are deliberately not in this release.** All three change
   merge-path classification, and each plan says it needs its own blast-radius
   review. Adding them to the end of a long tranche is how a customer loses
@@ -127,19 +141,3 @@ Revert to 2.9.1. No migration ships: the new `UNCOVERED` claim type is a
   path would print the step to resume from; it prints nothing. Either make
   prepare a no-op when the surfaces already carry the target version, or add
   the resume flag.
-
-## Release Authorization
-
-- Evidence base commit: `645e6362e62da449ceb3e3510d8846f80f4f4c53`
-
-- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.9.1 FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 invoke ci` passed on the final 2.9.2 tree with exit status 0: 379 tests OK, 70 tests OK, 2587 tests OK, 1 tests OK across 3037 tests in total, and the upgrade leg seeded under the previous release and upgraded onto the tested runtime with its rows surviving.
-
-  The gated tree is the release tree apart from this authorization record,
-  which is Markdown in a single plan file and is appended after the gate by
-  construction.
-
-- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.9.1 FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_HOST_PORT=47099 NETBOX_URL=http://127.0.0.1:47099 invoke artifact-test` passed with exit status 0 against the installed `forward_netbox-2.9.2-py3-none-any.whl` on NetBox 4.6.8, Branching 1.1.3, Python 3.14, with every installed route returning 200, all plugin migrations applying cleanly with no drift, and a validated SBOM.
-
-The optional evidence ids are not recorded. The release owner's 2026-07-27
-proportionality decision applies; see
-`docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md`.


### PR DESCRIPTION
## Summary

The first `v2.9.2` tag published nothing — the workflow failed at its first step (`dependabot/alerts` returns 403 to a workflow's `GITHUB_TOKEN`), so build, PyPI upload and the GitHub release were all skipped. #335 fixes the check. The tag ruleset forbids deletion, so it was suspended for one command, the tag removed, and the ruleset restored.

This retires the superseded authorization record so `--authorize` can render its replacement.

## Why removed, not edited

The old record attested a gate run on a tree that was never published and is **no longer the tree being tagged** — that tree now carries the workflow fix. Editing it in place would leave a record whose evidence base commit *and* whose gated tree both belong to a different release attempt.

The replacement is rendered against this commit, which is what binds the evidence to the tagged tree. This commit becomes the production commit of the second attempt.

## Validation

Gate already re-run green on the new tree: 382 / 70 / 2587 tests OK, artifact leg exit 0. `invoke harness-check` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa
