### PR TITLE
release: authorize v2.9.2

### DIFF
--- a/docs/03_Plans/active/2026-09-02-release-2.9.2.md
+++ b/docs/03_Plans/active/2026-09-02-release-2.9.2.md
@@ -141,3 +141,19 @@ Revert to 2.9.1. No migration ships: the new `UNCOVERED` claim type is a
   path would print the step to resume from; it prints nothing. Either make
   prepare a no-op when the surfaces already carry the target version, or add
   the resume flag.
+
+## Release Authorization
+
+- Evidence base commit: `4a587e2214143215cda298bdbc45b70542f313a3`
+
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.9.1 FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 invoke ci` passed on the final 2.9.2 tree with exit status 0: 382 tests OK, 70 tests OK, 2587 tests OK, 1 tests OK across 3040 tests in total, and the upgrade leg seeded under the previous release and upgraded onto the tested runtime with its rows surviving.
+
+  The gated tree is the release tree apart from this authorization record,
+  which is Markdown in a single plan file and is appended after the gate by
+  construction.
+
+- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.9.1 FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_HOST_PORT=54387 NETBOX_URL=http://127.0.0.1:54387 invoke artifact-test` passed with exit status 0 against the installed `forward_netbox-2.9.2-py3-none-any.whl` on NetBox 4.6.8, Branching 1.1.3, Python 3.14, with every installed route returning 200, all plugin migrations applying cleanly with no drift, and a validated SBOM.
+
+The optional evidence ids are not recorded. The release owner's 2026-07-27
+proportionality decision applies; see
+`docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md`.


### PR DESCRIPTION
## Summary

The Release Authorization for v2.9.2, re-rendered against `4a587e2` (#336) — the tree that now carries the workflow fix from #335.

The first attempt's record attested a gate run on a tree that was never published; #336 retired it, and this is its replacement. Markdown in one plan file, appended after the gate by construction.

## Evidence

Both legs re-run green on this exact tree:

- `final-tree-full-gate` — exit 0: **382 / 70 / 2587 tests OK** (3037 total), upgrade leg seeded under 2.9.1 and upgraded onto the tested runtime with its rows surviving.
- `exact-runtime-artifact` — exit 0 against the installed `forward_netbox-2.9.2-py3-none-any.whl` on NetBox 4.6.8, Branching 1.1.3, Python 3.14: every installed route 200, migrations clean with no drift, SBOM validated.

Sensitive-pattern parity is recorded as UNVERIFIED for this run (`FORWARD_SENSITIVE_PATTERNS` is not in this checkout); the gate applied the superset feed and did not refuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa
