### PR TITLE
docs: plan the 3.0.0 release

### DIFF
--- a/docs/03_Plans/active/2026-09-02-release-3.0.0.md
+++ b/docs/03_Plans/active/2026-09-02-release-3.0.0.md
@@ -1,0 +1,88 @@
+# Release 3.0.0
+
+## Goal
+
+Ship the NetBox 4.7 runtime as a major version. 3.0 supports NetBox `4.7.x`
+with `netbox-branching` `1.2.x` and nothing else; `2.9.x` remains the
+maintained 4.6 lane.
+
+## Constraints
+
+- **The two versions move together.** Branching `1.2` requires NetBox `4.7`
+  and `1.1` cannot run on it, so there is no straddle and no dual-support
+  matrix. This is why the release is major rather than minor.
+- **`netbox-branching` `1.2.0` is not released.** `1.2.0b1` is what supports
+  4.7, and it is what this release pins. Its own notes say not to use it in
+  production and that no upgrade path is provided to future releases. The
+  release owner weighed that and chose to ship; the consequence is stated in
+  the release notes rather than buried.
+- **No optional plugin can be installed on 4.7.** Each of the five declares a
+  `max_version` in the 4.6 series and NetBox refuses to start outside a
+  plugin's declared range.
+- The plugin still has no version-conditional code, and must not grow any: the
+  fail-closed property every engine relies on depends on one supported series.
+
+## Touched Surfaces
+
+Already merged in #341 (the whole runtime move), #340 (stale-deferral sweep).
+This release adds only the version bump and its authorization record.
+
+## Approach
+
+The engineering is done and on `main`. What remains is the release itself:
+
+1. `python3 scripts/release.py 3.0.0 --write --publish --auto-finish`, with
+   `--support` and `--requirements` set to the 4.7 text. Those flags exist
+   because the compatibility table reuses the previous row verbatim, which
+   would have published 3.0 as requiring the version it refuses to load on.
+2. The gate runs the artifact leg and the upgrade leg. The upgrade leg is the
+   interesting one: it stands 2.9.x up on NetBox 4.6.5 and upgrades to 3.0 on
+   4.7.0 against one database, so NetBox's own `ltree_paths` and
+   `denormalization_triggers` migrations run over rows this plugin wrote.
+3. Four-commit lineage, then bridge and anchor.
+
+## Validation
+
+Measured on `4.7.0` + `1.2.0b1` before the gate:
+
+- Full Django suite **2589 OK** (158 skipped); harness **382 OK**.
+- Migrations apply; `makemigrations --check` clean.
+- **All three fast paths ENABLED** with zero field-contract drift. Asked
+  directly, because a silently disabled path passes every test it has.
+- **Live Forward**: the plugin's own client authenticated against production,
+  listed 102 networks, resolved `155541`, fetched 100 snapshots and ran an
+  async NQE query on snapshot `1394725` returning 5228 device rows.
+
+## Rollback
+
+`2.9.x` is the supported path for anyone on NetBox 4.6, and nothing about 3.0
+changes it. A deployment that upgraded and wants to go back must restore its
+database: NetBox 4.7's own migrations are not reversible in practice, so this
+is a NetBox rollback rather than a plugin one. That is the honest answer and
+belongs in the release notes.
+
+## Decision Log
+
+- **Major, not minor.** Dropping a supported NetBox series and changing the
+  branching requirement are both breaking. Calling it 2.10 would have implied
+  an upgrade that silently fails to load.
+- **Shipped against a beta**, deliberately, to make 4.7 available now. Plan a
+  3.0.1 that moves the pin when `1.2.0` lands, and expect branch
+  re-provisioning.
+- **The optional integrations were not removed.** Their code, models, sync
+  paths and registry entries all remain and report an absent plugin honestly.
+  Only the validated runtime set changed, so restoring one is a data edit in
+  one file.
+- **Coverage loss is stated, not hidden.** 158 skips are real: the optional
+  adapters are exercised on the 2.9.x lane until an upstream raises its
+  ceiling.
+
+## Open
+
+- The upgrade leg has not run yet; it needs the bumped version and so runs
+  inside the gate.
+- `UPGRADE_FROM_NETBOX_VER` is still `v4.6.5`, the floor for releases before
+  2.6.7 - a longer hop than any customer will make. Correct but worth revisiting.
+- NetBox 4.7's upgrade script also runs `rebuild_config_context_cache`, which
+  the harness does not. The cache falls back to on-demand rendering, so this
+  should be benign, and it is unverified.


### PR DESCRIPTION
Release plan for 3.0.0 — the NetBox 4.7 runtime as a major version.

**Why major:** dropping a supported NetBox series and changing the branching requirement are both breaking. Calling it 2.10 would have implied an upgrade that silently fails to load.

**Measured before the gate** on 4.7.0 + branching 1.2.0b1:
- Full Django suite 2589 OK (158 skipped); harness 382 OK
- Migrations clean, no model-state drift
- All three fast paths ENABLED with zero field-contract drift — asked directly, since a silently disabled path passes every test it has
- Live Forward: 102 networks, network 155541, 100 snapshots, async NQE on snapshot 1394725 returning 5228 device rows

**Not yet run:** the upgrade leg, which needs the bumped version and so runs inside the gate. It stands 2.9.x up on NetBox 4.6.5 and upgrades to 3.0 on 4.7.0 against one database, so NetBox own ltree and trigger migrations run over rows this plugin wrote.

**Stated plainly in the plan:** the branching dependency is a beta with no upgrade path to 1.2.0 final, the 158 skips are real coverage loss on the optional adapters, and rollback is a NetBox rollback rather than a plugin one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa