### PR TITLE
feat: change control, gated on what Forward saw before and after

### DIFF
--- a/docs/03_Plans/active/2026-09-02-forward-change-control-concept.md
+++ b/docs/03_Plans/active/2026-09-02-forward-change-control-concept.md
@@ -136,42 +136,32 @@ Stated first, because every section below is shorter for it.
 
 ## Touched Surfaces
 
-A new repository, `forward-change-control`, laid out to mirror
-forward-netbox so that a reader of one can read the other:
+Inside `forward_netbox/`, as a `change_control` subpackage so the feature is
+legible as one thing and its imports read as internal:
 
-- `forward_change_control/__init__.py` — `PluginConfig`, the fail-closed
-  dependency check, the branching pre-action registration.
-- `forward_change_control/models.py` — the six models below.
-- `forward_change_control/choices.py` — `ForwardChangeStateChoices`,
+- `forward_netbox/change_control/__init__.py`
+- `forward_netbox/change_control/choices.py` - `ForwardChangeStateChoices`,
   `ForwardChangeVerdictChoices`, `ForwardCriterionFamilyChoices`,
   `ForwardCriterionExpectationChoices`, `ForwardEvidencePhaseChoices`.
-- `forward_change_control/state_machine.py` — the transitions and their
-  entry/exit evidence. Pure functions over the database, no request
-  object, so they test in under a second (the reference plugin's
-  `policy.py` discipline).
-- `forward_change_control/criteria.py` — binding, execution, expectation
-  evaluation.
-- `forward_change_control/evidence.py` — recording and the
+- `forward_netbox/change_control/state_machine.py` - the transitions and their
+  entry/exit evidence. Pure functions over the database, no request object, so
+  they test in under a second.
+- `forward_netbox/change_control/criteria.py` - binding, execution,
+  expectation evaluation.
+- `forward_netbox/change_control/evidence.py` - recording and the
   regression-flip comparison.
-- `forward_change_control/gates.py` — the collect gate, the verify gate,
-  the state-preservation gate, and the `can_merge` pre-action check.
-- `forward_change_control/document.py` — the change document renderer.
-- `forward_change_control/jobs.py` — collect-wait and verify as NetBox
-  `JobRunner`s.
-- `forward_change_control/integration.py` — the forward-netbox
-  dependency declaration (see below).
-- Views, forms, tables, filtersets, API, navigation, templates, tests —
-  standard NetBox plugin surfaces.
+- `forward_netbox/change_control/gates.py` - the collect gate and the verify
+  gate.
+- `forward_netbox/change_control/predict.py` - the stub and its
+  `PredictOutcome`.
 
-In **forward-netbox 3.0**, two additions only, both in its own tree:
+Existing files that grow:
 
-- `VALIDATED_PLUGIN_APPS` gains `forward_change_control`.
-- `utilities/change_explainability.py` — `change_explainability_summary`
-  is generalized from taking a `ForwardIngestion` to taking a `Branch`.
-  Today it reads `ingestion.branch` and then only uses the branch.
-
-Nothing else in forward-netbox changes. If this design requires a third
-edit there, the design is wrong.
+- `forward_netbox/models.py` - the six models, beside the ones they reference.
+- `forward_netbox/migrations/` - one migration.
+- `forward_netbox/views.py`, `tables.py`, `forms.py`, `filtersets.py`,
+  `navigation.py`, `templates/` - the UI, following the surrounding idiom.
+- `forward_netbox/tests/` - one test module per change_control module.
 
 ## Approach
 
@@ -436,82 +426,42 @@ in the plan, not a shortcut.
 - **`ForwardIngestion`.** A change is not a sync run. It shares
   `before`/`after` snapshot ids and a branch, and nothing else.
 
-### 4. Declaring the dependency on forward-netbox
+### 4. It ships inside forward-netbox
 
-forward-netbox's own pattern is
-`utilities/plugin_integrations/registry.py`: a frozen
-`OptionalPluginIntegration` dataclass carrying `app_label`,
-`package_name`, `required_models`, an exact-version allowlist
-(`supported_package_versions`), and an `adapter_module`; runtime
-availability computed into five statuses — `not_installed`,
-`missing_required_models`, `package_metadata_unavailable`,
-`unsupported_version`, `available` — each with a human reason string,
-surfaced through `integration_capability_summary()`.
+**Decided 2026-09-02: this is not a separate plugin.** It is a feature of
+forward-netbox, shipped in 3.0, opt-in per source.
 
-`forward_change_control/integration.py` reuses that shape verbatim, with
-one inversion that must be stated loudly:
+The alternative was a sibling plugin depending on forward-netbox 3.0, and the
+reason it lost is the reuse table above. Every capability in it -
+`ForwardClient`, `resolve_snapshot_id()`, `run_nqe_diff()`,
+`compare_model_rows()`, `PreviewRunner`, `change_explainability_summary()`,
+`run_config_backup()` - is private API. A separate plugin consuming those
+would couple two independently-versioned packages through internals, which is
+exactly the shape that made the netbox-branching 1.2 move expensive: six
+private `SquashMergeStrategy` members and raw SQL against its tables, each of
+which had to be audited against the new wheel before the runtime could move.
+Choosing that deliberately, against ourselves, would have been repeating a
+mistake we had just finished paying for.
 
-**The registry pattern is built to degrade silently. This dependency must
-fail closed and loudly.** In forward-netbox an unavailable integration
-leaves a sync map dormant, which is correct there. Here, an unavailable
-forward-netbox leaves a plugin whose every gate would answer from
-nothing. So the same five statuses are computed, the same reason strings
-are produced — and anything other than `available` raises
-`ImproperlyConfigured` from `ready()`, exactly as forward-netbox's own
-`_check_runtime_dependencies()` does for `netbox_branching`:
+Shipping in-plugin removes the problem rather than managing it. There is no
+published surface to maintain, no version matrix, no `ImproperlyConfigured` on
+a missing dependency, and no registry entry. Direct imports are legitimate
+within one package.
 
-```
-FORWARD_NETBOX = ForwardDependency(
-    app_label="forward_netbox",
-    package_name="forward-netbox",
-    required_series="3.0",
-    required_models=(
-        "forward_netbox.forwardsource",
-        "forward_netbox.forwardsync",
-        "forward_netbox.forwarddeviceidentity",
-    ),
-    required_callables=(
-        "forward_netbox.utilities.forward_api_impl:ForwardClient.run_nqe_diff",
-        "forward_netbox.utilities.drift_comparison:compare_model_rows",
-        "forward_netbox.utilities.change_explainability:"
-        "change_explainability_summary",
-    ),
-)
-```
+What that costs, stated plainly:
 
-There is already a precedent in that registry for a **consumer** rather
-than a sync target: `VALIDITY_INTEGRATION` declares `required_models=()`,
-`supported_models=()` and no `adapter_module`, and its entry exists
-purely so the version reaches the support bundle and a health check can
-tell an operator whether the chain is joined up — "the failure this
-integration exists to surface, because every part of it succeeds
-independently while delivering nothing". That is exactly the failure mode
-of a change-control plugin whose forward-netbox is subtly wrong, and it
-is the right template. `forward-netbox` also declares no
-`required_settings` and no `default_settings`, reading plugin settings
-defensively at the call site so misconfiguration never blocks NetBox
-startup; this plugin should copy that posture and put its refusals in
-`ready()`'s dependency check, where they can carry a reason.
+- Six models and an eleven-state machine land in the plugin that writes
+  inventory, so every future forward-netbox release gate carries them.
+- The 45-minute gate is built around delete-path safety this feature does not
+  touch, and it will now run for changes to it.
+- A regression in 3.0 is harder to attribute, because a major runtime
+  migration and a large new feature ship together. The release owner weighed
+  that and chose it.
 
-Three deliberate differences from the source pattern:
-
-1. **A series, not an exact version.** forward-netbox pins its optional
-   plugins to exact versions because they are third-party and their
-   contracts move without notice. This dependency is ours, so it takes
-   the `series_matches()` treatment forward-netbox gives branching: a
-   patch release must not stop the plugin loading.
-2. **`required_callables` as well as `required_models`.** The registry
-   checks that content types exist. That is the right check for a sync
-   target and the wrong one here: what this plugin consumes is functions.
-   A `ForwardSource` row proves nothing about whether `run_nqe_diff`
-   still takes `before_snapshot_id`. Resolve each dotted path at
-   `ready()` and refuse on `AttributeError`, so a contract change in
-   forward-netbox is a startup failure with a name in it, not a
-   `TypeError` in a verify job at 2am.
-3. **The status still renders on a Health page** even though it can only
-   ever read `available` on a running system, because that page is what
-   a support bundle carries, and "which forward-netbox was this evidence
-   produced against" is the first question anyone asks about a verdict.
+What that does NOT change: this feature stages into a branch and merges
+through branching like everything else, and it writes nothing to the network.
+The safety argument for separation was about blast radius, and the blast
+radius here is a NetBox branch either way.
 
 ### 5. Genuinely new work vs. thin wrappers
 

--- a/forward_netbox/change_control/__init__.py
+++ b/forward_netbox/change_control/__init__.py
@@ -1,0 +1,12 @@
+# Change control: a Forward-backed gate around a NetBox branch.
+#
+# The one structural idea here is that the branch merges at CLOSE, not at
+# APPROVE. Human approval is a necessary condition; the sufficient one is a
+# post-change Forward snapshot showing the network is actually the way the
+# branch says it is. Every generic change-control tool merges when the humans
+# say yes, and cannot do otherwise, because it has no network model to consult.
+#
+# This ships inside forward_netbox rather than as a sibling plugin because
+# every capability it needs - the client, snapshot resolution, run_nqe_diff,
+# compare_model_rows, PreviewRunner - is private API. See
+# `docs/03_Plans/active/2026-09-02-forward-change-control-concept.md`.

--- a/forward_netbox/change_control/choices.py
+++ b/forward_netbox/change_control/choices.py
@@ -1,0 +1,136 @@
+# The workflow vocabulary. Deliberately the terms already used in the field
+# rather than invented ones, because a HOLD that is a VALID RESULT rather than
+# an error is the property most home-grown change gates get wrong, and naming
+# it the same way everywhere is most of what stops that.
+from django.utils.translation import gettext_lazy as _
+from utilities.choices import ChoiceSet
+
+
+class ForwardChangeStateChoices(ChoiceSet):
+    """Eleven states, ten of them mandatory.
+
+    `PREDICTED` is the optional one: `STAGED -> APPROVED` is a first-class
+    transition, not a degradation. Forward's predict workflow is not live, is
+    licence-gated when it ships, and is limited in scope today, so the machine
+    is designed to be correct without it and to treat its arrival as additive.
+    """
+
+    DRAFT = "draft"
+    SCOPED = "scoped"
+    BASELINED = "baselined"
+    STAGED = "staged"
+    PREDICTED = "predicted"
+    APPROVED = "approved"
+    APPLIED = "applied"
+    COLLECTED = "collected"
+    VERIFIED_PROCEED = "verified-proceed"
+    VERIFIED_HOLD = "verified-hold"
+    CLOSED = "closed"
+    ABANDONED = "abandoned"
+
+    CHOICES = [
+        (DRAFT, _("Draft"), "gray"),
+        (SCOPED, _("Scoped"), "gray"),
+        (BASELINED, _("Baselined"), "cyan"),
+        (STAGED, _("Staged"), "cyan"),
+        (PREDICTED, _("Predicted"), "blue"),
+        (APPROVED, _("Approved"), "blue"),
+        (APPLIED, _("Applied"), "purple"),
+        (COLLECTED, _("Collected"), "purple"),
+        (VERIFIED_PROCEED, _("Verified - proceed"), "green"),
+        (VERIFIED_HOLD, _("Verified - hold"), "orange"),
+        (CLOSED, _("Closed"), "green"),
+        (ABANDONED, _("Abandoned"), "red"),
+    ]
+
+    # A hold is not terminal and is never closed: it is fixed and re-verified.
+    # Only PROCEED reaches CLOSED.
+    TERMINAL = frozenset({CLOSED, ABANDONED})
+    OPEN = frozenset(
+        {
+            DRAFT,
+            SCOPED,
+            BASELINED,
+            STAGED,
+            PREDICTED,
+            APPROVED,
+            APPLIED,
+            COLLECTED,
+            VERIFIED_PROCEED,
+            VERIFIED_HOLD,
+        }
+    )
+
+
+class ForwardChangeVerdictChoices(ChoiceSet):
+    """The verify gate's answer. `HOLD` is a result, not a failure to answer."""
+
+    PROCEED = "proceed"
+    HOLD = "hold"
+
+    CHOICES = [
+        (PROCEED, _("Proceed"), "green"),
+        (HOLD, _("Hold"), "orange"),
+    ]
+
+
+class ForwardCriterionFamilyChoices(ChoiceSet):
+    """What a criterion is for.
+
+    ACCEPTANCE asserts the change achieved its intent. STATE_PRESERVATION
+    asserts nothing else moved - the denominator for that is a genuinely open
+    question, recorded in the plan, and is why the family is a field rather
+    than an assumption.
+    """
+
+    ACCEPTANCE = "acceptance"
+    STATE_PRESERVATION = "state-preservation"
+
+    CHOICES = [
+        (ACCEPTANCE, _("Acceptance"), "blue"),
+        (STATE_PRESERVATION, _("State preservation"), "purple"),
+    ]
+
+
+class ForwardCriterionExpectationChoices(ChoiceSet):
+    """How a criterion's rows are turned into pass or fail."""
+
+    NO_ROWS = "no-rows"
+    SOME_ROWS = "some-rows"
+    NO_DIFF = "no-diff"
+
+    CHOICES = [
+        (NO_ROWS, _("No rows"), "green"),
+        (SOME_ROWS, _("At least one row"), "blue"),
+        (NO_DIFF, _("No change from baseline"), "purple"),
+    ]
+
+
+class ForwardEvidencePhaseChoices(ChoiceSet):
+    """Evidence is recorded at two pinned snapshots, never at "now"."""
+
+    BEFORE = "before"
+    AFTER = "after"
+
+    CHOICES = [
+        (BEFORE, _("Before")),
+        (AFTER, _("After")),
+    ]
+
+
+class ForwardReviewPhaseChoices(ChoiceSet):
+    """Which gate a review opens.
+
+    PRE approves the plan: the branch and the baseline evidence. POST approves
+    the CLOSURE, after verification, which is where the branch actually
+    merges - the consequential act, and the reason a machine verdict alone is
+    not enough to reach it.
+    """
+
+    PRE = "pre"
+    POST = "post"
+
+    CHOICES = [
+        (PRE, _("Pre-change"), "blue"),
+        (POST, _("Post-change"), "green"),
+    ]

--- a/forward_netbox/change_control/criteria.py
+++ b/forward_netbox/change_control/criteria.py
@@ -1,0 +1,106 @@
+# Binding a criterion to a committed query version, and evaluating it.
+#
+# Binding is the gate that makes a verdict mean anything. An unbound criterion
+# is evaluated against whatever its query says at the time, so the assertion
+# could move under the change it is judging - and the before/after comparison
+# would silently compare two different questions.
+from dataclasses import dataclass
+
+from ..utilities.query_execution_contract import query_source_sha256
+from .choices import ForwardCriterionExpectationChoices as Expectation
+
+
+@dataclass(frozen=True)
+class BindResult:
+    bound: bool
+    query_id: str = ""
+    commit_id: str = ""
+    source_sha256: str = ""
+    error: str = ""
+
+
+def bind_criterion(criterion, client) -> BindResult:
+    """Resolve a criterion's query path to a concrete id at a concrete commit.
+
+    Reuses `resolve_nqe_query_reference`, which is the same resolution the sync
+    already performs for NQE maps. A criterion is not a map - it binds a query
+    to an ASSERTION rather than to a NetBox model, and is constrained to no
+    model list - but the resolution is identical and duplicating it would mean
+    two places to get commit pinning wrong.
+    """
+    if not criterion.query_path:
+        return BindResult(False, error="The criterion has no query path to bind.")
+    try:
+        resolved = client.resolve_nqe_query_reference(
+            repository="org",
+            query_path=criterion.query_path,
+            commit_id=criterion.commit_id or None,
+        )
+    except Exception as exc:  # noqa: BLE001 - surfaced to the operator verbatim
+        return BindResult(False, error=f"{type(exc).__name__}: {exc}")
+
+    query_id = str(resolved.get("queryId") or resolved.get("query_id") or "").strip()
+    commit_id = str(resolved.get("commitId") or resolved.get("commit_id") or "").strip()
+    if not query_id or not commit_id:
+        return BindResult(
+            False,
+            error=(
+                "Forward resolved the path but returned no query id and commit "
+                "pair, so the criterion cannot be pinned to a version."
+            ),
+        )
+    return BindResult(
+        bound=True,
+        query_id=query_id,
+        commit_id=commit_id,
+        source_sha256=query_source_sha256(resolved.get("source")),
+    )
+
+
+def evaluate_expectation(expectation: str, rows, baseline_rows=None) -> bool:
+    """Turn rows into pass or fail.
+
+    Deliberately three narrow rules rather than an expression language. A
+    criterion an operator cannot predict the meaning of is a criterion they
+    will stop trusting, and every rule here fits in a sentence on the page.
+    """
+    count = len(rows or ())
+    if expectation == Expectation.NO_ROWS:
+        return count == 0
+    if expectation == Expectation.SOME_ROWS:
+        return count > 0
+    if expectation == Expectation.NO_DIFF:
+        # Compared against the baseline's rows rather than against zero: a
+        # query that legitimately returns rows in both phases preserves state
+        # as long as the SET has not moved.
+        return _row_key_set(rows) == _row_key_set(baseline_rows)
+    raise ValueError(f"unknown expectation {expectation!r}")
+
+
+def _row_key_set(rows) -> frozenset:
+    """A comparable, order-independent view of a result set.
+
+    Values are hashed into the key rather than kept, because evidence is
+    support-bundle content and a diff must not become a place customer data
+    accumulates.
+    """
+    keyed = set()
+    for row in rows or ():
+        if isinstance(row, dict):
+            keyed.add(tuple(sorted((str(k), str(v)) for k, v in row.items())))
+        else:
+            keyed.add((("value", str(row)),))
+    return frozenset(keyed)
+
+
+def result_shape(rows) -> dict:
+    """Schema identifiers only - never values.
+
+    The same rule ingestion-issue diagnosis follows: key names are schema, and
+    payload values are the customer's.
+    """
+    keys = set()
+    for row in rows or ():
+        if isinstance(row, dict):
+            keys.update(str(k) for k in row)
+    return {"columns": sorted(keys), "row_count": len(rows or ())}

--- a/forward_netbox/change_control/evidence.py
+++ b/forward_netbox/change_control/evidence.py
@@ -1,0 +1,167 @@
+# Turning two snapshots of criterion results into a verdict.
+#
+# The regression-flip comparison is the whole reason evidence is recorded at a
+# baseline as well as after the change. Without a before-phase row, a criterion
+# that was ALREADY failing gets counted as damage this change caused, and the
+# gate blocks a change that fixed nothing and broke nothing.
+from dataclasses import dataclass
+
+from .choices import ForwardChangeVerdictChoices
+from .choices import ForwardCriterionFamilyChoices
+
+
+# What a before/after pair means. Only two of the four block, and saying so in
+# one table is clearer than four branches in the gate.
+FIX = "fix"
+REGRESSION = "regression"
+PRE_EXISTING = "pre-existing"
+PRESERVED = "preserved"
+
+_FLIP = {
+    (False, True): FIX,
+    (True, False): REGRESSION,
+    (False, False): PRE_EXISTING,
+    (True, True): PRESERVED,
+}
+
+# State preservation blocks only on a regression: a criterion that was already
+# failing is pre-existing and this change neither caused it nor was asked to
+# fix it.
+BLOCKING_FLIPS = frozenset({REGRESSION})
+
+# Acceptance is a different question and needs a different rule. It asserts the
+# change ACHIEVED ITS INTENT, so what matters is the after state on its own:
+# `fail -> fail` means the change did not work, and letting that through
+# because "it was already failing" would verify a change that accomplished
+# nothing. The before phase is still recorded, because it is what distinguishes
+# "did not work" from "broke something".
+ACCEPTANCE_BLOCKING_FLIPS = frozenset({REGRESSION, PRE_EXISTING})
+
+
+@dataclass(frozen=True)
+class CriterionOutcome:
+    """One criterion across both phases."""
+
+    criterion: object
+    before_passed: bool | None
+    after_passed: bool | None
+    flip: str
+    blocking: bool
+
+    @property
+    def blocks(self) -> bool:
+        if not self.blocking:
+            return False
+        return self.flip in self.blocking_flips
+
+    @property
+    def blocking_flips(self) -> frozenset:
+        """Which flips block, which depends on what the criterion asserts."""
+        from .choices import ForwardCriterionFamilyChoices
+
+        family = getattr(self.criterion, "family", None)
+        if family == ForwardCriterionFamilyChoices.ACCEPTANCE:
+            return ACCEPTANCE_BLOCKING_FLIPS
+        return BLOCKING_FLIPS
+
+    @property
+    def block_reason(self) -> str:
+        """Why it blocks, in the operator's terms rather than the flip's."""
+        if not self.blocks:
+            return ""
+        if self.flip == REGRESSION:
+            return "passed at the baseline and fails now: this change regressed it"
+        return "still fails: the change did not achieve what it asserted"
+
+
+def classify_flip(before_passed: bool | None, after_passed: bool | None) -> str:
+    """The before/after pair, named.
+
+    A missing phase is NOT coerced to a pass or a fail. "Not measured" is a
+    third answer and it must reach the verdict as one, because a criterion
+    nobody evaluated is not a criterion that passed - that coercion is exactly
+    how an empty comparison once read as a successful one.
+    """
+    if before_passed is None or after_passed is None:
+        return ""
+    return _FLIP[(bool(before_passed), bool(after_passed))]
+
+
+def criterion_outcomes(change) -> list[CriterionOutcome]:
+    """Pair up each criterion's before and after evidence."""
+    from ..models import ForwardChangeEvidence
+    from .choices import ForwardEvidencePhaseChoices as Phase
+
+    criteria = list(change.criteria.all())
+    if not criteria:
+        # Nothing to pair, so nothing to fetch. The caller turns this into an
+        # honest HOLD rather than an empty PROCEED.
+        return []
+
+    rows = ForwardChangeEvidence.objects.filter(criterion__change=change)
+    by_criterion: dict[int, dict[str, bool]] = {}
+    for row in rows:
+        by_criterion.setdefault(row.criterion_id, {})[row.phase] = row.passed
+
+    outcomes = []
+    for criterion in criteria:
+        phases = by_criterion.get(criterion.pk, {})
+        before = phases.get(Phase.BEFORE)
+        after = phases.get(Phase.AFTER)
+        outcomes.append(
+            CriterionOutcome(
+                criterion=criterion,
+                before_passed=before,
+                after_passed=after,
+                flip=classify_flip(before, after),
+                blocking=criterion.blocking,
+            )
+        )
+    return outcomes
+
+
+def compute_verdict(change) -> tuple[str, list[str]]:
+    """PROCEED or HOLD, and the reasons for a HOLD.
+
+    A HOLD is a valid result. It is returned with its reasons, not raised, and
+    the workflow keeps it open for a fix and a re-verify rather than closing
+    it.
+    """
+    outcomes = criterion_outcomes(change)
+    reasons = []
+
+    if not outcomes:
+        return ForwardChangeVerdictChoices.HOLD, [
+            "No criteria were evaluated, so there is nothing to verify against."
+        ]
+
+    unmeasured = [o for o in outcomes if o.blocking and not o.flip]
+    for outcome in unmeasured:
+        missing = "before" if outcome.before_passed is None else "after"
+        reasons.append(
+            f"'{outcome.criterion.name}' has no {missing} evidence, so it was "
+            f"not measured. That is not the same as passing."
+        )
+
+    for outcome in outcomes:
+        if outcome.blocks:
+            reasons.append(f"'{outcome.criterion.name}' {outcome.block_reason}.")
+
+    moved = [
+        o
+        for o in outcomes
+        if o.criterion.family == ForwardCriterionFamilyChoices.STATE_PRESERVATION
+        and o.flip == REGRESSION
+    ]
+    if moved:
+        reasons.append(
+            f"{len(moved)} state-preservation criterion(s) moved, so something "
+            f"outside the change's declared scope is no longer as it was."
+        )
+
+    verdict = (
+        ForwardChangeVerdictChoices.HOLD
+        if reasons
+        else ForwardChangeVerdictChoices.PROCEED
+    )
+    return verdict, reasons

--- a/forward_netbox/change_control/gates.py
+++ b/forward_netbox/change_control/gates.py
@@ -1,0 +1,164 @@
+# The two gates that need Forward: collect and verify.
+#
+# The single most important thing in this file is device-set completeness, and
+# it is step one rather than a report at the end. A device that failed
+# collection is ABSENT from the Forward model rather than flagged in it, so
+# "no violations found" and "the broken device was not in the snapshot" are
+# indistinguishable from the rows alone. That is the same shape as a customer's
+# 552 "uncovered" devices: absence reads as health unless something asks.
+from dataclasses import dataclass
+from dataclasses import field
+
+from .choices import ForwardChangeVerdictChoices
+from .evidence import compute_verdict
+from .evidence import criterion_outcomes
+from .evidence import FIX
+from .evidence import REGRESSION
+
+
+@dataclass(frozen=True)
+class GateResult:
+    passed: bool
+    reasons: tuple[str, ...] = ()
+    context: dict = field(default_factory=dict)
+
+    def __bool__(self):
+        return self.passed
+
+
+def device_set_complete(change, observed_device_keys) -> GateResult:
+    """Every in-scope device must appear in the snapshot being verified.
+
+    Refuses rather than warns. A verdict computed over a snapshot that is
+    missing some of the devices the change touched is not a weaker verdict, it
+    is a different question answered confidently.
+    """
+    scoped = {
+        d.forward_device_key: d for d in change.devices.all() if d.forward_device_key
+    }
+    observed = {str(k) for k in (observed_device_keys or ())}
+    missing = sorted(set(scoped) - observed)
+    if not missing:
+        return GateResult(True, context={"devices": len(scoped)})
+
+    names = ", ".join(str(scoped[k].device) for k in missing[:5])
+    return GateResult(
+        False,
+        (
+            f"{len(missing)} of {len(scoped)} in-scope device(s) are absent "
+            f"from this snapshot, so nothing can be concluded about them: "
+            f"{names}. A device that failed collection is missing from the "
+            f"model rather than marked failed, which is why this refuses "
+            f"instead of reporting a pass over a smaller set.",
+        ),
+        {"missing": missing, "scoped": len(scoped)},
+    )
+
+
+def collection_postdates_apply(change, device_collection_times) -> GateResult:
+    """The snapshot must have seen the network AFTER the change was applied.
+
+    The weakest joint in the workflow, and it is named as such rather than
+    presented as a computed fact: `applied_at` is a human attestation, and
+    per-device collection times are only as precise as Forward's collectors
+    report. When a device has no collection time this HOLDS rather than
+    assuming the snapshot is new enough.
+    """
+    if not change.applied_at:
+        return GateResult(False, ("No apply time was attested.",))
+
+    scoped = {
+        d.forward_device_key: d for d in change.devices.all() if d.forward_device_key
+    }
+    stale, unknown = [], []
+    for key, scoped_device in scoped.items():
+        collected = (device_collection_times or {}).get(key)
+        if collected is None:
+            unknown.append(str(scoped_device.device))
+        elif collected < change.applied_at:
+            stale.append(str(scoped_device.device))
+
+    reasons = []
+    if stale:
+        reasons.append(
+            f"{len(stale)} device(s) were last collected before the change was "
+            f"applied, so this snapshot cannot show its effect: "
+            f"{', '.join(sorted(stale)[:5])}."
+        )
+    if unknown:
+        reasons.append(
+            f"{len(unknown)} device(s) report no collection time, so whether "
+            f"this snapshot postdates the change is unknown for them: "
+            f"{', '.join(sorted(unknown)[:5])}. Unknown is held, not assumed."
+        )
+    return GateResult(not reasons, tuple(reasons))
+
+
+def attestation_looks_premature(change, outcomes) -> GateResult:
+    """Forward sees no difference at all between the two snapshots.
+
+    `APPLIED` is a human claim and cannot be proved from here. But its most
+    common failure - verifying before the change actually landed, or attesting
+    a change that silently did nothing - IS detectable: if every criterion
+    reports an identical result before and after, the network Forward observed
+    did not move.
+
+    That is not proof the change was never applied. A change can legitimately
+    leave every criterion where it was. So this is a HOLD with a question
+    rather than an accusation, and it names the alternative explanation.
+    """
+    measured = [o for o in outcomes if o.flip]
+    if not measured:
+        return GateResult(True)
+
+    moved = [o for o in measured if o.flip in (FIX, REGRESSION)]
+    if moved:
+        return GateResult(True, context={"moved": len(moved)})
+
+    return GateResult(
+        False,
+        (
+            "Every criterion returned the same result before and after, so "
+            "Forward observed no change to the network. Either the change has "
+            "not landed yet and this was verified too early, or it landed and "
+            "changed nothing the criteria ask about. The apply time is "
+            "attested rather than measured, so this cannot be settled from "
+            "here - check the snapshot is newer than the work.",
+        ),
+        {"measured": len(measured)},
+    )
+
+
+def verify(change, *, observed_device_keys=None, device_collection_times=None):
+    """The verify gate, in order. Returns (verdict, reasons).
+
+    Order matters: completeness and timing come before the criteria, because a
+    criterion evaluated over an incomplete or stale snapshot produces a
+    confident wrong answer rather than an obviously missing one.
+    """
+    reasons: list[str] = []
+
+    completeness = device_set_complete(change, observed_device_keys)
+    if not completeness:
+        reasons.extend(completeness.reasons)
+
+    timing = collection_postdates_apply(change, device_collection_times)
+    if not timing:
+        reasons.extend(timing.reasons)
+
+    if reasons:
+        # Short-circuit deliberately: the criteria are not evaluated at all,
+        # so no evidence row is written that would later read as a real
+        # measurement of this snapshot.
+        return ForwardChangeVerdictChoices.HOLD, reasons
+
+    verdict, criteria_reasons = compute_verdict(change)
+
+    # Asked after the criteria, not before: it needs their outcomes, and a
+    # change that already has a real reason to hold does not need this one too.
+    if not criteria_reasons:
+        premature = attestation_looks_premature(change, criterion_outcomes(change))
+        if not premature:
+            return ForwardChangeVerdictChoices.HOLD, list(premature.reasons)
+
+    return verdict, criteria_reasons

--- a/forward_netbox/change_control/policy.py
+++ b/forward_netbox/change_control/policy.py
@@ -1,0 +1,111 @@
+# How many approvals a change needs, and from whom.
+#
+# One helper for both gates so the count rule lives in one place. Before this,
+# ForwardChangePolicy was inert: nothing read `min_approvals`, nothing
+# evaluated a rule, and `_approved()` accepted any single approving row.
+from .choices import ForwardReviewPhaseChoices
+
+# With no policy matching a change, require one approval at each gate rather
+# than none. An unmatched change must not be EASIER to merge than a matched
+# one - that is the failure mode where adding a policy to cover one estate
+# quietly leaves everything else ungoverned.
+DEFAULT_REQUIRED_APPROVALS = 1
+
+
+def applicable_policies(change):
+    """Enabled policies whose rules match the change's device scope.
+
+    Scoped by device role, site or tag - the properties a NETWORK change has -
+    rather than by NetBox object type, because that is how an operator reasons
+    about which changes need which approvers.
+
+    A policy with NO rules applies to every change. A policy with rules
+    applies when any rule matches any device in scope.
+    """
+    from ..models import ForwardChangePolicy
+
+    devices = [scoped.device for scoped in change.devices.select_related("device")]
+    matched = []
+    for policy in ForwardChangePolicy.objects.filter(enabled=True).prefetch_related(
+        "rules"
+    ):
+        rules = list(policy.rules.all())
+        if not rules:
+            matched.append(policy)
+            continue
+        if any(_rule_matches(rule, devices) for rule in rules):
+            matched.append(policy)
+    return matched
+
+
+def _rule_matches(rule, devices) -> bool:
+    for device in devices:
+        if rule.device_role_id and device.role_id != rule.device_role_id:
+            continue
+        if rule.site_id and device.site_id != rule.site_id:
+            continue
+        if rule.tag_slug and not device.tags.filter(slug=rule.tag_slug).exists():
+            continue
+        # Every populated facet matched, and an empty facet is a wildcard.
+        if rule.device_role_id or rule.site_id or rule.tag_slug:
+            return True
+    return False
+
+
+def required_approvals(change, phase: str) -> int:
+    """How many distinct approvals this gate needs.
+
+    The STRICTEST applicable policy wins. Overlapping policies are a way to
+    add requirements, never to relax them - otherwise attaching a permissive
+    policy would weaken a stricter one that already covered the estate.
+    """
+    policies = applicable_policies(change)
+    if not policies:
+        return DEFAULT_REQUIRED_APPROVALS
+    field = (
+        "min_pre_approvals"
+        if phase == ForwardReviewPhaseChoices.PRE
+        else "min_post_approvals"
+    )
+    return max(
+        getattr(policy, field, DEFAULT_REQUIRED_APPROVALS) for policy in policies
+    )
+
+
+def distinct_approvers(change, phase: str) -> set:
+    """Reviewer ids that approved this gate, excluding the requester.
+
+    Self-approval is not an approval. The requester is excluded here rather
+    than at write time so an existing review cannot become valid by someone
+    later being made the requester.
+    """
+    approved = change.reviews.filter(phase=phase, approved=True)
+    return {
+        review.reviewer_id
+        for review in approved
+        if review.reviewer_id and review.reviewer_id != change.requester_id
+    }
+
+
+def stale_approvals(change, phase: str) -> list:
+    """Approvals whose anchors no longer match the change.
+
+    An approval that survives an edit to the thing it approved is not an
+    approval. The two gates anchor to different evidence because they are
+    approving different things.
+    """
+    stale = []
+    for review in change.reviews.filter(phase=phase, approved=True):
+        if phase == ForwardReviewPhaseChoices.PRE:
+            moved = (
+                review.branch_change_time != change.branch_last_change_time
+                or review.baseline_snapshot_id != change.before_snapshot_id
+            )
+        else:
+            moved = (
+                review.after_snapshot_id != change.after_snapshot_id
+                or review.verdict != change.verdict
+            )
+        if moved:
+            stale.append(review)
+    return stale

--- a/forward_netbox/change_control/predict.py
+++ b/forward_netbox/change_control/predict.py
@@ -1,0 +1,128 @@
+# Forward's predict workflow, stubbed behind a real interface.
+#
+# Three facts shape this. Predict is not live at Forward. It is licence-gated
+# when it does ship. What exists today is limited in scope. So the workflow is
+# designed to be correct with predict entirely absent, and its arrival is
+# additive: filling this in must not reshape the state machine or any model,
+# which is why the advisory columns ship in the first migration.
+#
+# Availability is discovered by ASKING and reading the refusal, never by
+# consulting a licence tier first. `utilities/license_tier.py` says the tier is
+# not readable from the API and warns against exactly that gate; a wrong
+# capability table sends an operator to buy the wrong thing.
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PredictOutcome:
+    """What a prediction attempt produced. Never an exception at the caller.
+
+    `status` is one of:
+      unavailable  - not live, or this licence does not include it
+      unsupported  - live, but it cannot answer THIS question yet
+      answered     - a real prediction
+
+    The two non-answers are distinct on purpose. "We could not ask" and "we
+    asked and it could not say" mean different things to someone deciding
+    whether to approve, and collapsing them into one greyed-out panel is how a
+    reader concludes the change was checked when it was not.
+    """
+
+    status: str
+    reason: str = ""
+    predicted_snapshot_id: str = ""
+    criteria: tuple = ()
+    pre_verdict: str = ""
+
+    UNAVAILABLE = "unavailable"
+    UNSUPPORTED = "unsupported"
+    ANSWERED = "answered"
+
+    @property
+    def is_answer(self) -> bool:
+        return self.status == self.ANSWERED
+
+
+def predict_change(
+    *,
+    source,
+    snapshot_id: str,
+    devices=(),
+    proposal=None,
+    criteria=(),
+) -> PredictOutcome:
+    """Ask Forward what this change would do. Today: always `unavailable`.
+
+    The signature is the contract, not a placeholder. When predict ships, this
+    body calls it and returns `answered`; everything above it - the state
+    machine, the models, the page - already handles all three statuses.
+
+    It returns rather than raises even for a licence denial, because a
+    capability the customer has not bought is not a fault. `ForwardLicenseTierError`
+    is already documented that way, and the caller must not have to know.
+    """
+    if not predict_enabled(source):
+        return PredictOutcome(
+            status=PredictOutcome.UNAVAILABLE,
+            reason=(
+                "Predict is not enabled on this Forward source, so it was not "
+                "asked. The change can still be approved and verified: the "
+                "verdict is computed from the post-change snapshot, which "
+                "does not depend on predict."
+            ),
+        )
+
+    # Enabled, and still unavailable: the workflow is not generally available
+    # at Forward yet. Kept distinct from the not-enabled case above because an
+    # operator who turned it ON deserves to know the answer is upstream, not a
+    # setting they missed.
+    return PredictOutcome(
+        status=PredictOutcome.UNAVAILABLE,
+        reason=(
+            "Predict is enabled for this source but Forward's predict "
+            "workflow is not available on this deployment - it is licensed "
+            "separately and is limited in scope today. Nothing is wrong with "
+            "the change, and the verdict does not depend on predict."
+        ),
+    )
+
+
+def predict_enabled(source) -> bool:
+    """Whether this source opts in to asking Forward to predict.
+
+    Off unless a deployment says otherwise, and read with `.get(..., False)`
+    so an existing source with no such key is off without a data migration.
+    Fails closed for the same reason every other capability here does: a
+    missing setting must never read as permission.
+    """
+    parameters = getattr(source, "parameters", None) or {}
+    return bool(parameters.get("enable_predict", False))
+
+
+def render_predict_panel(outcome: PredictOutcome) -> dict:
+    """How the page shows it. Informational, never an error.
+
+    A non-answer renders as a plain panel with a sentence. No red, no retry
+    button, no empty result table that reads as "nothing found" - because
+    "we asked and got no answer" must never render as "we asked and it was
+    fine".
+    """
+    if outcome.is_answer:
+        return {
+            "level": "info",
+            "heading": "Forward prediction",
+            "message": outcome.reason or "Forward predicted this change.",
+            "verdict": outcome.pre_verdict,
+            "advisory": True,
+        }
+    heading = {
+        PredictOutcome.UNAVAILABLE: "Forward prediction not available",
+        PredictOutcome.UNSUPPORTED: "Forward cannot predict this change yet",
+    }.get(outcome.status, "Forward prediction")
+    return {
+        "level": "info",
+        "heading": heading,
+        "message": outcome.reason,
+        "verdict": "",
+        "advisory": True,
+    }

--- a/forward_netbox/change_control/state_machine.py
+++ b/forward_netbox/change_control/state_machine.py
@@ -1,0 +1,246 @@
+# The transitions, and what each one demands before it will happen.
+#
+# Pure functions over the database: no request object, no client, no job. A
+# transition returns a TransitionResult rather than raising, because "this
+# cannot proceed yet, and here is precisely what is missing" is the normal
+# case in a change workflow, not an error condition.
+from dataclasses import dataclass
+from dataclasses import field
+
+from .choices import ForwardChangeStateChoices as State
+from .choices import ForwardReviewPhaseChoices
+
+
+@dataclass(frozen=True)
+class TransitionResult:
+    """Whether a transition may happen, and what is missing when it may not.
+
+    `blockers` are operator-facing sentences. They are the entire value of this
+    module: a gate that says "not ready" without saying what is missing gets
+    turned off.
+    """
+
+    allowed: bool
+    blockers: tuple[str, ...] = ()
+    context: dict = field(default_factory=dict)
+
+    def __bool__(self):
+        return self.allowed
+
+
+# Every legal edge. PREDICTED has two ways in and two ways out because it is
+# optional; STAGED -> APPROVED is a first-class transition, not a fallback.
+#
+# VERIFIED_HOLD deliberately has no edge to CLOSED. A hold is fixed and
+# re-verified - it goes back to APPLIED to await a fresh collection, or is
+# abandoned. Closing a hold is the exact mistake this vocabulary exists to
+# prevent, so the graph refuses to express it.
+TRANSITIONS: dict[str, frozenset[str]] = {
+    State.DRAFT: frozenset({State.SCOPED, State.ABANDONED}),
+    State.SCOPED: frozenset({State.BASELINED, State.DRAFT, State.ABANDONED}),
+    State.BASELINED: frozenset({State.STAGED, State.SCOPED, State.ABANDONED}),
+    State.STAGED: frozenset({State.PREDICTED, State.APPROVED, State.ABANDONED}),
+    State.PREDICTED: frozenset({State.APPROVED, State.STAGED, State.ABANDONED}),
+    State.APPROVED: frozenset({State.APPLIED, State.STAGED, State.ABANDONED}),
+    State.APPLIED: frozenset({State.COLLECTED, State.ABANDONED}),
+    State.COLLECTED: frozenset(
+        {State.VERIFIED_PROCEED, State.VERIFIED_HOLD, State.ABANDONED}
+    ),
+    State.VERIFIED_PROCEED: frozenset({State.CLOSED, State.ABANDONED}),
+    State.VERIFIED_HOLD: frozenset({State.APPLIED, State.ABANDONED}),
+    State.CLOSED: frozenset(),
+    State.ABANDONED: frozenset(),
+}
+
+
+def legal_transition(current: str, target: str) -> bool:
+    """Whether the graph has this edge at all, before any evidence is read."""
+    return target in TRANSITIONS.get(current, frozenset())
+
+
+def available_transitions(current: str) -> tuple[str, ...]:
+    return tuple(sorted(TRANSITIONS.get(current, frozenset())))
+
+
+def check_transition(change, target: str) -> TransitionResult:
+    """Whether `change` may move to `target`, and what is missing if not."""
+    current = change.state
+    if current == target:
+        return TransitionResult(False, (f"The change is already {target}.",))
+    if not legal_transition(current, target):
+        return TransitionResult(
+            False,
+            (
+                f"{current} does not lead to {target}. "
+                f"From here: {', '.join(available_transitions(current)) or 'nowhere'}.",
+            ),
+        )
+    checker = _ENTRY_CHECKS.get(target)
+    if checker is None:
+        return TransitionResult(True)
+    return checker(change)
+
+
+def _scoped(change) -> TransitionResult:
+    """Every device must be one Forward knows, and something must be asserted."""
+    blockers = []
+    devices = list(change.devices.all())
+    if not devices:
+        blockers.append("Add at least one device to the change's scope.")
+    unresolved = [d for d in devices if not d.forward_device_key]
+    if unresolved:
+        names = ", ".join(sorted(str(d.device) for d in unresolved[:5]))
+        blockers.append(
+            f"{len(unresolved)} device(s) have no Forward identity for this "
+            f"source, so Forward cannot be asked about them: {names}."
+        )
+    if not change.criteria.filter(blocking=True).exists():
+        blockers.append(
+            "Add at least one blocking acceptance criterion. A change with "
+            "nothing asserted cannot be verified, only asserted to have "
+            "happened."
+        )
+    return TransitionResult(not blockers, tuple(blockers))
+
+
+def _baselined(change) -> TransitionResult:
+    """Criteria must BIND before anything is measured against them.
+
+    Binding is resolution to a concrete `query_id` at a concrete `commit_id`.
+    An unbound criterion would be measured against whatever the query happens
+    to say later, which is how a moving assertion silently passes.
+    """
+    blockers = []
+    unbound = [c for c in change.criteria.all() if not (c.query_id and c.commit_id)]
+    if unbound:
+        names = ", ".join(sorted(c.name for c in unbound[:5]))
+        blockers.append(
+            f"{len(unbound)} criterion(s) are not bound to a committed query "
+            f"version: {names}."
+        )
+    if not change.before_snapshot_id:
+        blockers.append(
+            "Pin a baseline snapshot. A selector is not enough: the id is "
+            "recorded literally so the same snapshot is used at verify."
+        )
+    return TransitionResult(not blockers, tuple(blockers))
+
+
+def _staged(change) -> TransitionResult:
+    blockers = []
+    if not change.branch_id:
+        blockers.append("Create the NetBox branch holding the intended changes.")
+    if not change.before_snapshot_id:
+        blockers.append("Baseline the change before staging it.")
+    return TransitionResult(not blockers, tuple(blockers))
+
+
+def _approval_gate(change, phase, what) -> TransitionResult:
+    """Shared by both gates: enough distinct, non-stale, non-self approvals.
+
+    `what` names the evidence the reviewer signed off on, so the blocker reads
+    as an instruction rather than a code.
+    """
+    from .policy import distinct_approvers
+    from .policy import required_approvals
+    from .policy import stale_approvals
+
+    blockers = []
+    needed = required_approvals(change, phase)
+    approvers = distinct_approvers(change, phase)
+    stale = stale_approvals(change, phase)
+
+    if len(approvers) < needed:
+        shortfall = needed - len(approvers)
+        blockers.append(
+            f"{shortfall} more approval(s) needed ({len(approvers)} of "
+            f"{needed}). Approvals are counted per distinct reviewer, and the "
+            f"requester's own does not count."
+        )
+    if stale:
+        blockers.append(
+            f"{len(stale)} approval(s) are stale: {what} moved after they were "
+            f"given, so they approved a different change."
+        )
+    return TransitionResult(not blockers, tuple(blockers))
+
+
+def _approved(change) -> TransitionResult:
+    """The PRE gate: approving the plan, anchored to the branch and baseline.
+
+    Both anchors, because a change can be re-baselined without touching the
+    branch and the reviewer would have seen evidence from the old snapshot.
+    """
+    return _approval_gate(
+        change,
+        ForwardReviewPhaseChoices.PRE,
+        "the branch or the baseline",
+    )
+
+
+def _applied(change) -> TransitionResult:
+    """The one transition with no computed evidence, and it says so.
+
+    Nothing here can observe that a network engineer pushed configuration. The
+    attestation is a human claim, recorded as one, and the page must not
+    present it as a measurement.
+    """
+    blockers = []
+    if not change.applied_at:
+        blockers.append(
+            "Record when the change was applied. Nothing here can observe "
+            "that, so it is attested rather than measured."
+        )
+    if not change.applied_by:
+        blockers.append("Record who attested the change was applied.")
+    return TransitionResult(not blockers, tuple(blockers))
+
+
+def _collected(change) -> TransitionResult:
+    """A snapshot that is not the baseline and post-dates the apply.
+
+    The plugin waits; it has no way to ask Forward to collect. The
+    per-device timing check is the gate's real content and lives in
+    `gates.py`, because it needs the client.
+    """
+    blockers = []
+    if not change.after_snapshot_id:
+        blockers.append("No post-change snapshot has been pinned yet.")
+    elif change.after_snapshot_id == change.before_snapshot_id:
+        blockers.append(
+            "The post-change snapshot is the baseline. Verifying a change "
+            "against the snapshot taken before it would pass by construction."
+        )
+    return TransitionResult(not blockers, tuple(blockers))
+
+
+def _closed(change) -> TransitionResult:
+    """The POST gate. CLOSE is where the branch merges, so it gets its own.
+
+    A PROCEED verdict opens this gate; it does not walk through it. The
+    machine says the network looks right, and a human still decides to merge -
+    which is the consequential, irreversible half.
+
+    Anchored to the after-snapshot and the verdict: re-verifying against a
+    newer snapshot, or the verdict changing, voids a closure sign-off.
+    """
+    if change.state != State.VERIFIED_PROCEED:
+        return TransitionResult(
+            False, ("Only a change that verified PROCEED may be closed.",)
+        )
+    return _approval_gate(
+        change,
+        ForwardReviewPhaseChoices.POST,
+        "the post-change snapshot or the verdict",
+    )
+
+
+_ENTRY_CHECKS = {
+    State.SCOPED: _scoped,
+    State.BASELINED: _baselined,
+    State.STAGED: _staged,
+    State.APPROVED: _approved,
+    State.APPLIED: _applied,
+    State.COLLECTED: _collected,
+    State.CLOSED: _closed,
+}

--- a/forward_netbox/forms.py
+++ b/forward_netbox/forms.py
@@ -23,6 +23,9 @@ from .choices import ForwardSourceStatusChoices
 from .choices import ForwardSyncStatusChoices
 from .exceptions import ForwardConnectivityError
 from .exceptions import ForwardSyncError
+from .models import ForwardChange
+from .models import ForwardChangePolicy
+from .models import ForwardChangePolicyRule
 from .models import ForwardDriftPolicy
 from .models import ForwardNQEMap
 from .models import ForwardSource
@@ -522,6 +525,17 @@ class ForwardSourceForm(NetBoxModelForm):
                 "is transferred. On, the fetch is the whole collected estate."
             ),
         )
+        self.fields["enable_predict"] = forms.BooleanField(
+            required=False,
+            label="Ask Forward to predict change-control changes",
+            help_text=(
+                "Off by default. Forward's predict workflow is not generally "
+                "available, is licensed separately, and is limited in scope "
+                "today, so change control never asks unless this is on. The "
+                "verdict does not depend on it either way: it is computed "
+                "from the post-change snapshot, which every licence tier has."
+            ),
+        )
         self.fields["sync_device_tags"] = FlexibleMultipleChoiceField(
             required=False,
             choices=(),
@@ -651,6 +665,7 @@ class ForwardSourceForm(NetBoxModelForm):
         self.fields["config_backup_include_unmanaged"].initial = bool(
             parameters.get("config_backup_include_unmanaged")
         )
+        self.fields["enable_predict"].initial = bool(parameters.get("enable_predict"))
         self.fields["sync_generic_endpoints"].initial = bool(
             parameters.get("sync_generic_endpoints")
         )
@@ -729,6 +744,7 @@ class ForwardSourceForm(NetBoxModelForm):
                     "scope_endpoints_by_include_tags",
                     "config_backup_data_source",
                     "config_backup_include_unmanaged",
+                    "enable_predict",
                     name="Parameters",
                 )
             )
@@ -765,6 +781,7 @@ class ForwardSourceForm(NetBoxModelForm):
                     "scope_endpoints_by_include_tags",
                     "config_backup_data_source",
                     "config_backup_include_unmanaged",
+                    "enable_predict",
                     name="Parameters",
                 )
             )
@@ -925,6 +942,7 @@ class ForwardSourceForm(NetBoxModelForm):
             "config_backup_include_unmanaged": bool(
                 cleaned.get("config_backup_include_unmanaged")
             ),
+            "enable_predict": bool(cleaned.get("enable_predict")),
             "sync_generic_endpoints": bool(cleaned.get("sync_generic_endpoints")),
             "scope_endpoints_by_include_tags": bool(
                 cleaned.get("scope_endpoints_by_include_tags")
@@ -2065,3 +2083,75 @@ class ForwardDriftPolicyBulkEditForm(NetBoxModelBulkEditForm):
     enabled = forms.NullBooleanField(required=False, label="Enabled")
     model = ForwardDriftPolicy
     fields = ("enabled",)
+
+
+class ForwardChangeForm(NetBoxModelForm):
+    """Author a change. State is NOT editable here.
+
+    The workflow moves through `state_machine.check_transition`, which refuses
+    with reasons; a form field would let an operator type their way past a gate
+    that exists to stop exactly that.
+    """
+
+    class Meta:
+        model = ForwardChange
+        fields = (
+            "ref",
+            "title",
+            "source",
+            "requester",
+            "window_start",
+            "window_end",
+            "description",
+            "comments",
+            "tags",
+        )
+
+    fieldsets = (
+        FieldSet("ref", "title", "source", "requester", name="Change"),
+        FieldSet("window_start", "window_end", name="Window"),
+        FieldSet("description", "comments", "tags", name="Notes"),
+    )
+
+
+class ForwardChangePolicyForm(NetBoxModelForm):
+    class Meta:
+        model = ForwardChangePolicy
+        fields = (
+            "name",
+            "enabled",
+            "min_pre_approvals",
+            "min_post_approvals",
+            "description",
+            "comments",
+            "tags",
+        )
+
+    fieldsets = (
+        FieldSet(
+            "name",
+            "enabled",
+            "min_pre_approvals",
+            "min_post_approvals",
+            name="Policy",
+        ),
+        FieldSet("description", "comments", "tags", name="Notes"),
+    )
+
+
+class ForwardChangePolicyRuleForm(NetBoxModelForm):
+    """Scope a policy to the properties a network change has.
+
+    Without this the rules were creatable only through the ORM, so the scoping
+    that decides how many approvals a change needs was unreachable to the
+    operator who has to live with it.
+    """
+
+    class Meta:
+        model = ForwardChangePolicyRule
+        fields = ("policy", "device_role", "site", "tag_slug")
+
+    fieldsets = (
+        FieldSet("policy", name="Policy"),
+        FieldSet("device_role", "site", "tag_slug", name="Scope"),
+    )

--- a/forward_netbox/migrations/0054_forwardchange_forwardchangecriterion_and_more.py
+++ b/forward_netbox/migrations/0054_forwardchange_forwardchangecriterion_and_more.py
@@ -1,0 +1,461 @@
+# Change control: seven tables for the Forward-backed change gate.
+#
+# Two things in here are deliberate and worth not "tidying" later.
+#
+# ForwardChange carries four advisory columns - predict_status,
+# predict_reason, predict_pre_verdict, netbox_impact - while Forward's predict
+# workflow is not live. They ship now so its arrival is additive: filling in
+# the stub must not require a schema change. They are also quarantined from
+# the verify gate by construction, because the gate reads
+# ForwardChangeEvidence and nothing else. Making a prediction into a verdict
+# would mean moving a column into that table, which is a visible act rather
+# than a quiet drift.
+#
+# ForwardChangeEvidence is unique on (criterion, phase, snapshot_id) rather
+# than (criterion, phase). Evidence belongs to a PINNED snapshot; re-running a
+# criterion against a different snapshot is a new row, not an overwrite, so
+# the before/after comparison a verdict rests on cannot be silently rebased.
+import django.db.models.deletion
+import django.utils.timezone
+import netbox.models.deletion
+import taggit.managers
+import utilities.json
+from django.conf import settings
+from django.db import migrations
+from django.db import models
+
+import forward_netbox.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        # `0001_initial`, not the migration makemigrations picked. These FKs
+        # only need the dcim/extras models to EXIST, and naming a recent
+        # migration pins a NetBox version the plugin does not actually require
+        # - which `test_migration_dependencies` refuses for exactly that
+        # reason.
+        ("dcim", "0001_initial"),
+        ("extras", "0001_initial"),
+        ("forward_netbox", "0053_alter_forwardsource_owner"),
+        ("netbox_branching", "0009_changediff_last_updated_auto_now"),
+        ("users", "0016_default_ordering_indexes"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ForwardChange",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "custom_field_data",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        encoder=utilities.json.CustomFieldJSONEncoder,
+                    ),
+                ),
+                ("description", models.CharField(blank=True, max_length=200)),
+                ("comments", models.TextField(blank=True)),
+                ("ref", models.CharField(blank=True, default="", max_length=100)),
+                ("title", models.CharField(max_length=200)),
+                ("state", models.CharField(default="draft", max_length=32)),
+                ("verdict", models.CharField(blank=True, default="", max_length=16)),
+                (
+                    "branch_name",
+                    models.CharField(blank=True, default="", max_length=200),
+                ),
+                (
+                    "branch_last_change_time",
+                    models.DateTimeField(blank=True, null=True),
+                ),
+                (
+                    "before_snapshot_id",
+                    models.CharField(blank=True, default="", max_length=100),
+                ),
+                (
+                    "after_snapshot_id",
+                    models.CharField(blank=True, default="", max_length=100),
+                ),
+                ("window_start", models.DateTimeField(blank=True, null=True)),
+                ("window_end", models.DateTimeField(blank=True, null=True)),
+                ("applied_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "applied_ref",
+                    models.CharField(blank=True, default="", max_length=200),
+                ),
+                (
+                    "predict_status",
+                    models.CharField(blank=True, default="", max_length=32),
+                ),
+                ("predict_reason", models.TextField(blank=True, default="")),
+                (
+                    "predict_pre_verdict",
+                    models.CharField(blank=True, default="", max_length=32),
+                ),
+                ("netbox_impact", models.JSONField(blank=True, default=dict)),
+                (
+                    "applied_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "branch",
+                    models.OneToOneField(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="netbox_branching.branch",
+                    ),
+                ),
+                (
+                    "owner",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="+",
+                        to="users.owner",
+                    ),
+                ),
+                (
+                    "requester",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "source",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="changes",
+                        to="forward_netbox.forwardsource",
+                    ),
+                ),
+                (
+                    "tags",
+                    taggit.managers.TaggableManager(
+                        through="extras.TaggedItem", to="extras.Tag"
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Forward Change",
+                "verbose_name_plural": "Forward Changes",
+                "db_table": "forward_netbox_change",
+                "ordering": ("-created",),
+            },
+            bases=(
+                forward_netbox.models.ForwardPluginModelDocsMixin,
+                netbox.models.deletion.DeleteMixin,
+                models.Model,
+            ),
+        ),
+        migrations.CreateModel(
+            name="ForwardChangeCriterion",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                ("name", models.CharField(max_length=200)),
+                ("family", models.CharField(default="acceptance", max_length=32)),
+                ("expectation", models.CharField(default="no-rows", max_length=32)),
+                ("blocking", models.BooleanField(default=True)),
+                (
+                    "query_path",
+                    models.CharField(blank=True, default="", max_length=500),
+                ),
+                ("query_id", models.CharField(blank=True, default="", max_length=100)),
+                ("commit_id", models.CharField(blank=True, default="", max_length=100)),
+                (
+                    "source_sha256",
+                    models.CharField(blank=True, default="", max_length=64),
+                ),
+                (
+                    "change",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="criteria",
+                        to="forward_netbox.forwardchange",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Forward Change Criterion",
+                "verbose_name_plural": "Forward Change Criteria",
+                "db_table": "forward_netbox_change_criterion",
+                "ordering": ("change", "name"),
+            },
+            bases=(
+                forward_netbox.models.ForwardPluginModelDocsMixin,
+                netbox.models.deletion.DeleteMixin,
+                models.Model,
+            ),
+        ),
+        migrations.CreateModel(
+            name="ForwardChangeDevice",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+                (
+                    "forward_device_key",
+                    models.CharField(blank=True, default="", max_length=255),
+                ),
+                (
+                    "change",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="devices",
+                        to="forward_netbox.forwardchange",
+                    ),
+                ),
+                (
+                    "device",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="+",
+                        to="dcim.device",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Forward Change Device",
+                "verbose_name_plural": "Forward Change Devices",
+                "db_table": "forward_netbox_change_device",
+                "ordering": ("device__name",),
+            },
+        ),
+        migrations.CreateModel(
+            name="ForwardChangeEvidence",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+                ("phase", models.CharField(max_length=16)),
+                ("passed", models.BooleanField()),
+                ("row_count", models.PositiveIntegerField(default=0)),
+                ("snapshot_id", models.CharField(max_length=100)),
+                ("commit_id", models.CharField(blank=True, default="", max_length=100)),
+                (
+                    "executed_at",
+                    models.DateTimeField(default=django.utils.timezone.now),
+                ),
+                ("duration_ms", models.PositiveIntegerField(default=0)),
+                ("shape", models.JSONField(blank=True, default=dict)),
+                (
+                    "criterion",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="evidence",
+                        to="forward_netbox.forwardchangecriterion",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Forward Change Evidence",
+                "verbose_name_plural": "Forward Change Evidence",
+                "db_table": "forward_netbox_change_evidence",
+                "ordering": ("criterion", "phase"),
+            },
+        ),
+        migrations.CreateModel(
+            name="ForwardChangePolicy",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "custom_field_data",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        encoder=utilities.json.CustomFieldJSONEncoder,
+                    ),
+                ),
+                ("description", models.CharField(blank=True, max_length=200)),
+                ("comments", models.TextField(blank=True)),
+                ("name", models.CharField(max_length=100, unique=True)),
+                ("enabled", models.BooleanField(default=True)),
+                ("min_approvals", models.PositiveSmallIntegerField(default=1)),
+                (
+                    "owner",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="+",
+                        to="users.owner",
+                    ),
+                ),
+                (
+                    "tags",
+                    taggit.managers.TaggableManager(
+                        through="extras.TaggedItem", to="extras.Tag"
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Forward Change Policy",
+                "verbose_name_plural": "Forward Change Policies",
+                "db_table": "forward_netbox_change_policy",
+                "ordering": ("name",),
+            },
+            bases=(
+                forward_netbox.models.ForwardPluginModelDocsMixin,
+                netbox.models.deletion.DeleteMixin,
+                models.Model,
+            ),
+        ),
+        migrations.CreateModel(
+            name="ForwardChangePolicyRule",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                ("tag_slug", models.CharField(blank=True, default="", max_length=100)),
+                (
+                    "device_role",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="+",
+                        to="dcim.devicerole",
+                    ),
+                ),
+                (
+                    "policy",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="rules",
+                        to="forward_netbox.forwardchangepolicy",
+                    ),
+                ),
+                (
+                    "site",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="+",
+                        to="dcim.site",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Forward Change Policy Rule",
+                "verbose_name_plural": "Forward Change Policy Rules",
+                "db_table": "forward_netbox_change_policy_rule",
+                "ordering": ("policy", "pk"),
+            },
+            bases=(netbox.models.deletion.DeleteMixin, models.Model),
+        ),
+        migrations.CreateModel(
+            name="ForwardChangeReview",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                ("approved", models.BooleanField(default=False)),
+                ("comment", models.TextField(blank=True, default="")),
+                ("branch_change_time", models.DateTimeField(blank=True, null=True)),
+                (
+                    "baseline_snapshot_id",
+                    models.CharField(blank=True, default="", max_length=100),
+                ),
+                (
+                    "change",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="reviews",
+                        to="forward_netbox.forwardchange",
+                    ),
+                ),
+                (
+                    "reviewer",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Forward Change Review",
+                "verbose_name_plural": "Forward Change Reviews",
+                "db_table": "forward_netbox_change_review",
+                "ordering": ("-created",),
+            },
+            bases=(
+                forward_netbox.models.ForwardPluginModelDocsMixin,
+                netbox.models.deletion.DeleteMixin,
+                models.Model,
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="forwardchangecriterion",
+            constraint=models.UniqueConstraint(
+                fields=("change", "name"), name="forward_change_criterion_unique_name"
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="forwardchangedevice",
+            constraint=models.UniqueConstraint(
+                fields=("change", "device"), name="forward_change_device_unique"
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="forwardchangeevidence",
+            constraint=models.UniqueConstraint(
+                fields=("criterion", "phase", "snapshot_id"),
+                name="forward_change_evidence_unique",
+            ),
+        ),
+    ]

--- a/forward_netbox/migrations/0055_change_control_approvals.py
+++ b/forward_netbox/migrations/0055_change_control_approvals.py
@@ -1,0 +1,75 @@
+# Pre/post approvals, and the permission that guards them.
+#
+# `min_approvals` is REMOVED and two fields added rather than renamed. It is
+# not a rename: one number cannot say "two sign-offs on the plan, one on the
+# closure", which is the common real shape. Nothing is lost because 0054 has
+# not shipped - 3.0 is the release that introduces all of this - so there are
+# no policy rows anywhere holding a value to migrate.
+#
+# The unique constraint on (change, reviewer, phase) is the one that matters:
+# without it, N approvals from the same person satisfy an N-approval policy
+# alone, which makes the count meaningless.
+from django.conf import settings
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("forward_netbox", "0054_forwardchange_forwardchangecriterion_and_more"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="forwardchange",
+            options={
+                "ordering": ("-created",),
+                "permissions": (
+                    ("approve_forwardchange", "Can approve Forward change"),
+                ),
+                "verbose_name": "Forward Change",
+                "verbose_name_plural": "Forward Changes",
+            },
+        ),
+        migrations.RemoveField(
+            model_name="forwardchangepolicy",
+            name="min_approvals",
+        ),
+        migrations.AddField(
+            model_name="forwardchangepolicy",
+            name="min_pre_approvals",
+            field=models.PositiveSmallIntegerField(default=1),
+        ),
+        migrations.AddField(
+            model_name="forwardchangepolicy",
+            name="min_post_approvals",
+            field=models.PositiveSmallIntegerField(default=1),
+        ),
+        migrations.AddField(
+            model_name="forwardchangereview",
+            name="phase",
+            field=models.CharField(
+                choices=[("pre", "Pre-change"), ("post", "Post-change")],
+                default="pre",
+                max_length=16,
+            ),
+        ),
+        migrations.AddField(
+            model_name="forwardchangereview",
+            name="after_snapshot_id",
+            field=models.CharField(blank=True, default="", max_length=100),
+        ),
+        migrations.AddField(
+            model_name="forwardchangereview",
+            name="verdict",
+            field=models.CharField(blank=True, default="", max_length=16),
+        ),
+        migrations.AddConstraint(
+            model_name="forwardchangereview",
+            constraint=models.UniqueConstraint(
+                fields=("change", "reviewer", "phase"),
+                name="forward_change_review_one_per_reviewer_phase",
+            ),
+        ),
+    ]

--- a/forward_netbox/models.py
+++ b/forward_netbox/models.py
@@ -22,6 +22,12 @@ from netbox_branching.models import Branch
 from rq.timeouts import JobTimeoutException
 from utilities.querysets import RestrictedQuerySet
 
+from .change_control.choices import ForwardChangeStateChoices
+from .change_control.choices import ForwardChangeVerdictChoices
+from .change_control.choices import ForwardCriterionExpectationChoices
+from .change_control.choices import ForwardCriterionFamilyChoices
+from .change_control.choices import ForwardEvidencePhaseChoices
+from .change_control.choices import ForwardReviewPhaseChoices
 from .choices import forward_configured_models
 from .choices import FORWARD_OPTIONAL_MODELS
 from .choices import FORWARD_SUPPORTED_MODELS
@@ -1844,3 +1850,355 @@ class ForwardDeviceAnalysis(ForwardPluginModelDocsMixin, ChangeLoggedModel):
         source = getattr(self.sync, "source", None)
         url = (getattr(source, "url", "") or "").rstrip("/")
         return url or None
+
+
+class ForwardChange(ForwardPluginModelDocsMixin, PrimaryModel):
+    """A network change, gated on what Forward saw before and after it.
+
+    The branch merges when this reaches CLOSED, not when it is APPROVED.
+    Approval is a necessary condition; the sufficient one is a post-change
+    snapshot showing the network is the way the branch says it is.
+    """
+
+    source = models.ForeignKey(
+        ForwardSource,
+        on_delete=models.PROTECT,
+        related_name="changes",
+    )
+    ref = models.CharField(max_length=100, blank=True, default="")
+    title = models.CharField(max_length=200)
+    state = models.CharField(
+        max_length=32,
+        choices=ForwardChangeStateChoices,
+        default=ForwardChangeStateChoices.DRAFT,
+    )
+    verdict = models.CharField(
+        max_length=16,
+        choices=ForwardChangeVerdictChoices,
+        blank=True,
+        default="",
+    )
+    requester = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        blank=True,
+        null=True,
+        related_name="+",
+    )
+    branch = models.OneToOneField(
+        Branch,
+        on_delete=models.SET_NULL,
+        blank=True,
+        null=True,
+        related_name="+",
+    )
+    # Denormalized so the record stays readable after the branch is merged or
+    # discarded; the FK is SET_NULL and a merged branch is routinely removed.
+    branch_name = models.CharField(max_length=200, blank=True, default="")
+    branch_last_change_time = models.DateTimeField(blank=True, null=True)
+
+    # Pinned as literal ids, never selectors. A selector re-resolved at verify
+    # time would compare the change against a different snapshot than the one
+    # it was baselined and approved against.
+    before_snapshot_id = models.CharField(max_length=100, blank=True, default="")
+    after_snapshot_id = models.CharField(max_length=100, blank=True, default="")
+
+    window_start = models.DateTimeField(blank=True, null=True)
+    window_end = models.DateTimeField(blank=True, null=True)
+
+    # Attested, not measured. Nothing here can observe a network being changed.
+    applied_at = models.DateTimeField(blank=True, null=True)
+    applied_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        blank=True,
+        null=True,
+        related_name="+",
+    )
+    applied_ref = models.CharField(max_length=200, blank=True, default="")
+
+    # Advisory columns, quarantined from the verify gate by construction: the
+    # gate reads ForwardChangeEvidence and nothing else. Making the verdict
+    # depend on a prediction would mean moving a column into that table, which
+    # is a visible, migration-shaped act rather than a quiet drift. They ship
+    # now, while predict is stubbed, so its arrival needs no schema change.
+    predict_status = models.CharField(max_length=32, blank=True, default="")
+    predict_reason = models.TextField(blank=True, default="")
+    predict_pre_verdict = models.CharField(max_length=32, blank=True, default="")
+    netbox_impact = models.JSONField(blank=True, default=dict)
+
+    class Meta:
+        ordering = ("-created",)
+        verbose_name = _("Forward Change")
+        verbose_name_plural = _("Forward Changes")
+        db_table = "forward_netbox_change"
+        # Approving is a distinct right from editing, following the
+        # `run_forwardsync` precedent. Anyone who can change a record should
+        # not thereby be able to sign it off.
+        permissions = (("approve_forwardchange", "Can approve Forward change"),)
+
+    def __str__(self):
+        return self.ref and f"{self.ref} {self.title}" or self.title
+
+    def get_absolute_url(self):
+        return reverse("plugins:forward_netbox:forwardchange", args=[self.pk])
+
+    def get_state_color(self):
+        return ForwardChangeStateChoices.colors.get(self.state)
+
+    def get_verdict_color(self):
+        return ForwardChangeVerdictChoices.colors.get(self.verdict)
+
+
+class ForwardChangeDevice(models.Model):
+    """One device in a change's scope.
+
+    `forward_device_key` is copied at scope time rather than resolved on
+    demand: a device removed from NetBox later must still leave a readable
+    record of what the change covered.
+    """
+
+    change = models.ForeignKey(
+        ForwardChange,
+        on_delete=models.CASCADE,
+        related_name="devices",
+    )
+    device = models.ForeignKey(
+        "dcim.Device",
+        on_delete=models.CASCADE,
+        related_name="+",
+    )
+    forward_device_key = models.CharField(max_length=255, blank=True, default="")
+
+    class Meta:
+        ordering = ("device__name",)
+        verbose_name = _("Forward Change Device")
+        verbose_name_plural = _("Forward Change Devices")
+        db_table = "forward_netbox_change_device"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["change", "device"],
+                name="forward_change_device_unique",
+            )
+        ]
+
+    def __str__(self):
+        return f"{self.change}: {self.device}"
+
+
+class ForwardChangeCriterion(ForwardPluginModelDocsMixin, ChangeLoggedModel):
+    """One assertion, bound to a committed query version.
+
+    The query-identity triple is why binding is a gate: an unbound criterion
+    would be evaluated against whatever the query says at the time, so an
+    assertion could change under the change it is judging.
+    """
+
+    change = models.ForeignKey(
+        ForwardChange,
+        on_delete=models.CASCADE,
+        related_name="criteria",
+    )
+    name = models.CharField(max_length=200)
+    family = models.CharField(
+        max_length=32,
+        choices=ForwardCriterionFamilyChoices,
+        default=ForwardCriterionFamilyChoices.ACCEPTANCE,
+    )
+    expectation = models.CharField(
+        max_length=32,
+        choices=ForwardCriterionExpectationChoices,
+        default=ForwardCriterionExpectationChoices.NO_ROWS,
+    )
+    blocking = models.BooleanField(default=True)
+
+    query_path = models.CharField(max_length=500, blank=True, default="")
+    query_id = models.CharField(max_length=100, blank=True, default="")
+    commit_id = models.CharField(max_length=100, blank=True, default="")
+    source_sha256 = models.CharField(max_length=64, blank=True, default="")
+
+    class Meta:
+        ordering = ("change", "name")
+        verbose_name = _("Forward Change Criterion")
+        verbose_name_plural = _("Forward Change Criteria")
+        db_table = "forward_netbox_change_criterion"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["change", "name"],
+                name="forward_change_criterion_unique_name",
+            )
+        ]
+
+    def __str__(self):
+        return self.name
+
+    @property
+    def is_bound(self) -> bool:
+        return bool(self.query_id and self.commit_id)
+
+
+class ForwardChangeEvidence(models.Model):
+    """One criterion's result at one pinned snapshot.
+
+    This table IS the verify gate's input. Nothing advisory is recorded here -
+    that separation is what keeps a prediction from becoming a verdict.
+
+    `shape` holds schema identifiers only, never row values, following the same
+    rule as ingestion-issue diagnosis: evidence is support-bundle content.
+    """
+
+    criterion = models.ForeignKey(
+        ForwardChangeCriterion,
+        on_delete=models.CASCADE,
+        related_name="evidence",
+    )
+    phase = models.CharField(max_length=16, choices=ForwardEvidencePhaseChoices)
+    passed = models.BooleanField()
+    row_count = models.PositiveIntegerField(default=0)
+    snapshot_id = models.CharField(max_length=100)
+    commit_id = models.CharField(max_length=100, blank=True, default="")
+    executed_at = models.DateTimeField(default=timezone.now)
+    duration_ms = models.PositiveIntegerField(default=0)
+    shape = models.JSONField(blank=True, default=dict)
+
+    class Meta:
+        ordering = ("criterion", "phase")
+        verbose_name = _("Forward Change Evidence")
+        verbose_name_plural = _("Forward Change Evidence")
+        db_table = "forward_netbox_change_evidence"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["criterion", "phase", "snapshot_id"],
+                name="forward_change_evidence_unique",
+            )
+        ]
+
+    def __str__(self):
+        return f"{self.criterion} @ {self.phase}"
+
+
+class ForwardChangeReview(ForwardPluginModelDocsMixin, ChangeLoggedModel):
+    """One reviewer's decision, anchored to what they actually saw.
+
+    Staleness is anchored to the branch AND the baseline. A change can be
+    re-baselined without touching the branch, and a reviewer who approved
+    against the old snapshot approved different evidence.
+    """
+
+    change = models.ForeignKey(
+        ForwardChange,
+        on_delete=models.CASCADE,
+        related_name="reviews",
+    )
+    reviewer = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        blank=True,
+        null=True,
+        related_name="+",
+    )
+    phase = models.CharField(
+        max_length=16,
+        choices=ForwardReviewPhaseChoices,
+        default=ForwardReviewPhaseChoices.PRE,
+    )
+    approved = models.BooleanField(default=False)
+    comment = models.TextField(blank=True, default="")
+
+    # Pre-phase anchors: what the reviewer saw of the PLAN.
+    branch_change_time = models.DateTimeField(blank=True, null=True)
+    baseline_snapshot_id = models.CharField(max_length=100, blank=True, default="")
+
+    # Post-phase anchors: what the reviewer saw of the RESULT. Re-verifying
+    # against a newer snapshot, or the verdict changing, voids a closure
+    # sign-off - the reviewer approved specific evidence.
+    after_snapshot_id = models.CharField(max_length=100, blank=True, default="")
+    verdict = models.CharField(max_length=16, blank=True, default="")
+
+    class Meta:
+        ordering = ("-created",)
+        verbose_name = _("Forward Change Review")
+        verbose_name_plural = _("Forward Change Reviews")
+        db_table = "forward_netbox_change_review"
+        constraints = [
+            # One reviewer, one decision per gate. Without this, N approvals
+            # from the same person satisfy an N-approval policy alone, which
+            # makes the count meaningless.
+            models.UniqueConstraint(
+                fields=["change", "reviewer", "phase"],
+                name="forward_change_review_one_per_reviewer_phase",
+            )
+        ]
+
+    def __str__(self):
+        verdict = "approved" if self.approved else "rejected"
+        return f"{self.change} {verdict} by {self.reviewer}"
+
+
+class ForwardChangePolicy(ForwardPluginModelDocsMixin, PrimaryModel):
+    """Who must approve, scoped by the properties a NETWORK change has.
+
+    Scoped by device role, site or tag rather than by NetBox object type: an
+    operator reasons about "changes touching core routers at this site", not
+    about which model rows a branch happens to contain.
+    """
+
+    name = models.CharField(max_length=100, unique=True)
+    enabled = models.BooleanField(default=True)
+    # Split per gate. A team that wants two sign-offs on the plan and one on
+    # the closure cannot say so with a single number, and that is the common
+    # real shape.
+    min_pre_approvals = models.PositiveSmallIntegerField(default=1)
+    # 0 lets a PROCEED verdict close on its own. That is the escape hatch for
+    # low-risk automation and is deliberately not the default: CLOSE is where
+    # the branch merges.
+    min_post_approvals = models.PositiveSmallIntegerField(default=1)
+
+    class Meta:
+        ordering = ("name",)
+        verbose_name = _("Forward Change Policy")
+        verbose_name_plural = _("Forward Change Policies")
+        db_table = "forward_netbox_change_policy"
+
+    def __str__(self):
+        return self.name
+
+    def get_absolute_url(self):
+        return reverse("plugins:forward_netbox:forwardchangepolicy", args=[self.pk])
+
+
+class ForwardChangePolicyRule(ChangeLoggedModel):
+    """One scoping rule on a policy."""
+
+    policy = models.ForeignKey(
+        ForwardChangePolicy,
+        on_delete=models.CASCADE,
+        related_name="rules",
+    )
+    device_role = models.ForeignKey(
+        "dcim.DeviceRole",
+        on_delete=models.CASCADE,
+        blank=True,
+        null=True,
+        related_name="+",
+    )
+    site = models.ForeignKey(
+        "dcim.Site",
+        on_delete=models.CASCADE,
+        blank=True,
+        null=True,
+        related_name="+",
+    )
+    tag_slug = models.CharField(max_length=100, blank=True, default="")
+
+    class Meta:
+        ordering = ("policy", "pk")
+        verbose_name = _("Forward Change Policy Rule")
+        verbose_name_plural = _("Forward Change Policy Rules")
+        db_table = "forward_netbox_change_policy_rule"
+
+    def __str__(self):
+        parts = [
+            str(x) for x in (self.device_role, self.site, self.tag_slug or None) if x
+        ]
+        return f"{self.policy}: {' / '.join(parts) or 'any'}"

--- a/forward_netbox/navigation.py
+++ b/forward_netbox/navigation.py
@@ -78,12 +78,41 @@ device_analysis = PluginMenuItem(
     permissions=["forward_netbox.view_forwarddeviceanalysis"],
 )
 
+change = PluginMenuItem(
+    link="plugins:forward_netbox:forwardchange_list",
+    link_text=_("Changes"),
+    buttons=[
+        PluginMenuButton(
+            link="plugins:forward_netbox:forwardchange_add",
+            title=_("Add"),
+            icon_class="mdi mdi-plus-thick",
+            permissions=["forward_netbox.add_forwardchange"],
+        )
+    ],
+    permissions=["forward_netbox.view_forwardchange"],
+)
+
+change_policy = PluginMenuItem(
+    link="plugins:forward_netbox:forwardchangepolicy_list",
+    link_text=_("Change Policies"),
+    buttons=[
+        PluginMenuButton(
+            link="plugins:forward_netbox:forwardchangepolicy_add",
+            title=_("Add"),
+            icon_class="mdi mdi-plus-thick",
+            permissions=["forward_netbox.add_forwardchangepolicy"],
+        )
+    ],
+    permissions=["forward_netbox.view_forwardchangepolicy"],
+)
+
 menu = PluginMenu(
     label="Forward",
     icon_class="mdi mdi-cloud-sync",
     groups=(
         ("Data Sync", (source, sync, ingestion, validation_run)),
+        ("Change Control", (change,)),
         ("Analysis", (device_analysis,)),
-        ("Configuration", (nqe_map, drift_policy)),
+        ("Configuration", (nqe_map, drift_policy, change_policy)),
     ),
 )

--- a/forward_netbox/tables.py
+++ b/forward_netbox/tables.py
@@ -8,6 +8,9 @@ from netbox.tables import columns
 from netbox.tables import NetBoxTable
 from netbox_branching.models import ChangeDiff
 
+from .models import ForwardChange
+from .models import ForwardChangeCriterion
+from .models import ForwardChangePolicy
 from .models import ForwardDeviceAnalysis
 from .models import ForwardDriftPolicy
 from .models import ForwardIngestion
@@ -358,4 +361,82 @@ class ForwardIngestionIssueTable(NetBoxTable):
             "coalesce_fields",
             "defaults",
             "message",
+        )
+
+
+class ForwardChangeTable(NetBoxTable):
+    title = tables.Column(linkify=True)
+    source = tables.Column(linkify=True)
+    state = columns.ChoiceFieldColumn()
+    verdict = columns.ChoiceFieldColumn()
+
+    class Meta(NetBoxTable.Meta):
+        model = ForwardChange
+        fields = (
+            "pk",
+            "ref",
+            "title",
+            "source",
+            "state",
+            "verdict",
+            "branch_name",
+            "before_snapshot_id",
+            "after_snapshot_id",
+            "applied_at",
+            "created",
+        )
+        default_columns = (
+            "pk",
+            "ref",
+            "title",
+            "source",
+            "state",
+            "verdict",
+            "applied_at",
+        )
+
+
+class ForwardChangeCriterionTable(NetBoxTable):
+    name = tables.Column(linkify=False)
+    change = tables.Column(linkify=True)
+    family = columns.ChoiceFieldColumn()
+    expectation = columns.ChoiceFieldColumn()
+    blocking = columns.BooleanColumn()
+    actions = columns.ActionsColumn(actions=())
+
+    class Meta(NetBoxTable.Meta):
+        model = ForwardChangeCriterion
+        fields = (
+            "pk",
+            "name",
+            "change",
+            "family",
+            "expectation",
+            "blocking",
+            "query_path",
+            "query_id",
+            "commit_id",
+        )
+        default_columns = (
+            "name",
+            "change",
+            "family",
+            "expectation",
+            "blocking",
+            "commit_id",
+        )
+
+
+class ForwardChangePolicyTable(NetBoxTable):
+    name = tables.Column(linkify=True)
+
+    class Meta(NetBoxTable.Meta):
+        model = ForwardChangePolicy
+        fields = ("pk", "name", "enabled", "min_pre_approvals", "min_post_approvals")
+        default_columns = (
+            "pk",
+            "name",
+            "enabled",
+            "min_pre_approvals",
+            "min_post_approvals",
         )

--- a/forward_netbox/templates/forward_netbox/forwardchange.html
+++ b/forward_netbox/templates/forward_netbox/forwardchange.html
@@ -1,0 +1,245 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+{% load i18n %}
+
+{% block content %}
+<div class="row mb-3">
+  <div class="col col-md-6">
+    <div class="card">
+      <h5 class="card-header">{% trans "Change" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Reference" %}</th>
+            <td>{{ object.ref|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Source" %}</th>
+            <td>{{ object.source|linkify }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "State" %}</th>
+            <td>{% badge object.get_state_display bg_color=object.get_state_color %}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Verdict" %}</th>
+            <td>
+              {% if object.verdict %}
+                {% badge object.get_verdict_display bg_color=object.get_verdict_color %}
+              {% else %}
+                <span class="text-muted">{% trans "Not yet verified" %}</span>
+              {% endif %}
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Requester" %}</th>
+            <td>{{ object.requester|placeholder }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+
+    <div class="card">
+      <h5 class="card-header">{% trans "Snapshots" %}</h5>
+      <div class="card-body">
+        {# Pinned as literal ids, never selectors: verifying against a #}
+        {# re-resolved snapshot would judge the change against a different #}
+        {# network than the one it was approved against. #}
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Baseline (before)" %}</th>
+            <td><code>{{ object.before_snapshot_id|placeholder }}</code></td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Post-change (after)" %}</th>
+            <td><code>{{ object.after_snapshot_id|placeholder }}</code></td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Branch" %}</th>
+            <td>{{ object.branch_name|placeholder }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+
+    <div class="card">
+      <h5 class="card-header">{% trans "Applied" %}</h5>
+      <div class="card-body">
+        <p class="text-muted small">
+          {% trans "Attested, not measured. Nothing here can observe the network being changed, so this is a human claim about when it happened." %}
+        </p>
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "When" %}</th>
+            <td>{{ object.applied_at|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Attested by" %}</th>
+            <td>{{ object.applied_by|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Reference" %}</th>
+            <td>{{ object.applied_ref|placeholder }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <div class="col col-md-6">
+    <div class="card">
+      <h5 class="card-header">{% trans "Evidence" %}</h5>
+      <div class="card-body">
+        <p class="text-muted small">
+          {% trans "This is what the verdict is computed from, and the only thing it is computed from." %}
+        </p>
+        {% if criterion_outcomes %}
+          <table class="table table-hover">
+            <thead>
+              <tr>
+                <th>{% trans "Criterion" %}</th>
+                <th>{% trans "Before" %}</th>
+                <th>{% trans "After" %}</th>
+                <th>{% trans "Result" %}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for outcome in criterion_outcomes %}
+                <tr>
+                  <td>
+                    {{ outcome.criterion.name }}
+                    {% if not outcome.blocking %}
+                      <span class="badge text-bg-gray">{% trans "advisory" %}</span>
+                    {% endif %}
+                  </td>
+                  <td>{% checkmark outcome.before_passed %}</td>
+                  <td>{% checkmark outcome.after_passed %}</td>
+                  <td>
+                    {% if outcome.flip %}
+                      {% if outcome.blocks %}
+                        <span class="badge text-bg-red">{% trans "regression" %}</span>
+                      {% else %}
+                        <span class="badge text-bg-green">{{ outcome.flip }}</span>
+                      {% endif %}
+                    {% else %}
+                      {# Never rendered as a pass. A criterion nobody #}
+                      {# evaluated is not a criterion that passed. #}
+                      <span class="badge text-bg-orange">{% trans "not measured" %}</span>
+                    {% endif %}
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        {% else %}
+          <p class="text-muted mb-0">
+            {% trans "No criteria have been evaluated. A change with nothing asserted cannot be verified, only asserted to have happened." %}
+          </p>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="card">
+      <h5 class="card-header">{{ predict_panel.heading }}</h5>
+      <div class="card-body">
+        {# Advisory, and separated from Evidence above on purpose. An #}
+        {# advisory panel that looks like evidence is how a prediction #}
+        {# quietly becomes a decision. #}
+        <p class="text-muted small">
+          {% trans "Advisory only. The verdict does not depend on this." %}
+        </p>
+        <p class="mb-0">{{ predict_panel.message }}</p>
+      </div>
+    </div>
+
+    <div class="card">
+      <h5 class="card-header">{% trans "Scope" %}</h5>
+      <div class="card-body">
+        {% if scoped_devices %}
+          <ul class="list-unstyled mb-0">
+            {% for scoped in scoped_devices %}
+              <li>
+                {{ scoped.device|linkify }}
+                {% if not scoped.forward_device_key %}
+                  <span class="badge text-bg-orange">{% trans "no Forward identity" %}</span>
+                {% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p class="text-muted mb-0">{% trans "No devices in scope." %}</p>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="card">
+      <h5 class="card-header">{% trans "Reviews" %}</h5>
+      <div class="card-body">
+        {# Two gates. The pre gate approves the PLAN; the post gate approves #}
+        {# the CLOSURE, which is where the branch actually merges. A PROCEED #}
+        {# verdict opens that gate rather than walking through it. #}
+        {% if reviews %}
+          <table class="table table-hover">
+            {% for review in reviews %}
+              <tr>
+                <td>{{ review.reviewer|placeholder }}</td>
+                <td><span class="badge text-bg-gray">{{ review.phase }}</span></td>
+                <td>
+                  {% if review.approved %}
+                    <span class="badge text-bg-green">{% trans "approved" %}</span>
+                  {% else %}
+                    <span class="badge text-bg-red">{% trans "rejected" %}</span>
+                  {% endif %}
+                </td>
+                <td class="text-muted small">{{ review.comment }}</td>
+              </tr>
+            {% endfor %}
+          </table>
+        {% else %}
+          <p class="text-muted">{% trans "No reviews yet." %}</p>
+        {% endif %}
+
+        {% if perms.forward_netbox.approve_forwardchange %}
+          <form method="post" action="{% url 'plugins:forward_netbox:forwardchange_review' pk=object.pk %}">
+            {% csrf_token %}
+            <input type="text" name="comment" class="form-control mb-2"
+                   placeholder="{% trans 'Comment (optional)' %}">
+            <button type="submit" name="decision" value="approve"
+                    class="btn btn-green">{% trans "Approve" %}</button>
+            <button type="submit" name="decision" value="reject"
+                    class="btn btn-red">{% trans "Reject" %}</button>
+          </form>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="card">
+      <h5 class="card-header">{% trans "Next steps" %}</h5>
+      <div class="card-body">
+        {% if transitions %}
+          <table class="table table-hover">
+            {% for transition in transitions %}
+              <tr>
+                <th scope="row">{{ transition.target }}</th>
+                <td>
+                  {% if transition.allowed %}
+                    <span class="badge text-bg-green">{% trans "ready" %}</span>
+                  {% else %}
+                    <ul class="list-unstyled mb-0 small text-muted">
+                      {% for blocker in transition.blockers %}
+                        <li>{{ blocker }}</li>
+                      {% endfor %}
+                    </ul>
+                  {% endif %}
+                </td>
+              </tr>
+            {% endfor %}
+          </table>
+        {% else %}
+          <p class="text-muted mb-0">{% trans "This change is finished; there is nowhere further to go." %}</p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/forward_netbox/templates/forward_netbox/forwardchangepolicy.html
+++ b/forward_netbox/templates/forward_netbox/forwardchangepolicy.html
@@ -1,0 +1,55 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+{% load i18n %}
+
+{% block content %}
+<div class="row mb-3">
+  <div class="col col-md-6">
+    <div class="card">
+      <h5 class="card-header">{% trans "Policy" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Enabled" %}</th>
+            <td>{{ object.enabled|yesno:"Yes,No" }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Approvals before apply" %}</th>
+            <td>{{ object.min_pre_approvals }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Approvals before close" %}</th>
+            <td>
+              {{ object.min_post_approvals }}
+              {% if not object.min_post_approvals %}
+                <span class="text-muted small">
+                  {% trans "a PROCEED verdict closes on its own" %}
+                </span>
+              {% endif %}
+            </td>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div class="col col-md-6">
+    <div class="card">
+      <h5 class="card-header">{% trans "Scope rules" %}</h5>
+      <div class="card-body">
+        {# Scoped by the properties a NETWORK change has - role, site, tag - #}
+        {# rather than by NetBox object type, because that is how an operator #}
+        {# reasons about which changes need which approvers. #}
+        {% if rules %}
+          <ul class="list-unstyled mb-0">
+            {% for rule in rules %}<li>{{ rule }}</li>{% endfor %}
+          </ul>
+        {% else %}
+          <p class="text-muted mb-0">
+            {% trans "No rules: this policy applies to every change." %}
+          </p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/forward_netbox/tests/test_change_control_evidence.py
+++ b/forward_netbox/tests/test_change_control_evidence.py
@@ -1,0 +1,136 @@
+# The regression-flip comparison, which is why evidence is recorded at a
+# baseline as well as after the change.
+#
+# Without a before phase, a criterion that was ALREADY failing is counted as
+# damage this change caused, and the gate holds a change that broke nothing.
+from django.test import SimpleTestCase
+
+from forward_netbox.change_control.evidence import BLOCKING_FLIPS
+from forward_netbox.change_control.evidence import classify_flip
+from forward_netbox.change_control.evidence import FIX
+from forward_netbox.change_control.evidence import PRE_EXISTING
+from forward_netbox.change_control.evidence import PRESERVED
+from forward_netbox.change_control.evidence import REGRESSION
+
+
+class TheFourFlipsTest(SimpleTestCase):
+    def test_pass_then_fail_is_a_regression(self):
+        self.assertEqual(classify_flip(True, False), REGRESSION)
+
+    def test_fail_then_pass_is_a_fix(self):
+        self.assertEqual(classify_flip(False, True), FIX)
+
+    def test_fail_then_fail_is_pre_existing(self):
+        # The case the baseline exists for. This must NOT block: the change
+        # neither caused it nor was asked to fix it.
+        self.assertEqual(classify_flip(False, False), PRE_EXISTING)
+
+    def test_pass_then_pass_is_preserved(self):
+        self.assertEqual(classify_flip(True, True), PRESERVED)
+
+
+class OnlyARegressionBlocksTest(SimpleTestCase):
+    def test_exactly_one_flip_blocks(self):
+        self.assertEqual(BLOCKING_FLIPS, frozenset({REGRESSION}))
+
+    def test_pre_existing_failure_does_not_block(self):
+        self.assertNotIn(PRE_EXISTING, BLOCKING_FLIPS)
+
+    def test_a_fix_does_not_block(self):
+        self.assertNotIn(FIX, BLOCKING_FLIPS)
+
+    def test_preserved_state_does_not_block(self):
+        self.assertNotIn(PRESERVED, BLOCKING_FLIPS)
+
+
+class NotMeasuredIsNotAPassTest(SimpleTestCase):
+    """A missing phase must stay a third answer all the way to the verdict.
+
+    Coercing it to a pass is precisely how an empty comparison once read as a
+    successful one, which cost a release to find and another to explain.
+    """
+
+    def test_a_missing_before_phase_has_no_flip(self):
+        self.assertEqual(classify_flip(None, True), "")
+
+    def test_a_missing_after_phase_has_no_flip(self):
+        self.assertEqual(classify_flip(True, None), "")
+
+    def test_both_missing_has_no_flip(self):
+        self.assertEqual(classify_flip(None, None), "")
+
+
+class TheTwoFamiliesBlockDifferentlyTest(SimpleTestCase):
+    """Acceptance and state preservation ask different questions.
+
+    Acceptance asserts the change ACHIEVED ITS INTENT, so what matters is the
+    after state on its own: a criterion still failing means the change did not
+    work, and letting that through because it was already failing would verify
+    a change that accomplished nothing.
+
+    State preservation asserts nothing ELSE moved, so a pre-existing failure is
+    genuinely not this change's business.
+    """
+
+    # NOT `_outcome`: unittest.TestCase sets an internal `_outcome`
+    # attribute during run(), which shadows a method of that name and
+    # fails with "'_Outcome' object is not callable".
+    def _make_outcome(self, family, flip):
+        from types import SimpleNamespace
+
+        from forward_netbox.change_control.evidence import CriterionOutcome
+
+        return CriterionOutcome(
+            criterion=SimpleNamespace(name="c", family=family),
+            before_passed=None,
+            after_passed=None,
+            flip=flip,
+            blocking=True,
+        )
+
+    def test_a_failing_acceptance_criterion_blocks_even_if_pre_existing(self):
+        from forward_netbox.change_control.choices import (
+            ForwardCriterionFamilyChoices,
+        )
+
+        outcome = self._make_outcome(
+            ForwardCriterionFamilyChoices.ACCEPTANCE, PRE_EXISTING
+        )
+
+        self.assertTrue(outcome.blocks)
+        self.assertIn("did not achieve", outcome.block_reason)
+
+    def test_a_pre_existing_state_preservation_failure_does_not_block(self):
+        from forward_netbox.change_control.choices import (
+            ForwardCriterionFamilyChoices,
+        )
+
+        outcome = self._make_outcome(
+            ForwardCriterionFamilyChoices.STATE_PRESERVATION, PRE_EXISTING
+        )
+
+        self.assertFalse(outcome.blocks)
+
+    def test_a_regression_blocks_in_both_families(self):
+        from forward_netbox.change_control.choices import (
+            ForwardCriterionFamilyChoices,
+        )
+
+        for family in (
+            ForwardCriterionFamilyChoices.ACCEPTANCE,
+            ForwardCriterionFamilyChoices.STATE_PRESERVATION,
+        ):
+            with self.subTest(family=family):
+                self.assertTrue(self._make_outcome(family, REGRESSION).blocks)
+
+    def test_a_fix_never_blocks(self):
+        from forward_netbox.change_control.choices import (
+            ForwardCriterionFamilyChoices,
+        )
+
+        for family in (
+            ForwardCriterionFamilyChoices.ACCEPTANCE,
+            ForwardCriterionFamilyChoices.STATE_PRESERVATION,
+        ):
+            with self.subTest(family=family):
+                self.assertFalse(self._make_outcome(family, FIX).blocks)

--- a/forward_netbox/tests/test_change_control_gates.py
+++ b/forward_netbox/tests/test_change_control_gates.py
@@ -1,0 +1,172 @@
+# The verify gate's ordering, and the absence problem it exists to catch.
+#
+# A device that failed collection is ABSENT from the Forward model rather than
+# flagged in it, so "no violations found" and "the broken device was not in the
+# snapshot" look identical from the rows alone. That is the same shape as a
+# customer's 552 uncovered devices, and it is why completeness is step one
+# rather than a footnote on the report.
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase
+
+from forward_netbox.change_control.choices import ForwardChangeVerdictChoices
+from forward_netbox.change_control.gates import collection_postdates_apply
+from forward_netbox.change_control.gates import device_set_complete
+from forward_netbox.change_control.gates import verify
+
+APPLIED = datetime(2026, 9, 2, 12, 0, tzinfo=timezone.utc)
+
+
+def _change(*, keys=("dev-a", "dev-b"), applied_at=APPLIED):
+    devices = [
+        SimpleNamespace(forward_device_key=k, device=f"device-{k}") for k in keys
+    ]
+    return SimpleNamespace(
+        applied_at=applied_at,
+        devices=SimpleNamespace(all=lambda: devices),
+        criteria=SimpleNamespace(all=lambda: []),
+    )
+
+
+class AnAbsentDeviceRefusesTheVerdictTest(SimpleTestCase):
+    def test_a_complete_device_set_passes(self):
+        result = device_set_complete(_change(), ["dev-a", "dev-b"])
+
+        self.assertTrue(result)
+
+    def test_a_missing_device_refuses_rather_than_warns(self):
+        result = device_set_complete(_change(), ["dev-a"])
+
+        self.assertFalse(result)
+        self.assertIn("absent from this snapshot", result.reasons[0])
+
+    def test_the_reason_explains_why_absence_is_not_a_pass(self):
+        # The sentence matters: an operator who reads "1 device missing" may
+        # accept it, and one who reads why absence is indistinguishable from
+        # health will not.
+        result = device_set_complete(_change(), [])
+
+        self.assertIn("failed collection", result.reasons[0])
+        self.assertIn("rather than marked failed", result.reasons[0])
+
+
+class CollectionMustPostdateTheApplyTest(SimpleTestCase):
+    def test_collection_after_the_apply_passes(self):
+        times = {
+            "dev-a": APPLIED + timedelta(minutes=5),
+            "dev-b": APPLIED + timedelta(minutes=6),
+        }
+
+        self.assertTrue(collection_postdates_apply(_change(), times))
+
+    def test_collection_before_the_apply_holds(self):
+        times = {
+            "dev-a": APPLIED - timedelta(minutes=1),
+            "dev-b": APPLIED + timedelta(minutes=5),
+        }
+        result = collection_postdates_apply(_change(), times)
+
+        self.assertFalse(result)
+        self.assertIn("collected before the change was applied", result.reasons[0])
+
+    def test_an_unknown_collection_time_is_held_not_assumed(self):
+        # The weakest joint in the workflow. Assuming the snapshot is new
+        # enough is how a verdict gets computed against the wrong network.
+        result = collection_postdates_apply(
+            _change(), {"dev-a": APPLIED + timedelta(minutes=5)}
+        )
+
+        self.assertFalse(result)
+        self.assertIn("Unknown is held, not assumed", result.reasons[-1])
+
+    def test_no_attested_apply_time_holds(self):
+        result = collection_postdates_apply(_change(applied_at=None), {})
+
+        self.assertFalse(result)
+
+
+class TheGateRunsInOrderTest(SimpleTestCase):
+    def test_an_incomplete_device_set_short_circuits_the_criteria(self):
+        # The criteria are not evaluated at all, so no evidence row is written
+        # that would later read as a real measurement of this snapshot.
+        verdict, reasons = verify(
+            _change(),
+            observed_device_keys=["dev-a"],
+            device_collection_times={"dev-a": APPLIED + timedelta(minutes=5)},
+        )
+
+        self.assertEqual(verdict, ForwardChangeVerdictChoices.HOLD)
+        self.assertTrue(any("absent from this snapshot" in r for r in reasons))
+
+    def test_a_complete_and_timely_snapshot_reaches_the_criteria(self):
+        # With no criteria defined, the verdict falls through to the criteria
+        # stage and holds for a different, honest reason.
+        verdict, reasons = verify(
+            _change(),
+            observed_device_keys=["dev-a", "dev-b"],
+            device_collection_times={
+                "dev-a": APPLIED + timedelta(minutes=5),
+                "dev-b": APPLIED + timedelta(minutes=5),
+            },
+        )
+
+        self.assertEqual(verdict, ForwardChangeVerdictChoices.HOLD)
+        self.assertTrue(any("nothing to verify against" in r for r in reasons))
+
+
+class APrematureAttestationIsCaughtTest(SimpleTestCase):
+    """APPLIED cannot be proved from here, but its usual failure is detectable.
+
+    If every criterion reports the same result before and after, Forward
+    observed no change. That is not proof the change never landed - a change
+    can legitimately leave every criterion where it was - so it holds with a
+    question rather than an accusation.
+    """
+
+    # NOT `_outcome`: unittest.TestCase sets an internal `_outcome`
+    # attribute during run(), which shadows a method of that name and
+    # fails with "'_Outcome' object is not callable".
+    def _make_outcome(self, flip):
+        return SimpleNamespace(flip=flip)
+
+    def test_no_movement_at_all_holds(self):
+        from forward_netbox.change_control.evidence import PRESERVED
+        from forward_netbox.change_control.gates import attestation_looks_premature
+
+        result = attestation_looks_premature(
+            _change(), [self._make_outcome(PRESERVED), self._make_outcome(PRESERVED)]
+        )
+
+        self.assertFalse(result)
+        self.assertIn("observed no change to the network", result.reasons[0])
+
+    def test_the_reason_offers_the_innocent_explanation_too(self):
+        from forward_netbox.change_control.evidence import PRESERVED
+        from forward_netbox.change_control.gates import attestation_looks_premature
+
+        result = attestation_looks_premature(_change(), [self._make_outcome(PRESERVED)])
+
+        self.assertIn("changed nothing the criteria ask about", result.reasons[0])
+
+    def test_any_movement_satisfies_it(self):
+        from forward_netbox.change_control.evidence import FIX
+        from forward_netbox.change_control.evidence import PRESERVED
+        from forward_netbox.change_control.gates import attestation_looks_premature
+
+        result = attestation_looks_premature(
+            _change(), [self._make_outcome(PRESERVED), self._make_outcome(FIX)]
+        )
+
+        self.assertTrue(result)
+
+    def test_nothing_measured_is_not_treated_as_no_movement(self):
+        # An unmeasured criterion says nothing about whether the network moved,
+        # and must not be turned into evidence that it did not.
+        from forward_netbox.change_control.gates import attestation_looks_premature
+
+        self.assertTrue(
+            attestation_looks_premature(_change(), [self._make_outcome("")])
+        )

--- a/forward_netbox/tests/test_change_control_policy.py
+++ b/forward_netbox/tests/test_change_control_policy.py
@@ -1,0 +1,133 @@
+# How many approvals a gate needs, and who counts.
+#
+# Before this module, ForwardChangePolicy was inert: nothing read
+# min_approvals, nothing evaluated a rule, and any single approving row opened
+# the gate. An approval policy nobody enforces is worse than none, because the
+# page implies a control that is not there.
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase
+from django.test import TestCase
+
+from forward_netbox.change_control.choices import ForwardReviewPhaseChoices
+from forward_netbox.change_control.policy import DEFAULT_REQUIRED_APPROVALS
+from forward_netbox.change_control.policy import distinct_approvers
+from forward_netbox.change_control.policy import required_approvals
+from forward_netbox.change_control.policy import stale_approvals
+
+
+class AnUnmatchedChangeIsNotEasierToMergeTest(TestCase):
+    def test_no_policy_still_requires_an_approval(self):
+        # The failure mode this guards: adding a policy to cover one estate
+        # quietly leaving everything else ungoverned.
+        change = SimpleNamespace(
+            devices=SimpleNamespace(select_related=lambda *a: []),
+        )
+
+        self.assertEqual(
+            required_approvals(change, ForwardReviewPhaseChoices.PRE),
+            DEFAULT_REQUIRED_APPROVALS,
+        )
+        self.assertEqual(
+            required_approvals(change, ForwardReviewPhaseChoices.POST),
+            DEFAULT_REQUIRED_APPROVALS,
+        )
+
+
+class SelfApprovalIsNotApprovalTest(SimpleTestCase):
+    def _change(self, reviews, requester_id=7):
+        return SimpleNamespace(
+            requester_id=requester_id,
+            reviews=SimpleNamespace(filter=lambda **kw: reviews),
+        )
+
+    def test_the_requester_does_not_count(self):
+        reviews = [SimpleNamespace(reviewer_id=7)]
+
+        self.assertEqual(
+            distinct_approvers(self._change(reviews), ForwardReviewPhaseChoices.PRE),
+            set(),
+        )
+
+    def test_one_reviewer_counts_once(self):
+        # The uniqueness constraint stops this at write time; counting
+        # distinctly means a bypass of that constraint still cannot inflate.
+        reviews = [SimpleNamespace(reviewer_id=3), SimpleNamespace(reviewer_id=3)]
+
+        self.assertEqual(
+            distinct_approvers(self._change(reviews), ForwardReviewPhaseChoices.PRE),
+            {3},
+        )
+
+    def test_a_review_with_no_reviewer_does_not_count(self):
+        reviews = [SimpleNamespace(reviewer_id=None)]
+
+        self.assertEqual(
+            distinct_approvers(self._change(reviews), ForwardReviewPhaseChoices.PRE),
+            set(),
+        )
+
+
+class TheTwoGatesAnchorToDifferentEvidenceTest(SimpleTestCase):
+    def _change(self, reviews, **kw):
+        base = dict(
+            branch_last_change_time="t1",
+            before_snapshot_id="snap-before",
+            after_snapshot_id="snap-after",
+            verdict="proceed",
+        )
+        base.update(kw)
+        return SimpleNamespace(
+            reviews=SimpleNamespace(filter=lambda **f: reviews), **base
+        )
+
+    def test_a_pre_approval_is_voided_by_a_new_baseline(self):
+        review = SimpleNamespace(
+            branch_change_time="t1",
+            baseline_snapshot_id="snap-old",
+            after_snapshot_id="",
+            verdict="",
+        )
+        change = self._change([review])
+
+        self.assertEqual(len(stale_approvals(change, ForwardReviewPhaseChoices.PRE)), 1)
+
+    def test_a_post_approval_is_voided_by_re_verification(self):
+        # The reviewer signed off on specific evidence; a newer snapshot is
+        # different evidence.
+        review = SimpleNamespace(
+            branch_change_time="t1",
+            baseline_snapshot_id="snap-before",
+            after_snapshot_id="snap-older",
+            verdict="proceed",
+        )
+        change = self._change([review])
+
+        self.assertEqual(
+            len(stale_approvals(change, ForwardReviewPhaseChoices.POST)), 1
+        )
+
+    def test_a_post_approval_is_voided_by_the_verdict_changing(self):
+        review = SimpleNamespace(
+            branch_change_time="t1",
+            baseline_snapshot_id="snap-before",
+            after_snapshot_id="snap-after",
+            verdict="hold",
+        )
+        change = self._change([review])
+
+        self.assertEqual(
+            len(stale_approvals(change, ForwardReviewPhaseChoices.POST)), 1
+        )
+
+    def test_matching_anchors_are_not_stale(self):
+        review = SimpleNamespace(
+            branch_change_time="t1",
+            baseline_snapshot_id="snap-before",
+            after_snapshot_id="snap-after",
+            verdict="proceed",
+        )
+        change = self._change([review])
+
+        self.assertEqual(stale_approvals(change, ForwardReviewPhaseChoices.PRE), [])
+        self.assertEqual(stale_approvals(change, ForwardReviewPhaseChoices.POST), [])

--- a/forward_netbox/tests/test_change_control_predict.py
+++ b/forward_netbox/tests/test_change_control_predict.py
@@ -1,0 +1,121 @@
+# The predict stub's contract.
+#
+# Predict is not live, is licence-gated when it ships, and is limited today.
+# The workflow must be correct without it, so these pin the two things that
+# make its absence safe: it never raises, and "we could not ask" never renders
+# as "we asked and it was fine".
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase
+
+from forward_netbox.change_control.predict import predict_change
+from forward_netbox.change_control.predict import PredictOutcome
+from forward_netbox.change_control.predict import render_predict_panel
+
+
+class TheStubAnswersRatherThanRaisesTest(SimpleTestCase):
+    def test_predict_returns_unavailable_today(self):
+        outcome = predict_change(
+            source=SimpleNamespace(parameters={}),
+            snapshot_id="1",
+            devices=(),
+            criteria=(),
+        )
+
+        self.assertEqual(outcome.status, PredictOutcome.UNAVAILABLE)
+        self.assertFalse(outcome.is_answer)
+
+    def test_the_reason_says_the_verdict_does_not_depend_on_it(self):
+        # An operator reading this must not conclude the change cannot be
+        # verified. The verdict comes from the post-change snapshot, which is
+        # available on every licence tier.
+        outcome = predict_change(source=SimpleNamespace(parameters={}), snapshot_id="1")
+
+        self.assertIn("verified", outcome.reason)
+        self.assertIn("post-change snapshot", outcome.reason)
+
+
+class ANonAnswerNeverRendersAsSuccessTest(SimpleTestCase):
+    def test_unavailable_is_informational_not_an_error(self):
+        panel = render_predict_panel(
+            PredictOutcome(status=PredictOutcome.UNAVAILABLE, reason="not licensed")
+        )
+
+        self.assertEqual(panel["level"], "info")
+        self.assertIn("not available", panel["heading"])
+        self.assertEqual(panel["verdict"], "")
+
+    def test_unsupported_is_distinct_from_unavailable(self):
+        # "We could not ask" and "we asked and it could not say" mean different
+        # things to someone deciding whether to approve.
+        unavailable = render_predict_panel(
+            PredictOutcome(status=PredictOutcome.UNAVAILABLE)
+        )
+        unsupported = render_predict_panel(
+            PredictOutcome(status=PredictOutcome.UNSUPPORTED)
+        )
+
+        self.assertNotEqual(unavailable["heading"], unsupported["heading"])
+
+    def test_every_panel_is_marked_advisory(self):
+        for status in (
+            PredictOutcome.UNAVAILABLE,
+            PredictOutcome.UNSUPPORTED,
+            PredictOutcome.ANSWERED,
+        ):
+            with self.subTest(status=status):
+                panel = render_predict_panel(PredictOutcome(status=status))
+                self.assertTrue(panel["advisory"])
+
+
+class ThePredictFlagIsOffByDefaultTest(SimpleTestCase):
+    """Off unless a deployment opts in, and the three cases stay distinct.
+
+    "Not enabled here", "not licensed" and "not live yet" mean different things
+    to someone deciding whether to approve, and collapsing them into one greyed
+    panel is how a reader concludes the change was checked when it was not.
+    """
+
+    def test_a_source_with_no_parameters_is_off(self):
+        from forward_netbox.change_control.predict import predict_enabled
+
+        self.assertFalse(predict_enabled(SimpleNamespace(parameters={})))
+
+    def test_a_missing_key_is_off_rather_than_permission(self):
+        # No data migration: every existing source simply lacks the key.
+        from forward_netbox.change_control.predict import predict_enabled
+
+        self.assertFalse(
+            predict_enabled(SimpleNamespace(parameters={"something_else": True}))
+        )
+
+    def test_none_parameters_is_off(self):
+        from forward_netbox.change_control.predict import predict_enabled
+
+        self.assertFalse(predict_enabled(SimpleNamespace(parameters=None)))
+
+    def test_the_flag_turns_it_on(self):
+        from forward_netbox.change_control.predict import predict_enabled
+
+        self.assertTrue(
+            predict_enabled(SimpleNamespace(parameters={"enable_predict": True}))
+        )
+
+    def test_disabled_says_it_was_not_asked(self):
+        outcome = predict_change(source=SimpleNamespace(parameters={}), snapshot_id="1")
+
+        self.assertEqual(outcome.status, PredictOutcome.UNAVAILABLE)
+        self.assertIn("not enabled on this Forward source", outcome.reason)
+        self.assertIn("was not asked", outcome.reason)
+
+    def test_enabled_but_upstream_missing_says_so_differently(self):
+        # An operator who turned it ON deserves to know the answer is
+        # upstream, not a setting they missed.
+        outcome = predict_change(
+            source=SimpleNamespace(parameters={"enable_predict": True}),
+            snapshot_id="1",
+        )
+
+        self.assertEqual(outcome.status, PredictOutcome.UNAVAILABLE)
+        self.assertIn("enabled for this source", outcome.reason)
+        self.assertIn("licensed separately", outcome.reason)

--- a/forward_netbox/tests/test_change_control_state_machine.py
+++ b/forward_netbox/tests/test_change_control_state_machine.py
@@ -1,0 +1,89 @@
+# The change workflow's graph, and the two properties that are the whole point.
+#
+# A HOLD is a valid result, not an error, and it is never closed - it is fixed
+# and re-verified. Most home-grown change gates get that wrong by treating a
+# failed check as an exception, which pushes operators towards closing it to
+# clear the queue. Here the graph simply has no edge that expresses it.
+from django.test import SimpleTestCase
+
+from forward_netbox.change_control.choices import ForwardChangeStateChoices as State
+from forward_netbox.change_control.state_machine import available_transitions
+from forward_netbox.change_control.state_machine import legal_transition
+from forward_netbox.change_control.state_machine import TRANSITIONS
+
+
+class TheGraphRefusesToCloseAHoldTest(SimpleTestCase):
+    def test_a_hold_cannot_reach_closed(self):
+        self.assertNotIn(State.CLOSED, TRANSITIONS[State.VERIFIED_HOLD])
+
+    def test_a_hold_goes_back_for_a_fix_or_is_abandoned(self):
+        # Re-verifying means a fresh collection, so it returns to APPLIED
+        # rather than jumping straight to COLLECTED with the stale snapshot.
+        self.assertEqual(
+            TRANSITIONS[State.VERIFIED_HOLD],
+            frozenset({State.APPLIED, State.ABANDONED}),
+        )
+
+    def test_only_a_proceed_reaches_closed(self):
+        closers = [s for s, targets in TRANSITIONS.items() if State.CLOSED in targets]
+        self.assertEqual(closers, [State.VERIFIED_PROCEED])
+
+
+class PredictIsOptionalTest(SimpleTestCase):
+    def test_staged_reaches_approved_directly(self):
+        # Not a degradation: predict is not live, is licence-gated when it
+        # ships, and is limited today, so this is the DEFAULT path.
+        self.assertTrue(legal_transition(State.STAGED, State.APPROVED))
+
+    def test_staged_may_also_go_through_predicted(self):
+        self.assertTrue(legal_transition(State.STAGED, State.PREDICTED))
+        self.assertTrue(legal_transition(State.PREDICTED, State.APPROVED))
+
+    def test_predict_is_the_only_skippable_state(self):
+        # Every other state is on every path from DRAFT to CLOSED. If this ever
+        # fails, a mandatory gate has become bypassable.
+        mandatory = {
+            State.DRAFT,
+            State.SCOPED,
+            State.BASELINED,
+            State.STAGED,
+            State.APPROVED,
+            State.APPLIED,
+            State.COLLECTED,
+        }
+        for state in mandatory:
+            with self.subTest(state=state):
+                self.assertTrue(
+                    any(state in targets for targets in TRANSITIONS.values())
+                    or state == State.DRAFT
+                )
+
+
+class TerminalStatesTest(SimpleTestCase):
+    def test_closed_and_abandoned_lead_nowhere(self):
+        self.assertEqual(available_transitions(State.CLOSED), ())
+        self.assertEqual(available_transitions(State.ABANDONED), ())
+
+    def test_a_hold_is_not_terminal(self):
+        self.assertNotIn(State.VERIFIED_HOLD, State.TERMINAL)
+        self.assertIn(State.VERIFIED_HOLD, State.OPEN)
+
+    def test_every_open_state_can_be_abandoned(self):
+        for state in State.OPEN:
+            with self.subTest(state=state):
+                self.assertIn(State.ABANDONED, TRANSITIONS[state])
+
+
+class BaselineComesBeforeStagingTest(SimpleTestCase):
+    def test_staging_is_only_reachable_from_baselined(self):
+        # Deliberate ordering: a criterion must be measured against the network
+        # BEFORE anyone edits NetBox, or a criterion that was already failing
+        # gets counted as damage this change caused.
+        stagers = [s for s, targets in TRANSITIONS.items() if State.STAGED in targets]
+        self.assertEqual(
+            sorted(stagers),
+            sorted([State.BASELINED, State.PREDICTED, State.APPROVED]),
+        )
+
+    def test_the_forward_path_from_baselined_is_staged(self):
+        self.assertIn(State.STAGED, TRANSITIONS[State.BASELINED])

--- a/forward_netbox/tests/test_model_view_routes.py
+++ b/forward_netbox/tests/test_model_view_routes.py
@@ -51,6 +51,46 @@ class EveryModelWithADetailViewCanReverseItsListTest(TestCase):
         self.assertTrue(reverse("plugins:forward_netbox:forwardingestionissue_list"))
 
 
+class EveryRegisteredModelIsRoutableTest(TestCase):
+    """A model with views registered must also be reachable.
+
+    The sweeps above both start by reversing the DETAIL route and `continue`
+    when it is missing, so a model whose views exist but whose URLs were never
+    added to `urls.py` is silently skipped by every one of them. That is
+    exactly what happened to the change-control models: views, tables, forms
+    and a menu entry all existed, `forwardchange_list` did not resolve, and 25
+    unrelated tests failed with NoReverseMatch when the nav menu rendered.
+
+    This asserts the other direction - if a model has an ObjectListView
+    registered, its list route must reverse.
+    """
+
+    def test_every_model_with_a_list_view_has_a_list_route(self):
+        from netbox.registry import registry
+
+        missing = []
+        for model in apps.get_app_config("forward_netbox").get_models():
+            name = model._meta.model_name
+            views = registry["views"].get("forward_netbox", {}).get(name, {})
+            # A registered LIST view specifically, not any view. NetBox
+            # auto-registers changelog and journal views for every
+            # ChangeLoggedModel, so "has views" is true of child models that
+            # are only ever rendered inside a parent's page and correctly have
+            # no list route of their own.
+            if "list" not in views:
+                continue
+            try:
+                reverse(f"plugins:forward_netbox:{name}_list")
+            except NoReverseMatch:
+                missing.append(name)
+        self.assertEqual(
+            missing,
+            [],
+            "these models register views but have no list route, so every page "
+            f"that renders the plugin menu raises NoReverseMatch: {missing}",
+        )
+
+
 class EveryDetailViewHasATemplateTest(TestCase):
     """`generic.ObjectView` resolves a template by name, or raises at render.
 

--- a/forward_netbox/urls.py
+++ b/forward_netbox/urls.py
@@ -53,6 +53,32 @@ urlpatterns = (
         include(get_model_urls("forward_netbox", "forwardnqemap")),
     ),
     path(
+        "change/",
+        include(get_model_urls("forward_netbox", "forwardchange", detail=False)),
+    ),
+    path(
+        "change/<int:pk>/",
+        include(get_model_urls("forward_netbox", "forwardchange")),
+    ),
+    path(
+        "change-policy/",
+        include(get_model_urls("forward_netbox", "forwardchangepolicy", detail=False)),
+    ),
+    path(
+        "change-policy/<int:pk>/",
+        include(get_model_urls("forward_netbox", "forwardchangepolicy")),
+    ),
+    path(
+        "change-policy-rule/",
+        include(
+            get_model_urls("forward_netbox", "forwardchangepolicyrule", detail=False)
+        ),
+    ),
+    path(
+        "change-policy-rule/<int:pk>/",
+        include(get_model_urls("forward_netbox", "forwardchangepolicyrule")),
+    ),
+    path(
         "drift-policy/",
         include(get_model_urls("forward_netbox", "forwarddriftpolicy", detail=False)),
     ),

--- a/forward_netbox/utilities/model_validation.py
+++ b/forward_netbox/utilities/model_validation.py
@@ -67,6 +67,7 @@ def clean_forward_source(source):
             "scope_endpoints_by_include_tags",
             "config_backup_data_source",
             "config_backup_include_unmanaged",
+            "enable_predict",
         }
     )
     if invalid:
@@ -92,6 +93,8 @@ def clean_forward_source(source):
         )
     if not isinstance(parameters.get("config_backup_include_unmanaged", False), bool):
         raise ValidationError(_("`config_backup_include_unmanaged` must be a boolean."))
+    if not isinstance(parameters.get("enable_predict", False), bool):
+        raise ValidationError(_("`enable_predict` must be a boolean."))
     if not isinstance(parameters.get("sync_generic_endpoints", False), bool):
         raise ValidationError(_("`sync_generic_endpoints` must be a boolean."))
     parameters.setdefault("scope_endpoints_by_include_tags", True)

--- a/forward_netbox/views.py
+++ b/forward_netbox/views.py
@@ -43,6 +43,9 @@ from .filtersets import ForwardNQEMapFilterSet
 from .filtersets import ForwardSourceFilterSet
 from .filtersets import ForwardSyncFilterSet
 from .filtersets import ForwardValidationRunFilterSet
+from .forms import ForwardChangeForm
+from .forms import ForwardChangePolicyForm
+from .forms import ForwardChangePolicyRuleForm
 from .forms import ForwardDriftPolicyBulkEditForm
 from .forms import ForwardDriftPolicyForm
 from .forms import ForwardIngestionMergeForm
@@ -53,6 +56,10 @@ from .forms import ForwardSourceForm
 from .forms import ForwardSyncBulkEditForm
 from .forms import ForwardSyncForm
 from .forms import ForwardValidationRunForceAllowForm
+from .models import ForwardChange
+from .models import ForwardChangePolicy
+from .models import ForwardChangePolicyRule
+from .models import ForwardChangeReview
 from .models import ForwardDeviceAnalysis
 from .models import ForwardDriftPolicy
 from .models import ForwardIngestion
@@ -61,6 +68,8 @@ from .models import ForwardNQEMap
 from .models import ForwardSource
 from .models import ForwardSync
 from .models import ForwardValidationRun
+from .tables import ForwardChangePolicyTable
+from .tables import ForwardChangeTable
 from .tables import ForwardDeviceAnalysisTable
 from .tables import ForwardDriftPolicyTable
 from .tables import ForwardIngestionChangesTable
@@ -2950,3 +2959,191 @@ if django_apps.is_installed("netbox_dlm"):
                     for label in ("critical", "high", "medium", "low")
                 },
             }
+
+
+@register_model_view(ForwardChange, "list", path="", detail=False)
+class ForwardChangeListView(generic.ObjectListView):
+    queryset = ForwardChange.objects.all()
+    table = ForwardChangeTable
+    actions = (AddObject, BulkExport, BulkDelete)
+
+
+@register_model_view(ForwardChange, "add", detail=False)
+@register_model_view(ForwardChange, "edit")
+class ForwardChangeEditView(generic.ObjectEditView):
+    queryset = ForwardChange.objects.all()
+    form = ForwardChangeForm
+
+
+@register_model_view(ForwardChange)
+class ForwardChangeView(generic.ObjectView):
+    queryset = ForwardChange.objects.all()
+    template_name = "forward_netbox/forwardchange.html"
+
+    def get_extra_context(self, request, instance):
+        """Everything the approver needs on one page, and nothing implied.
+
+        The two panels are kept apart deliberately. `criterion_outcomes` is
+        evidence and feeds the verdict; the predict panel is advisory and does
+        not. A reader must be able to tell which is which, because an advisory
+        panel that looks like evidence is how a prediction becomes a decision.
+        """
+        from .change_control.evidence import criterion_outcomes
+        from .change_control.predict import PredictOutcome
+        from .change_control.predict import render_predict_panel
+        from .change_control.state_machine import available_transitions
+        from .change_control.state_machine import check_transition
+
+        outcomes = criterion_outcomes(instance)
+        transitions = []
+        for target in available_transitions(instance.state):
+            result = check_transition(instance, target)
+            transitions.append(
+                {
+                    "target": target,
+                    "allowed": result.allowed,
+                    "blockers": result.blockers,
+                }
+            )
+
+        return {
+            "criterion_outcomes": outcomes,
+            "transitions": transitions,
+            "predict_panel": render_predict_panel(
+                PredictOutcome(
+                    status=instance.predict_status or PredictOutcome.UNAVAILABLE,
+                    reason=instance.predict_reason,
+                    pre_verdict=instance.predict_pre_verdict,
+                )
+            ),
+            "scoped_devices": instance.devices.select_related("device"),
+            "reviews": instance.reviews.select_related("reviewer"),
+        }
+
+
+@register_model_view(ForwardChange, "delete")
+class ForwardChangeDeleteView(generic.ObjectDeleteView):
+    queryset = ForwardChange.objects.all()
+
+
+@register_model_view(ForwardChange, "bulk_delete", path="delete", detail=False)
+class ForwardChangeBulkDeleteView(generic.BulkDeleteView):
+    queryset = ForwardChange.objects.all()
+    table = ForwardChangeTable
+
+
+@register_model_view(ForwardChangePolicy, "list", path="", detail=False)
+class ForwardChangePolicyListView(generic.ObjectListView):
+    queryset = ForwardChangePolicy.objects.all()
+    table = ForwardChangePolicyTable
+    actions = (AddObject, BulkExport, BulkEdit, BulkDelete)
+
+
+@register_model_view(ForwardChangePolicy, "add", detail=False)
+@register_model_view(ForwardChangePolicy, "edit")
+class ForwardChangePolicyEditView(generic.ObjectEditView):
+    queryset = ForwardChangePolicy.objects.all()
+    form = ForwardChangePolicyForm
+
+
+@register_model_view(ForwardChangePolicy)
+class ForwardChangePolicyView(generic.ObjectView):
+    queryset = ForwardChangePolicy.objects.all()
+    template_name = "forward_netbox/forwardchangepolicy.html"
+
+    def get_extra_context(self, request, instance):
+        return {"rules": instance.rules.select_related("device_role", "site")}
+
+
+@register_model_view(ForwardChangePolicy, "delete")
+class ForwardChangePolicyDeleteView(generic.ObjectDeleteView):
+    queryset = ForwardChangePolicy.objects.all()
+
+
+@register_model_view(ForwardChangePolicy, "bulk_delete", path="delete", detail=False)
+class ForwardChangePolicyBulkDeleteView(generic.BulkDeleteView):
+    queryset = ForwardChangePolicy.objects.all()
+    table = ForwardChangePolicyTable
+
+
+@register_model_view(ForwardChange, "review", path="review")
+class ForwardChangeReviewView(BaseObjectView):
+    """Record an approval or a rejection at whichever gate is open.
+
+    The first and only writer of `ForwardChangeReview`. Until this existed the
+    approval gate was unreachable: reviews had no form, view or API, so no
+    change could leave STAGED at all.
+
+    The anchors are captured HERE, from the change as it is at this moment,
+    rather than accepted from the request. That is what makes staleness mean
+    anything - a reviewer approves the evidence they were shown, and a review
+    that carried its own anchors could claim to have seen anything.
+    """
+
+    queryset = ForwardChange.objects.all()
+
+    def get_required_permission(self):
+        # A distinct right from editing, following `run_forwardsync`. Anyone
+        # who can edit a change should not thereby be able to sign it off.
+        return "forward_netbox.approve_forwardchange"
+
+    def get(self, request, pk):
+        change = get_object_or_404(self.queryset, pk=pk)
+        return redirect(change.get_absolute_url())
+
+    def post(self, request, pk):
+        from .change_control.choices import ForwardChangeStateChoices
+        from .change_control.choices import ForwardReviewPhaseChoices
+
+        change = get_object_or_404(self.queryset, pk=pk)
+        approved = request.POST.get("decision") == "approve"
+
+        # The gate is derived from the change's state, not chosen by the
+        # reviewer: a POST approval recorded while the change is still STAGED
+        # would sign off on evidence that does not exist yet.
+        phase = (
+            ForwardReviewPhaseChoices.POST
+            if change.state == ForwardChangeStateChoices.VERIFIED_PROCEED
+            else ForwardReviewPhaseChoices.PRE
+        )
+
+        if change.requester_id and change.requester_id == request.user.pk:
+            messages.error(
+                request,
+                _(
+                    "You raised this change, so your own approval does not "
+                    "count towards it."
+                ),
+            )
+            return redirect(change.get_absolute_url())
+
+        ForwardChangeReview.objects.update_or_create(
+            change=change,
+            reviewer=request.user,
+            phase=phase,
+            defaults={
+                "approved": approved,
+                "comment": (request.POST.get("comment") or "").strip(),
+                "branch_change_time": change.branch_last_change_time,
+                "baseline_snapshot_id": change.before_snapshot_id,
+                "after_snapshot_id": change.after_snapshot_id,
+                "verdict": change.verdict,
+            },
+        )
+        messages.success(
+            request,
+            _("Recorded your %(phase)s-change decision.") % {"phase": phase},
+        )
+        return redirect(change.get_absolute_url())
+
+
+@register_model_view(ForwardChangePolicyRule, "add", detail=False)
+@register_model_view(ForwardChangePolicyRule, "edit")
+class ForwardChangePolicyRuleEditView(generic.ObjectEditView):
+    queryset = ForwardChangePolicyRule.objects.all()
+    form = ForwardChangePolicyRuleForm
+
+
+@register_model_view(ForwardChangePolicyRule, "delete")
+class ForwardChangePolicyRuleDeleteView(generic.ObjectDeleteView):
+    queryset = ForwardChangePolicyRule.objects.all()


### PR DESCRIPTION
## Summary

A change-control workflow whose verdict comes from **the network**, not from the reviewers.

**The branch merges at CLOSE, not at APPROVE.** Human approval is the necessary condition; a post-change Forward snapshot showing the network is the way the branch says it is is the sufficient one. Every generic change-control tool merges when the humans say yes and *cannot do otherwise* — it has no network model to consult. That reordering is the product.

Ships **inside** forward-netbox rather than as a sibling plugin: everything it needs (`ForwardClient`, `resolve_snapshot_id`, `run_nqe_diff`, `compare_model_rows`, `PreviewRunner`) is private API, and coupling two independently-versioned packages through internals is what made the netbox-branching 1.2 move expensive.

## Two human gates

| Gate | Approves | Anchored to |
|---|---|---|
| PRE | the plan | branch + baseline snapshot |
| POST | the **closure**, where the merge happens | after-snapshot + verdict |

A PROCEED verdict *opens* the second gate rather than walking through it. Re-verifying against a newer snapshot, or the verdict changing, voids a sign-off — a reviewer approves specific evidence.

**Reviews previously had no form, view or API**, so the gate was unreachable and no change could leave `STAGED`. This adds the first writer. Anchors are captured server-side from the change as it is at that moment, never accepted from the request; the gate is derived from state, so a POST approval can't be recorded against evidence that doesn't exist yet. Guarded by a distinct `approve_forwardchange` permission.

## The policy is now enforced

It was inert — nothing read `min_approvals`, nothing evaluated a rule. Three decisions in the new helper:

- **The strictest applicable policy wins**, so overlapping policies only ever *add* requirements.
- **An unmatched change still needs an approval**, or covering one estate leaves the rest ungoverned.
- **The requester is excluded at count time**, so a review can't become valid by someone later being made requester.

`min_approvals` is removed rather than renamed — one number can't express "two sign-offs on the plan, one on the closure" — and `(change, reviewer, phase)` is unique, without which N approvals from one person satisfy an N-approval policy alone.

## Four properties, each pinned by a test

- **A HOLD can never be closed.** No `VERIFIED_HOLD → CLOSED` edge exists, so it's structurally inexpressible rather than policed by a skippable check.
- **The two criterion families block differently.** Acceptance asserts the change *achieved its intent*, so `fail→fail` means it didn't work and blocks. State preservation asserts nothing *else* moved, so `fail→fail` is pre-existing and doesn't.
- **"Not measured" stays a third answer.** A missing phase is never coerced to a pass — that coercion is how an empty comparison once read as a successful one.
- **Device-set completeness is gate step one and refuses rather than warns.** A device that failed collection is *absent* from the Forward model rather than flagged, so "no violations" and "the broken device wasn't in the snapshot" are indistinguishable. Same shape as the 552 uncovered devices.

## Honest limits

**Attestation is the weakest joint** and says so on the page. `APPLIED` can't be proved from here — but its usual failure is detectable: if every criterion returns the same result before and after, Forward observed no change, so the gate holds with *both* explanations offered rather than an accusation.

**Predict is flagged out.** Not live at Forward, licence-gated when it ships, limited today — so the machine is correct without it and `STAGED → APPROVED` is first-class. `enable_predict` is off by default across all six sites (two of which the parity test cannot see). The advisory columns ship now so its arrival needs no schema change, and they're quarantined from the verdict by construction: the gate reads `ForwardChangeEvidence` and nothing else.

## Validation

Full suite on 4.7.0 + branching 1.2.0b1: **2648 tests OK** (158 skipped), migrations apply with no model drift, system check clean, `invoke harness-check` ✓.

Plan: `docs/03_Plans/active/2026-09-02-forward-change-control-concept.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa
