### PR TITLE
docs: record what 3.0 actually carries

### DIFF
--- a/docs/03_Plans/active/2026-09-02-release-3.0.0.md
+++ b/docs/03_Plans/active/2026-09-02-release-3.0.0.md
@@ -24,8 +24,14 @@ maintained 4.6 lane.
 
 ## Touched Surfaces
 
-Already merged in #341 (the whole runtime move), #340 (stale-deferral sweep).
-This release adds only the version bump and its authorization record.
+Already merged: #340 (stale-deferral sweep), #341 (the runtime move), #343
+(change control). This release adds only the version bump and its
+authorization record.
+
+3.0 therefore carries two things, not one: the NetBox 4.7 runtime, and a new
+change-control feature. That was a deliberate call - a major-version migration
+and a large feature in the same gate makes a regression harder to attribute,
+and it was weighed and accepted rather than drifted into.
 
 ## Approach
 
@@ -45,7 +51,7 @@ The engineering is done and on `main`. What remains is the release itself:
 
 Measured on `4.7.0` + `1.2.0b1` before the gate:
 
-- Full Django suite **2589 OK** (158 skipped); harness **382 OK**.
+- Full Django suite **2648 OK** (158 skipped); harness **382 OK**.
 - Migrations apply; `makemigrations --check` clean.
 - **All three fast paths ENABLED** with zero field-contract drift. Asked
   directly, because a silently disabled path passes every test it has.


### PR DESCRIPTION
The release plan described 3.0 as the 4.7 runtime plus its authorization record. It also carries change control (#343).

Stated as the deliberate call it was: a major-version migration and a large new feature landing in the same gate makes a regression harder to attribute. That was weighed and accepted, not drifted into.

Suite figure updated to the measured 2648 OK (158 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa