### PR TITLE
docs: redact live Forward identifiers from the plan files

### DIFF
--- a/docs/03_Plans/active/2026-09-02-netbox-4.7-runtime.md
+++ b/docs/03_Plans/active/2026-09-02-netbox-4.7-runtime.md
@@ -89,9 +89,11 @@ Measured on NetBox `4.7.0` with Branching `1.2.0b1`:
 
 - **Live Forward validation**, which no unit test covers: the plugin's own
   `ForwardClient` authenticated against production Forward, listed 102
-  networks, resolved network `155541`, fetched 100 snapshots, and ran an async
-  NQE query against snapshot `1394725` returning **5228 device rows** - the
-  submit, poll and paginate path end to end.
+  networks, resolved the configured network, fetched 100 snapshots, and ran an
+  async NQE query against its newest processed snapshot returning **5228
+  device rows** - the submit, poll and paginate path end to end. The network
+  and snapshot ids are deliberately not recorded here: they identify a
+  customer's estate, and the counts are what make this evidence.
 
 - Still to run in the release gate: the artifact leg and the upgrade leg. The
   upgrade leg needs the bumped version, so it runs as part of `invoke ci`

--- a/docs/03_Plans/active/2026-09-02-release-3.0.0.md
+++ b/docs/03_Plans/active/2026-09-02-release-3.0.0.md
@@ -56,8 +56,10 @@ Measured on `4.7.0` + `1.2.0b1` before the gate:
 - **All three fast paths ENABLED** with zero field-contract drift. Asked
   directly, because a silently disabled path passes every test it has.
 - **Live Forward**: the plugin's own client authenticated against production,
-  listed 102 networks, resolved `155541`, fetched 100 snapshots and ran an
-  async NQE query on snapshot `1394725` returning 5228 device rows.
+  listed 102 networks, resolved the configured network, fetched 100 snapshots
+  and ran an async NQE query on its newest processed snapshot returning 5228
+  device rows. Identifiers are omitted on purpose - they name a customer's
+  estate, and the counts carry the evidence.
 
 ## Rollback
 


### PR DESCRIPTION
The release gate refused the tree, correctly.

Recording the live validation, I wrote a real Forward network id and snapshot id into two plan files. Those identify a customer estate, and plan files are published with the repository.

The evidence is unchanged in substance — 102 networks listed, the configured network resolved, 100 snapshots fetched, an async NQE query on the newest processed snapshot returning 5228 device rows. The **counts** are what make it evidence; the identifiers only said whose network it was.

Both files now say the omission is deliberate, so the next person recording a live run does not reach for the id again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa