### PR TITLE
style: apply the whole-repo lint the release gate runs

### DIFF
--- a/forward_netbox/utilities/ingestion_merge.py
+++ b/forward_netbox/utilities/ingestion_merge.py
@@ -40,7 +40,7 @@ def suppress_ingest_side_effect_signals():
     Does NOT suppress core.signals.handle_changed_object (ObjectChange /
     Branching diff tracking) — that is intentional and required for Branching
     review.
-    
+
     NOT suppressed on NetBox 4.7, and deliberately not replaced:
     `sync_cached_scope_fields` no longer exists. 4.7 maintains the
     CachedScopeMixin denormalized columns - Site's among them - with database

--- a/tasks.py
+++ b/tasks.py
@@ -1250,8 +1250,7 @@ def artifact_test(context):
             # at a max_version in the 4.6 series, so none of them is installed
             # in the artifact and naming them would put components in the SBOM
             # that the image does not contain.
-            "']' "
-            "> /tmp/netbox-runtime-pyproject.toml",
+            "']' " "> /tmp/netbox-runtime-pyproject.toml",
             "UV_CACHE_DIR=/tmp/uv-cache uv tool run --isolated "
             f"--from cyclonedx-bom=={CYCLONEDX_BOM_VERSION} "
             "cyclonedx-py environment "


### PR DESCRIPTION
Two files reached main unformatted — trailing whitespace in ingestion_merge.py, and tasks.py needing black.

**Same cause as the 2.9.2 gate failure.** `invoke ci` runs `pre-commit run --all-files`; the per-change runs during this tranche used `--files <list>`, which *modifies* the files it is handed and reports clean for everything it is not. Running it per change is not a substitute for running it over the repository, and missing that twice has now cost two release attempts.

No behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa