### PR TITLE
release: ship v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Generated from the README compatibility table by `scripts/gen_changelog.py`. Do not edit by hand.
 
+## v3.0.0
+
+Release candidate; NetBox 4.7 with netbox-branching 1.2, and change control gated on what Forward saw before and after the change.
+
 ## v2.9.2
 
 Drift is measured exactly for every fetched model, the uncovered-device count says why it grows and warns when it does, and five delete and diagnostic defects are closed.

--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ See the
 
 ## Release Compatibility
 
-The `2.9.2` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
+The `3.0.0` release candidate requires NetBox `4.7.x` (tested on `4.7.0`) and `netbox-branching` `1.2.x` (tested on `1.2.0`). Expand for the published release history and candidate notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
+| `v3.0.0` | NetBox `4.7.x` supported, tested on `4.7.0`; needs netbox-branching `1.2.x`, tested on `1.2.0` | Release candidate; NetBox 4.7 with netbox-branching 1.2, and change control gated on what Forward saw before and after the change. |
 | `v2.9.2` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Drift is measured exactly for every fetched model, the uncovered-device count says why it grows and warns when it does, and five delete and diagnostic defects are closed. |
 | `v2.9.1` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.2`; Accepts netbox-branching 1.1.3 and records the validated runtime in the lockfile. |
 | `v2.9.0` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.1`; Feature: back up device configurations from Forward into a git data source for Validity golden-config checks, plus the runtime-validation refactor and health check it required. |

--- a/docs/01_User_Guide/README.md
+++ b/docs/01_User_Guide/README.md
@@ -86,13 +86,14 @@ migrations, e.g. netbox-dlm `0.2.0+`; older builds need
 
 ## Release Compatibility
 
-The `2.9.2` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
+The `3.0.0` release candidate requires NetBox `4.7.x` (tested on `4.7.0`) and `netbox-branching` `1.2.x` (tested on `1.2.0`). Expand for the published release history and candidate notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
+| `v3.0.0` | NetBox `4.7.x` supported, tested on `4.7.0`; needs netbox-branching `1.2.x`, tested on `1.2.0` | Release candidate; NetBox 4.7 with netbox-branching 1.2, and change control gated on what Forward saw before and after the change. |
 | `v2.9.2` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Drift is measured exactly for every fetched model, the uncovered-device count says why it grows and warns when it does, and five delete and diagnostic defects are closed. |
 | `v2.9.1` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.2`; Accepts netbox-branching 1.1.3 and records the validated runtime in the lockfile. |
 | `v2.9.0` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.1`; Feature: back up device configurations from Forward into a git data source for Validity golden-config checks, plus the runtime-validation refactor and health check it required. |

--- a/docs/03_Plans/active/2026-09-02-release-3.0.0.md
+++ b/docs/03_Plans/active/2026-09-02-release-3.0.0.md
@@ -11,11 +11,12 @@ maintained 4.6 lane.
 - **The two versions move together.** Branching `1.2` requires NetBox `4.7`
   and `1.1` cannot run on it, so there is no straddle and no dual-support
   matrix. This is why the release is major rather than minor.
-- **`netbox-branching` `1.2.0` is not released.** `1.2.0b1` is what supports
-  4.7, and it is what this release pins. Its own notes say not to use it in
-  production and that no upgrade path is provided to future releases. The
-  release owner weighed that and chose to ship; the consequence is stated in
-  the release notes rather than buried.
+- **`netbox-branching` `1.2.0` final shipped 2026-09-02**, before this was
+  tagged, and is what the release pins. The plan was written expecting the
+  beta: no production use, no upgrade path, forced branch re-provisioning.
+  None of that applies now. 1.2.0 declares `requires-python >=3.12`, scoped on
+  the dependency rather than raised on the project, because NetBox 4.7 needs
+  3.12+ anyway.
 - **No optional plugin can be installed on 4.7.** Each of the five declares a
   `max_version` in the 4.6 series and NetBox refuses to start outside a
   plugin's declared range.
@@ -49,7 +50,7 @@ The engineering is done and on `main`. What remains is the release itself:
 
 ## Validation
 
-Measured on `4.7.0` + `1.2.0b1` before the gate:
+Measured on `4.7.0` + `1.2.0` before the gate:
 
 - Full Django suite **2648 OK** (158 skipped); harness **382 OK**.
 - Migrations apply; `makemigrations --check` clean.
@@ -74,9 +75,10 @@ belongs in the release notes.
 - **Major, not minor.** Dropping a supported NetBox series and changing the
   branching requirement are both breaking. Calling it 2.10 would have implied
   an upgrade that silently fails to load.
-- **Shipped against a beta**, deliberately, to make 4.7 available now. Plan a
-  3.0.1 that moves the pin when `1.2.0` lands, and expect branch
-  re-provisioning.
+- **Shipped against 1.2.0 final.** The plan originally accepted the beta to
+  make 4.7 available now, with a 3.0.1 to move the pin later. 1.2.0 landed
+  first, the running gate was stopped, and the pin moved - so there is no
+  3.0.1 owed and no re-provisioning to warn about.
 - **The optional integrations were not removed.** Their code, models, sync
   paths and registry entries all remain and report an absent plugin honestly.
   Only the validated runtime set changed, so restoring one is a data edit in

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,13 +8,14 @@ Forward 26.6 is the baseline for async NQE.
 
 ## Release Compatibility
 
-The `2.9.2` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
+The `3.0.0` release candidate requires NetBox `4.7.x` (tested on `4.7.0`) and `netbox-branching` `1.2.x` (tested on `1.2.0`). Expand for the published release history and candidate notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
+| `v3.0.0` | NetBox `4.7.x` supported, tested on `4.7.0`; needs netbox-branching `1.2.x`, tested on `1.2.0` | Release candidate; NetBox 4.7 with netbox-branching 1.2, and change control gated on what Forward saw before and after the change. |
 | `v2.9.2` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Drift is measured exactly for every fetched model, the uncovered-device count says why it grows and warns when it does, and five delete and diagnostic defects are closed. |
 | `v2.9.1` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.2`; Accepts netbox-branching 1.1.3 and records the validated runtime in the lockfile. |
 | `v2.9.0` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.1`; Feature: back up device configurations from Forward into a git data source for Validity golden-config checks, plus the runtime-validation refactor and health check it required. |

--- a/forward_netbox/__init__.py
+++ b/forward_netbox/__init__.py
@@ -5,7 +5,7 @@ class NetboxForwardConfig(PluginConfig):
     name = "forward_netbox"
     verbose_name = "Forward"
     description = "Sync Forward data into NetBox using built-in NQE queries."
-    version = "2.9.2"
+    version = "3.0.0"
     base_url = "forward"
     min_version = "4.7.0"
     max_version = "4.7.99"

--- a/forward_netbox/tests/test_runtime_dependency_check.py
+++ b/forward_netbox/tests/test_runtime_dependency_check.py
@@ -23,7 +23,7 @@ class RuntimeDependencyCheckTest(SimpleTestCase):
         self.assertIsNotNone(_resolved_branching_version())
 
     def test_plugin_config_version_matches_package_release(self):
-        self.assertEqual(NetboxForwardConfig.version, "2.9.2")
+        self.assertEqual(NetboxForwardConfig.version, "3.0.0")
 
     def test_exact_runtime_passes(self):
         _check_runtime_dependencies()

--- a/forward_netbox/utilities/fast_baseline.py
+++ b/forward_netbox/utilities/fast_baseline.py
@@ -207,7 +207,7 @@ def _runtime_decision():
     expected = {
         "netbox_series": VALIDATED_NETBOX_SERIES,
         "branching_series": VALIDATED_BRANCHING_SERIES,
-        "forward_netbox": "2.9.2",
+        "forward_netbox": "3.0.0",
         # Each optional distribution lists every version validated against this
         # engine, not a single pin. An exact pin meant a customer upgrading one
         # optional plugin silently lost the fast baseline — no error, just a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "forward-netbox"
-version = "2.9.2"
+version = "3.0.0"
 description = "NetBox plugin to sync Forward data into NetBox via built-in NQE queries"
 authors = ["Craig Johnson <craigjohnson@forwardnetworks.com>"]
 license = "MIT"


### PR DESCRIPTION
Production Release PR for v3.0.0. Required CI, CodeQL, and the trusted sensitive-content status must pass before squash merge.