### PR TITLE
feat: NetBox 4.7, change control, and branching 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 - **Support model:** field integration reference — **not** an officially
   supported Forward Networks product.
-- **Requires:** NetBox `4.6.5`, `netbox-branching` `1.1.1`; Forward `26.6`
+- **Requires:** NetBox `4.7.x`, `netbox-branching` `1.2.x`; Forward `26.6`
   baseline for async NQE (full matrix in
   [Release Compatibility](#release-compatibility)).
 - **Distribution:** PyPI + GitHub releases. `pip install forward-netbox` is the

--- a/constraints.txt
+++ b/constraints.txt
@@ -9,7 +9,7 @@ cryptography==50.0.0
 httpx==0.28.1
 netbox-cisco-aci==0.4.0
 netbox-dlm==0.9.1
-netboxlabs-netbox-branching==1.1.3
+netboxlabs-netbox-branching==1.2.0
 netbox-peering-manager==0.3.0
 netbox-routing==0.4.3
 netbox-validity==3.5.2

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -1,4 +1,4 @@
-ARG NETBOX_VER=v4.6.6
+ARG NETBOX_VER=v4.7.0
 
 FROM netboxcommunity/netbox:${NETBOX_VER}
 
@@ -16,8 +16,10 @@ COPY development/launch-netbox.sh /opt/netbox/launch-netbox.sh
 RUN chmod +x /opt/netbox/launch-netbox.sh
 
 RUN uv pip install --constraint ${CONSTRAINTS} ${PACKAGE}
-RUN uv pip install --constraint ${CONSTRAINTS} \
-    netbox-cisco-aci netbox-dlm netbox-peering-manager netbox-routing netbox-validity
+# The five optional plugins are NOT installed on NetBox 4.7: every one of them
+# declares `max_version = "4.6.99"`, and NetBox refuses to start with a plugin
+# outside its declared range, so the image would not boot. They return here the
+# moment an upstream raises its ceiling. The 4.6 lane keeps them on 2.9.x.
 RUN uv pip install "watchdog[watchmedo]"
 RUN uv pip install coverage
 

--- a/development/configuration/plugins.py
+++ b/development/configuration/plugins.py
@@ -2,16 +2,17 @@
 # Of course uncomment this file out.
 # To learn how to build images with your required plugins
 # See https://github.com/netbox-community/netbox-docker/wiki/Using-Netbox-Plugins
-# The development and CI runtime enables every supported optional integration at
-# the exact version pinned in constraints.txt. Production installs still choose
-# extras explicitly, but adapter regressions cannot hide behind skipped tests.
+# On NetBox 4.6 this enabled every supported optional integration, so adapter
+# regressions could not hide behind skipped tests. On 4.7 none of them can be
+# enabled: netbox-dlm, netbox-cisco-aci, netbox-peering-manager, netbox-routing
+# and netbox-validity all declare `max_version = "4.6.99"` and NetBox refuses to
+# start with a plugin outside its range.
+#
+# The optional-integration tests therefore skip on this runtime rather than
+# fail. That is a real loss of coverage and is stated as such: the 2.9.x lane on
+# 4.6 remains where those adapters are exercised until an upstream moves.
 PLUGINS = [
     "netbox_branching",
-    "netbox_dlm",
-    "netbox_routing",
-    "netbox_peering_manager",
-    "netbox_cisco_aci",
-    "validity",
     "forward_netbox",
 ]
 

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "${FORWARD_NETBOX_HOST_PORT:-8000}:8000"
     env_file: env/netbox.env
     environment:
-      NETBOX_VER: "${NETBOX_VER:-v4.6.8}"
+      NETBOX_VER: "${NETBOX_VER:-v4.7.0}"
     secrets:
       - api_token_pepper_1
       - db_password
@@ -31,7 +31,7 @@ services:
       context: ../
       dockerfile: development/Dockerfile
       args:
-        NETBOX_VER: "${NETBOX_VER:-v4.6.8}"
+        NETBOX_VER: "${NETBOX_VER:-v4.7.0}"
   netbox-worker:
     !!merge <<: *netbox
     depends_on:
@@ -40,7 +40,7 @@ services:
     ports: []
     environment:
       FORWARD_NETBOX_WORKER_AUTORELOAD: "${FORWARD_NETBOX_WORKER_AUTORELOAD:-1}"
-      NETBOX_VER: "${NETBOX_VER:-v4.6.8}"
+      NETBOX_VER: "${NETBOX_VER:-v4.7.0}"
     command:
       - sh
       - -lc

--- a/docs/01_User_Guide/README.md
+++ b/docs/01_User_Guide/README.md
@@ -4,21 +4,37 @@ Install the plugin package, enable the required plugins, run the migrations, and
 
 ## Requirements
 
-- NetBox `4.6.x`, `4.6.5` or newer (`4.5.x` and earlier are not supported).
-  Tested and validated on `4.6.8`.
-- `netboxlabs-netbox-branching` `1.1.x`. Tested on `1.1.2`.
+- NetBox `4.7.x` (`4.6.x` and earlier are not supported by this release; stay
+  on the `2.9.x` line for those). Tested and validated on `4.7.0`.
+- `netboxlabs-netbox-branching` `1.2.x`. Tested on `1.2.0`.
+- PostgreSQL `15+` and Redis `6+`, which NetBox `4.7` requires. These are the
+  part of the upgrade that installing a newer plugin does not fix, so check
+  them first.
 - Forward `26.6` is the baseline for async NQE.
 
-### Planning for NetBox 4.7
+### Which line to run
 
-The plugin declares `max_version = "4.6.99"`, so it refuses to load on NetBox
-`4.7` rather than half-working there. That is deliberate and will lift once the
-release gate has actually run against a `4.7` runtime.
+The two versions move together and cannot be mixed: `netbox-branching` `1.2`
+requires NetBox `4.7`, and `1.1` cannot run on it. There is no configuration
+that spans both.
 
-NetBox `4.7` also raises its own service minimums to **PostgreSQL 15+** and
-**Redis 6+**. Those are NetBox's requirements rather than the plugin's, and they
-are worth checking before planning that upgrade, because they are the part that
-is not fixed by installing a newer plugin.
+| You run | Use | Notes |
+| --- | --- | --- |
+| NetBox `4.6.x` | forward-netbox `2.9.x` | Maintained. All optional integrations available. |
+| NetBox `4.7.x` | forward-netbox `3.0.x` | No optional integrations yet - see below. |
+
+### Optional integrations are unavailable on 4.7
+
+`netbox-dlm`, `netbox-cisco-aci`, `netbox-peering-manager`, `netbox-routing`
+and `netbox-validity` each declare a `max_version` in the `4.6` series, and
+NetBox refuses to start with a plugin outside its declared range. They cannot
+be installed on `4.7` at all, so on this release the CVE and software-lifecycle
+tab, the ACI models, peering, routing and the Validity config-backup
+integration are not available.
+
+Nothing about those integrations was removed - the code, models and sync paths
+are all still here and report an absent plugin honestly. If you depend on any
+of them, stay on the `2.9.x` line until the plugin you need raises its ceiling.
 
 ## Package Installation
 

--- a/docs/03_Plans/active/2026-09-02-forward-change-control-concept.md
+++ b/docs/03_Plans/active/2026-09-02-forward-change-control-concept.md
@@ -1,0 +1,859 @@
+# Forward change control: a concept for a second plugin
+
+Status: concept. Nothing here is committed to a release. This is the
+decision-complete argument for a sibling plugin, `forward-change-control`,
+so that the choice to build it or not can be made on the evidence rather
+than on enthusiasm.
+
+## Goal
+
+Give a network change a lifecycle in NetBox whose gates are answered by
+Forward, not by a person asserting they were satisfied. A change names the
+devices it touches and the properties that must hold afterwards; the
+plugin pins a Forward snapshot before it, pins another after it, runs the
+same NQE criteria against both, and merges the NetBox branch describing
+the change **only** when the after-snapshot says the criteria hold.
+
+The one-sentence difference from every generic change-control tool: an
+approval opens the merge, but it does not complete the change. Evidence
+from a real post-change snapshot does.
+
+That claim rests on a snapshot and an NQE query, and nothing else — the
+two capabilities every Forward licence tier has and that forward-netbox
+has been exercising in production for a year. Forward's predict workflow
+is **not part of the load-bearing path**: it is not live, it is
+licence-gated, and it is limited in scope today, so it is designed for as
+an optional, capability-gated advisory step with a stubbed
+implementation. The product is whole without it. See sections 1a and 1b,
+and the Decision Log.
+
+## What this is NOT
+
+Stated first, because every section below is shorter for it.
+
+- **Not a ticketing system.** No queues, no assignment, no SLA, no
+  priority-as-workflow. A change carries a `ref` string pointing at
+  whatever ServiceNow/Jira record the customer already has, and that is
+  the whole of the integration.
+- **Not a config pusher, orchestrator or runbook engine.** The plugin
+  never opens a session to a device and must never claim to have. The
+  apply is performed by whatever the customer already uses, and the
+  plugin records an attestation that it happened.
+- **Not a reimplementation of branching.** No diff engine, no merge
+  engine, no conflict resolution, no revert. `netbox_branching` owns all
+  of it. The only branching code this plugin writes is one
+  `Branch.register_preaction_check(..., 'merge')` callable and a
+  `OneToOneField`.
+- **Not a fork or a re-skin of `netbox-change-control`.** That plugin is
+  the shape reference and nothing more. It declares `max_version =
+  '4.6.99'`, so on this runtime it cannot be installed at all, which
+  removes the option of building on top of it even if we wanted to.
+- **Not a second Forward client.** Credentials, retry, pagination, rate
+  limiting, async NQE polling and API-usage accounting all live in
+  `forward_netbox.utilities.forward_api_impl` and are consumed, never
+  copied.
+- **Not a Forward writer**, with one deliberate, opt-in exception:
+  publishing a criterion query into the org NQE library so it can be
+  diffed. See the Decision Log.
+- **Not a drift detector.** forward-netbox already answers "does NetBox
+  match Forward". This answers "did the change do what it said, and
+  nothing else".
+- **Not authoritative inventory.** Like `ForwardDeviceAnalysis`, its rows
+  are an operator-facing read model, not a sync target.
+- **Not a predict-based tool.** It does not require Forward's predict
+  workflow, does not degrade without it, and must never be described as
+  needing it. Predict is an optional advisory panel behind a stub.
+
+## Constraints
+
+- **NetBox 4.7 only.** `min_version = "4.7.0"`, `max_version = "4.7.99"`.
+  There is no 4.6 lane for this plugin: it does not exist yet, so it has
+  no installed base to straddle for.
+- **netbox-branching `1.2.0b1`.** 1.2.x requires 4.7 and 1.1.x cannot run
+  on it, so the pin follows forward-netbox 3.0 exactly. 1.2.0 final is
+  not released and the beta's own notes state that no upgrade path to a
+  later release is provided. Design accordingly: see Risks.
+- **forward-netbox 3.0 is a hard dependency**, not an optional one. The
+  3.0 line is in progress on `feat/netbox-4.7-runtime`. This plugin is
+  meaningless without it and must refuse to load rather than degrade.
+- **The five optional plugins are unavailable.** `netbox-dlm`,
+  `netbox-cisco-aci`, `netbox-peering-manager`, `netbox-routing` and
+  `netbox-validity` all declare a `max_version` in the 4.6 series, so
+  NetBox refuses to start with them on 4.7. No criterion, model or view
+  here may depend on any of them. In particular the config-backup ->
+  Validity golden-config path has no consumer on this runtime: the
+  backup half still works, the checking half does not exist.
+- **`netbox_branching.exempt_models` must list
+  `forward_change_control.*`.** Our models are change-logged, so
+  branching would track them, and a change record created while a branch
+  was active would be written into that branch's schema and become
+  invisible from main. This is a required installation step, not a
+  tuning knob. `netbox-change-control` records hitting exactly this.
+- **`VALIDATED_PLUGIN_APPS` must gain `forward_change_control` in the
+  same forward-netbox release.** That set is an exact match that fails
+  **closed and silently**: an app in `PLUGINS` but not in the set
+  disables COPY/SQL, the set-based merge and the fast baseline in
+  forward-netbox with no error, turning a first sync from minutes into
+  hours. Installing this plugin without that entry is a ten-times
+  slowdown nobody gets an error for.
+- **Read-only toward Forward stays the default.** `architecture-flow.md`
+  states the property as a contract: the plugin reads from Forward and
+  writes only to the local NetBox database. Any Forward write introduced
+  here is opt-in, separately permissioned, and named in the docs.
+- **Persisted diagnostics carry schema identifiers, never customer
+  data.** Evidence rows follow the existing `record_issue` /
+  `diagnostic_shape` policy: counts, keys and query identity persist;
+  row content does not.
+- **Forward's predict workflow may be assumed absent.** It is not live,
+  it is licence-gated, and it is limited in scope where it does exist. No
+  state transition, verdict, model field or gate may require it. It is
+  built as a stub with a real interface (section 1b) so that its arrival
+  is additive.
+- **Forward licence tiers cannot be pre-flighted.** There is no endpoint
+  exposing the tier; `license_tier.py` says so explicitly and warns
+  against adding a gate that assumes otherwise. Every capability question
+  is answered by asking Forward and reading the refusal, and a refusal is
+  reported as "not licensed", never as an error.
+- **NQE call volume is a live customer-facing concern.** Forward
+  engineering has already objected to unnecessary NQE runs. Every path
+  here is accounted through `api_usage_summary()` and the per-change
+  execution count is shown on the form before the change is saved.
+
+### NetBox 4.7 specifics that shape the design
+
+| 4.7 change | Consequence here |
+|---|---|
+| django-mptt replaced by PostgreSQL `ltree`; `lft`/`rght`/`tree_id`/`level` dropped, `level` unusable in `filter()`/`order_by()` | No model proposed here is hierarchical, and none should become one casually. If one ever must, it uses `NestedLtreeGroupModel`, never the deprecated `NestedGroupModel`. |
+| Denormalized field maintenance moved into database triggers; `registry['denormalized_fields']` removed | Do not denormalize through the registry. The one denormalized column proposed (`branch_name`) is maintained in `save()`, exactly as the reference plugin does it. |
+| `CustomField.objects.get_for_model()` returns a **list**, not a queryset | The change form and detail view must not call `.exists()` or `.order_by()` on it. |
+| `django_pglocks` gone; `django_pg_utils.advisory_lock` | The verify job takes an advisory lock keyed on the change pk so two verifies cannot interleave on one change. |
+| `extras.signals` has an import-time `apps.get_model()` side effect | Never import a NetBox signal module at module scope from anything `models.py` pulls in; import inside the function. `AppRegistryNotReady` otherwise. |
+| Selection custom-field values return `{"value", "label"}` objects in REST/GraphQL | Serializer tests must assert the object form, not the scalar. |
+| New `BULK_UPDATE_CHUNK_SIZE` | Evidence rows are written per criterion per phase and can reach the low thousands on a large change. Honour the setting rather than one unbounded `bulk_update`. |
+| Background processing for REST API requests | `POST .../verify/` returns a job rather than blocking. This is the native mechanism now; do not hand-roll one. |
+| Per-object errors for bulk operations | Bulk criterion edits report which criterion failed to bind, not just that one did. |
+| Snapshot-aware event rule conditions | A `VERIFIED_HOLD` event rule can condition on the pre/post state pair, which is how a customer wires a HOLD into their own paging. |
+
+## Touched Surfaces
+
+Inside `forward_netbox/`, as a `change_control` subpackage so the feature is
+legible as one thing and its imports read as internal:
+
+- `forward_netbox/change_control/__init__.py`
+- `forward_netbox/change_control/choices.py` - `ForwardChangeStateChoices`,
+  `ForwardChangeVerdictChoices`, `ForwardCriterionFamilyChoices`,
+  `ForwardCriterionExpectationChoices`, `ForwardEvidencePhaseChoices`.
+- `forward_netbox/change_control/state_machine.py` - the transitions and their
+  entry/exit evidence. Pure functions over the database, no request object, so
+  they test in under a second.
+- `forward_netbox/change_control/criteria.py` - binding, execution,
+  expectation evaluation.
+- `forward_netbox/change_control/evidence.py` - recording and the
+  regression-flip comparison.
+- `forward_netbox/change_control/gates.py` - the collect gate and the verify
+  gate.
+- `forward_netbox/change_control/predict.py` - the stub and its
+  `PredictOutcome`.
+
+Existing files that grow:
+
+- `forward_netbox/models.py` - the six models, beside the ones they reference.
+- `forward_netbox/migrations/` - one migration.
+- `forward_netbox/views.py`, `tables.py`, `forms.py`, `filtersets.py`,
+  `navigation.py`, `templates/` - the UI, following the surrounding idiom.
+- `forward_netbox/tests/` - one test module per change_control module.
+
+## Approach
+
+### 1. The workflow state machine
+
+Eleven states, **ten of which are mandatory**. The vocabulary is
+deliberately the one the Skyforge change flow already uses in the field —
+`STAGED`, `PREDICTED`, `APPROVED`, `APPLIED`, `COLLECTED`,
+`VERIFIED_PROCEED`, `VERIFIED_HOLD`, `CLOSED` — because it is a working
+reference, and because a HOLD that is a *valid result* rather than an
+error is the property most home-grown change gates get wrong.
+
+`PREDICTED` is the optional one. It is skippable by design and by
+default: `STAGED -> APPROVED` is a first-class transition, not a
+degradation. Section 1a states exactly what changes when it is skipped.
+
+| State | Entry evidence (what must be true to arrive) | Exit evidence (what must be produced to leave) | Forward capability behind it |
+|---|---|---|---|
+| `DRAFT` | Created by a user. | Nothing. The author's to hold, exactly as `netbox-change-control` treats draft. | none |
+| `SCOPED` | Every device in scope resolves to a `ForwardDeviceIdentity` row for the chosen `ForwardSource`, so every device is one Forward actually knows. At least one blocking acceptance criterion. | Every criterion **binds**: its query path resolves to a concrete `query_id` at a concrete `commit_id`. A criterion that cannot bind refuses the whole transition, with the binder's errors. | `resolve_nqe_query_reference()`, `get_nqe_query_history()`, `get_committed_nqe_query()` |
+| `BASELINED` | A concrete snapshot id, resolved from the selector and then **pinned** as a literal id. | One `ForwardChangeEvidence` row per criterion at `phase=before`, pass or fail. A criterion already failing here is recorded as failing, not skipped. | `resolve_snapshot_id()`, `get_snapshots()`, `run_nqe_query()`, `get_snapshot_metrics()` |
+| `STAGED` | A `netbox_branching.Branch` exists and holds `ChangeDiff` rows describing the intended post-change NetBox state. | `change_explainability_summary(branch)` returns a non-empty per-model, per-field, per-action summary. **Exits to either `PREDICTED` or `APPROVED`.** | none (branching) |
+| `PREDICTED` *(optional)* | The staged rows are classified against live NetBox without writing, and — where the capability exists — Forward is asked to predict the change. | Two independent advisory panels: **NetBox impact**, `{creates, updates, unchanged, rejected}` per model or `None` for a model that cannot be compared; and **Forward predict**, a `PredictOutcome` that is `unavailable`, `unsupported` or `answered`. A `None` renders "not measured", never zero. Nothing here is written to `ForwardChangeEvidence`. | `compare_model_rows()` via `PreviewRunner`; `predict_change()` (stubbed, see 1b) |
+| `APPROVED` | The policy's rules are satisfied by non-stale reviews. | An approval bound to **both** `branch_last_change_time` and `before_snapshot_id`. Either moving invalidates it. The approval records **which evidence was on the page when it was given** (see 1a). | none (people) |
+| `APPLIED` | A human or an external system attests the network was changed. This is **not computed**, and the design says so on the page. | `applied_at`, `applied_by`, `applied_ref`. | none |
+| `COLLECTED` | A snapshot exists that is not the baseline and whose per-device collection times all post-date `applied_at` for the devices in scope. The plugin **waits** for one; it has no way to request a collection. | `after_snapshot_id` pinned. Optionally `trigger_snapshot_reachability` completed, when any criterion is reachability-dependent. | `get_snapshots()`, `get_snapshot_metrics()`, `trigger_snapshot_reachability()` |
+| `VERIFIED_PROCEED` | Device-set completeness holds; every blocking acceptance criterion passes at `after_snapshot_id` **at the same `commit_id` used at baseline**; every state-preservation family shows no diff outside the declared blast radius. | The verdict, the per-criterion evidence rows at `phase=after`, the regression-flip list, and both snapshot ids. | `run_nqe_query()`, `run_nqe_diff(query_id, before, after)` |
+| `VERIFIED_HOLD` | Any of the above fails. **A valid result, not an error.** | The same evidence, with the failing criteria named. A HOLD is fixed and re-verified; it is never closed. | same |
+| `CLOSED` | Reachable **only** from `VERIFIED_PROCEED`, **and** the merge must complete without retryable failures. | The branch merges here, through branching's own merge. The change document is frozen. | none |
+| `ABANDONED` | Any open state, one-way. | The branch is discarded, not merged. | none |
+
+Two properties of this machine are the whole point:
+
+**The branch merges at CLOSE, not at APPROVE.** Every generic change
+control tool — `netbox-change-control` included — merges when the humans
+say yes. Here the humans opening the gate is a necessary condition and
+the *after-snapshot* is the sufficient one. The NetBox model becomes
+truth once Forward has seen the network actually be that way. That single
+reordering is what a Forward-backed change control buys, and it is not
+available to a plugin without a network model to consult.
+
+**Baseline before staged, deliberately.** A criterion must be evaluated
+against the network *before* anyone edits NetBox, or a criterion that was
+already failing gets counted as damage the change caused. The
+before-phase evidence exists to make the regression-flip computable:
+`fail -> pass` is a fix, `pass -> fail` is a regression, `fail -> fail`
+is pre-existing and must not block, `pass -> pass` is preserved state.
+Only `pass -> fail` and `pass -> pass`-turned-`fail` block.
+
+### 1a. The machine with predict entirely absent
+
+Predict is not live at Forward, it is license-gated when it does ship, and
+what exists today is limited in scope. The design therefore assumes it is
+absent and treats its arrival as additive. There is no hole to infer:
+`STAGED -> APPROVED` is a documented transition with its own tests.
+
+The verdict is unaffected. It is worth saying twice, because it is the
+claim the product rests on: **the load-bearing evidence is the
+post-change snapshot verification, and that runs on every license tier
+Forward sells.** A customer who will never have predict loses an advisory
+pre-flight panel and loses nothing else. Nothing in `VERIFIED_PROCEED`,
+`VERIFIED_HOLD` or `CLOSED` reads a prediction of any kind.
+
+That separation is structural rather than promised. Predictions are
+written to advisory columns on `ForwardChange` (`predict_status`,
+`predict_reason`, `predict_pre_verdict`, `netbox_impact`) and **never**
+to `ForwardChangeEvidence`. The verify gate reads only
+`ForwardChangeEvidence`. A future contributor cannot make the verdict
+depend on a prediction without first moving it into the evidence table,
+which is a visible, reviewable, migration-shaped act.
+
+What the approver sees, and what their approval therefore means:
+
+| Path taken | Evidence on the approval page | What the approval asserts |
+|---|---|---|
+| `STAGED -> APPROVED` (predict skipped, or unavailable) | The baseline evidence rows (every criterion's before-state, pass or fail), the bound criteria with their pinned `commit_id`s, the device scope, and the `ChangeDiff` explainability summary. | "I have read what this change asserts and what the network looks like now, and I accept the risk of applying it." This is a **weaker** claim than the one below, and the page says so in those terms. |
+| `STAGED -> PREDICTED -> APPROVED`, predict `unavailable` or `unsupported` | The above, plus the NetBox impact counts, plus a panel naming why Forward could not answer. | The same claim. The extra panel narrows the NetBox-side blast radius; it says nothing about the network. The page must not let "we asked and got no answer" read as "we asked and it was fine". |
+| `STAGED -> PREDICTED -> APPROVED`, predict `answered` | The above, plus a Forward pre-verdict against a predicted snapshot. | "...and a model of the network says it should hold." Still advisory: a pre-verdict is a prediction, and the change document must not cite it as evidence of network safety. |
+
+Three consequences that must be built, not assumed:
+
+- The change document's provenance block records **which of these three
+  paths was taken**, so a reader six months later knows what the approver
+  actually had in front of them.
+- A `PREDICTED` state whose outcome is `unavailable` is *not* a failed
+  predict. It advances exactly as a skip does.
+- Approval staleness is unchanged. It is anchored to
+  `branch_last_change_time` and `before_snapshot_id`; a prediction is not
+  an anchor, because re-running one changes nothing an approver relied on.
+
+### 1b. The predict capability: a stub with a real interface
+
+Not a TODO. A named function with a settled signature and return type,
+whose body today is one line. Filling it in must not reshape the state
+machine, any model, or any migration.
+
+```python
+def predict_change(
+    *,
+    source,          # ForwardSource: supplies the client and the network id
+    snapshot_id,     # the pinned baseline snapshot to predict from
+    devices,         # the change scope, as resolved Forward device keys
+    proposal,        # the config-level intent, or None when there is none
+    criteria,        # the bound criteria to score on the predicted snapshot
+) -> PredictOutcome: ...
+
+
+@dataclass(frozen=True)
+class PredictOutcome:
+    status: str                 # "unavailable" | "unsupported" | "answered"
+    reason: str                 # operator-facing sentence; "" only when answered
+    predicted_snapshot_id: str = ""
+    criteria: tuple[PredictedCriterion, ...] = ()   # criterion pk, passed, row_count
+    pre_verdict: str = ""       # "PROCEED" | "HOLD"; "" unless answered
+```
+
+The stub is `return PredictOutcome(status="unavailable", reason=NOT_LIVE)`.
+
+The three statuses exist because the capability has three distinct
+absences, and collapsing them is how a customer ends up believing a
+question was answered:
+
+| Status | When | What the UI shows |
+|---|---|---|
+| `unavailable` | The capability is not live, or this organization's licence does not include it, or the source is not configured for it. | An **informational** panel: "Forward predict: not available." plus the reason sentence. Not an error, not a warning, no red, no retry button. Health status `info`, matching how `health_checks.py` already renders "Data-file maps" when there is simply nothing to say. |
+| `unsupported` | The capability is live and licensed, but this particular change is outside what predict covers today — it is limited in scope, and will stay limited for some time. | An informational panel: "Forward predict: cannot answer this change." plus the reason naming what it could not model. Explicitly **not** a HOLD and explicitly not a pass. |
+| `answered` | A real predicted snapshot and a real pre-verdict. | The pre-verdict, the per-criterion predicted results, and the predicted snapshot id — every one of them labelled advisory, in the same way `change_estimate_kind = "workload_upper_bound"` labels an estimate today. |
+
+**Licence detection follows the existing precedent exactly, including its
+central limitation.** `utilities/license_tier.py` records that the tier is
+**not readable from the Forward API** — there is no endpoint exposing it,
+so the plugin cannot pre-flight against a licence and must not pretend
+to. Detection is after-the-fact recognition of a denial: Forward answers
+`is not permitted for this organization's license tier`, the client
+matches it, records `_record_api_usage("license_tier_denials")`, and
+raises `ForwardLicenseTierError` — a distinct exception documented as "a
+capability limit, not a fault: retrying, re-authenticating or re-running
+the sync cannot clear it".
+
+`predict_change` inherits all of that:
+
+- It catches `ForwardLicenseTierError` and converts it to
+  `PredictOutcome(status="unavailable", reason=license_tier_denial_message(...))`.
+  A licence limit is **never** an exception that reaches the operator as
+  a failure; it is a status with a sentence.
+- It adds exactly one counter, `predict_calls`, to the existing
+  `api_usage_summary()` payload alongside `nqe_query_calls` and
+  `nqe_diff_calls`, so predict volume is budgeted with everything else.
+  `license_tier_denials` already exists and needs nothing.
+- It reuses the facet vocabulary already in `license_tier.py` — NETWORK
+  (`N`, `NP`, `NS`, `NSP`) and SECURITY (`S`, `NS`, `NSP`) — rather than
+  inventing a second one.
+- It does **not** build a predict-to-facet table. `license_tier.py`
+  refuses that for the bundled maps on the grounds that a wrong table
+  sends operators to buy the wrong thing, and predict is a capability
+  nobody here has seen ship. Report the facet Forward's own denial names,
+  and nothing more.
+
+Because the tier cannot be pre-flighted, the first call on a source is
+also the discovery. Cache the outcome per source for the life of the
+process so an unlicensed org is not asked once per change, and never
+persist it — a licence can change, and a stale "not licensed" that
+outlives the purchase is its own support case.
+
+### 2. The verify gate, in order
+
+Ordered so the cheapest refusal comes first, following the release-gate
+ordering rule (`2026-07-28-gate-ordering-preflight.md`).
+
+**No step below reads a prediction of any kind** — not the Forward
+pre-verdict, not the NetBox impact counts. Every input is either a
+pinned snapshot id, an evidence row, or a device fact. This is what makes
+the product whole on a licence tier that will never include predict.
+
+1. **Snapshot distinctness.** `after_snapshot_id != before_snapshot_id`.
+   Verifying against the baseline is the trap that makes a change gate
+   report success forever, and it costs one string comparison to refuse.
+2. **Device-set completeness.** Every device in scope is present in the
+   after-snapshot with collection `result == completed`. A device that
+   failed collection is *absent from the model*, not flagged, so a check
+   over a snapshot missing the one broken device returns zero violations
+   and reads as a pass. This is the memory entry
+   `disabled-in-forward-deletes-from-netbox` restated as a gate: absence
+   is not evidence. HOLD if any scoped device is missing.
+3. **Collection ordering.** Per device, collection time > `applied_at`.
+   Where Forward does not expose a per-device collection time for a
+   device, the gate reports that device as `unproven`, never as passing.
+4. **Acceptance criteria.** Each blocking criterion runs at
+   `after_snapshot_id` at the baseline's `commit_id`. Pinning the commit
+   is not optional: a criterion whose text moved between baseline and
+   verify is a different assertion, and comparing the two answers is
+   meaningless.
+5. **State preservation.** For each state-preservation family,
+   `run_nqe_diff(query_id, before_snapshot_id, after_snapshot_id)`
+   returns the rows Forward itself says moved between the two snapshots.
+   Rows whose key is inside the declared blast radius are expected; rows
+   outside it are the "and nothing else broke" half of the verdict.
+6. **Verdict.** PROCEED only if 1-5 all hold. Anything else is HOLD, with
+   the failing item named by its criterion, not by a generic message.
+
+And one gate after the verdict, at CLOSE: **a partial merge is not a
+close.** forward-netbox already separates a merge's failures into
+retryable (`failed_change_count`) and unsatisfiable destination-rule
+rejections (`skipped_change_count`), and raises `ForwardPartialMergeError`
+rather than completing when retryable failures remain. A change whose
+merge lands partially stays at `VERIFIED_PROCEED` with the branch
+retryable; it does not become `CLOSED`. The operator escape hatch that
+exists there — `accept_reported_failures` — is reachable only by an
+explicit human action and must remain so here.
+
+### 3. Data model
+
+Six new models. Every one of them exists because nothing in
+forward-netbox holds that fact.
+
+| Model | Base | Purpose |
+|---|---|---|
+| `ForwardChange` | `PrimaryModel` | The change. `source` FK to `ForwardSource`; `branch` `OneToOneField` to `netbox_branching.Branch` (`SET_NULL`) plus a denormalized `branch_name`; `state`; `verdict`; `ref`; `title`; `requester`; window bounds; `before_snapshot_id`; `after_snapshot_id`; `applied_at`/`applied_by`/`applied_ref`. Plus four **advisory** columns quarantined from the gate: `predict_status`, `predict_reason`, `predict_pre_verdict`, `netbox_impact`. They ship in the first migration even though predict is stubbed, so its arrival needs no schema change. |
+| `ForwardChangeDevice` | plain `Model` | The scope. FK to `dcim.Device`, plus the resolved Forward device key copied at SCOPED time so the record stays readable if the device is later removed. Unique on `(change, device)`. |
+| `ForwardChangeCriterion` | `NetBoxModel` | One assertion. `family` (acceptance / state-preservation), `expectation`, `blocking`, and the query-identity triple `query_id` / `query_path` / `commit_id` plus `source_sha256`. |
+| `ForwardChangeEvidence` | plain `Model` | One criterion's result at one snapshot. `phase` (before/after), `passed`, `row_count`, `snapshot_id`, `commit_id`, `executed_at`, `duration_ms`, and a bounded schema-only `shape` JSON. Unique on `(criterion, phase, snapshot_id)`. |
+| `ForwardChangeReview` | `NetBoxModel` | One reviewer's decision. Staleness anchored to `branch_change_time` **and** `baseline_snapshot_id`. |
+| `ForwardChangePolicy` / `ForwardChangePolicyRule` | `PrimaryModel` / `NetBoxModel` | Who must approve. Scoped by device role, site or tag — the properties a *network* change has — rather than by NetBox object type. |
+
+#### What it reuses rather than duplicates
+
+This list is the design. Anything on it that gets reimplemented is a bug
+in the plan, not a shortcut.
+
+| Capability | Reused from forward-netbox | Why not duplicate |
+|---|---|---|
+| Forward credentials, base URL, TLS, timeouts | `ForwardSource.parameters`, `encrypt_secret`, `get_masked_parameters()` | A second credential store is a second thing to leak. Forward auth is HTTP Basic on every request — there is no token flow to share — so a second client would mean a second copy of a decrypted password. The change names a `ForwardSource`; it never holds one. |
+| The HTTP client, retry, rate limiting, API accounting | `ForwardClient` via `source.get_client()`, `_record_api_usage`, `api_usage_summary()` | Call-volume accounting is a customer commitment; a second unaccounted client silently breaks it. |
+| Snapshot resolution and listing | `resolve_snapshot_id()`, `get_snapshots()`, `get_latest_processed_snapshot_id()`, `get_latest_collected_snapshot_id()` | `latestCollected` in particular already contains the "every in-scope device was backfilled" logic that took a release to get right. |
+| Snapshot metrics | `get_snapshot_metrics()` | Already the freshness surface. |
+| NQE execution, pagination, async polling, page-streak guards | `run_nqe_query()` | The truncation traps here are known and fixed. Re-deriving them is how you get a silent short read. |
+| Before/after row diff | `run_nqe_diff(query_id, before, after)` | This *is* the state-preservation primitive. It already exists. |
+| NQE query resolution and versioning | `resolve_nqe_query_reference()`, `get_committed_nqe_query()`, `get_nqe_query_history()`, `query_source_sha256()` | Criterion binding is exactly the resolution forward-netbox already does for maps. |
+| Publishing a query to the org library | `has_nqe_library_write_permission()`, `add_org_nqe_query()`, `edit_org_nqe_query()`, `commit_org_nqe_queries()` | Opt-in; see Decision Log. |
+| Device identity: NetBox device <-> Forward device key | `ForwardDeviceIdentity` | The change scope resolves through it and stores nothing authoritative of its own. |
+| Branch creation, staging, diff, merge, conflicts | `netbox_branching` | See "What this is NOT". |
+| "What did this branch change" | `change_explainability_summary()` (generalized to a branch) | Already renders per-model, per-field, per-action counts from `ChangeDiff`. That is the change document's body. |
+| "What would this actually write" | `compare_model_rows()` / `PreviewRunner` | The write firewall and the priming contract took two releases and a hotfix to get right. Its `None` return — "this model was not compared" — is load-bearing and must be carried through, not coerced to zero. |
+| Publishing a criterion query | `publish_builtin_nqe_map_queries()` in `query_binding_resolution.py` | Already stages, skips byte-identical sources, commits once for all changed paths, and re-binds. The `org` repository is the only writable one; `fwd` is read-only. |
+| Blast-radius refusal thresholds | `ForwardDriftPolicy` as the pattern | Its `block_on_row_shrink` / `max_deleted_percent` shape is the right shape for a change's declared blast radius. |
+| Verbatim device configs, before and after | `run_config_backup()` | Already writes per-device config to a git `DataSource` with object-level dulwich. Pointing it at the two pinned snapshots gives a config diff for free. |
+| Diagnostics-safety policy | `record_issue` / `diagnostic_shape` | Evidence rows are support-bundle content. |
+| Runtime validation and health blocks | `validated_runtime.py`, `health_checks.py` patterns | The dependency status belongs on a Health page, not in a log line. |
+
+#### What it explicitly does not reuse, and why
+
+- **`ForwardNQEMap`.** Same three query-identity columns, different
+  contract: a map binds a query to a NetBox model for ingestion and is
+  constrained to `FORWARD_SUPPORTED_MODELS`; a criterion binds a query to
+  an assertion and is constrained to nothing. Sharing the table would put
+  rows in the sync's query registry that the sync must never execute.
+- **`ForwardValidationRun`.** It asserts *query health* — did the query
+  run, did it return rows, did the identity contract hold — and gates the
+  sync. A criterion asserts *network intent*. The two look alike and are
+  not, and conflating them would make a broken query indistinguishable
+  from a broken network.
+- **`ForwardIngestion`.** A change is not a sync run. It shares
+  `before`/`after` snapshot ids and a branch, and nothing else.
+
+### 4. It ships inside forward-netbox
+
+**Decided 2026-09-02: this is not a separate plugin.** It is a feature of
+forward-netbox, shipped in 3.0, opt-in per source.
+
+The alternative was a sibling plugin depending on forward-netbox 3.0, and the
+reason it lost is the reuse table above. Every capability in it -
+`ForwardClient`, `resolve_snapshot_id()`, `run_nqe_diff()`,
+`compare_model_rows()`, `PreviewRunner`, `change_explainability_summary()`,
+`run_config_backup()` - is private API. A separate plugin consuming those
+would couple two independently-versioned packages through internals, which is
+exactly the shape that made the netbox-branching 1.2 move expensive: six
+private `SquashMergeStrategy` members and raw SQL against its tables, each of
+which had to be audited against the new wheel before the runtime could move.
+Choosing that deliberately, against ourselves, would have been repeating a
+mistake we had just finished paying for.
+
+Shipping in-plugin removes the problem rather than managing it. There is no
+published surface to maintain, no version matrix, no `ImproperlyConfigured` on
+a missing dependency, and no registry entry. Direct imports are legitimate
+within one package.
+
+What that costs, stated plainly:
+
+- Six models and an eleven-state machine land in the plugin that writes
+  inventory, so every future forward-netbox release gate carries them.
+- The 45-minute gate is built around delete-path safety this feature does not
+  touch, and it will now run for changes to it.
+- A regression in 3.0 is harder to attribute, because a major runtime
+  migration and a large new feature ship together. The release owner weighed
+  that and chose it.
+
+What that does NOT change: this feature stages into a branch and merges
+through branching like everything else, and it writes nothing to the network.
+The safety argument for separation was about blast radius, and the blast
+radius here is a NetBox branch either way.
+
+### 5. Genuinely new work vs. thin wrappers
+
+Being honest about this is most of the value of the document.
+
+**Thin wrappers — one to three functions each, no new concepts:**
+
+| Work | Wrapping |
+|---|---|
+| Pin a snapshot | `resolve_snapshot_id()` then store the literal id |
+| List candidate snapshots for the collect gate | `get_snapshots()` |
+| Run a criterion | `run_nqe_query(query=..., snapshot_id=..., fetch_all=True)` |
+| Before/after state diff | `run_nqe_diff()` |
+| Bind a criterion to a version | `resolve_nqe_query_reference()` + `query_source_sha256()` |
+| Publish a criterion query | `add_org_nqe_query()` / `commit_org_nqe_queries()` |
+| Branch staging, merge, conflict | zero code |
+| "What would this write to NetBox" | `compare_model_rows()` |
+| Config before/after | `run_config_backup()` at each pinned snapshot |
+| Credentials, retry, rate limit, pagination | zero code |
+| Reachability precompute | `trigger_snapshot_reachability()` |
+
+**Genuinely new — nothing in forward-netbox does any of this:**
+
+- The state machine and its persistence. forward-netbox has run states
+  (`ForwardSyncStatusChoices`, `ForwardMergeAttempt.Status`); it has no
+  change lifecycle, no approval, no attestation.
+- The **expectation vocabulary**: `rows-empty`, `rows-non-empty`,
+  `row-count-equals`, `every-row-field-true`, `row-count-not-increased`.
+  This is the piece that turns an NQE query into an assertion, and there
+  is no equivalent anywhere in the tree.
+- **Fail-closed criterion binding.** `resolve_nqe_query_reference()`
+  resolves; it does not refuse a whole document because one criterion
+  did not. Borrowing `draft_change_acceptance`'s rule — a criterion that
+  cannot bind refuses the draft at draft time, rather than producing a
+  best-effort set that fails later at verify — is new behaviour on top of
+  an existing call.
+- **Evidence rows and the regression-flip comparison.** The four-way
+  `pass/fail` x `before/after` classification, and the rule that
+  `fail -> fail` never blocks.
+- **The state-preservation gate.** The hardest new thing in the design.
+  `run_nqe_diff` supplies the rows; deciding which families to watch and
+  what counts as inside the blast radius is entirely new judgement.
+- **The collect gate** — snapshot distinctness, device-set completeness,
+  per-device collection ordering. Each is cheap and each closes a way of
+  passing a gate without having tested anything.
+- **The change document**, grounded or refused: every claim cites an
+  evidence row from *that* verify attempt, a target with no evidence
+  reads `unproven` and never `pass`, and only a PROCEED is marked
+  verified. This is the deliverable an operator hands to a CAB, and it is
+  the piece with no analogue in either reference.
+- **Two-anchor approval staleness.** `netbox-change-control` invalidates
+  an approval when the branch moves. Here it must also invalidate when
+  the baseline snapshot moves, because an approval given against one
+  view of the network is not an approval of another.
+- **The `predict_change` seam** (section 1b). The interface, the
+  three-status outcome type, the advisory columns and the UI renderings
+  are new work and are built now. The body is one line and stays that way
+  until Forward ships the capability.
+
+**Deliberately not built:** a Forward predict implementation. Not a
+wrapper, because there is nothing to wrap — see the Decision Log.
+
+**New client methods required in forward-netbox** (the only place this
+design pushes work upstream, and it is optional to the first release):
+
+- per-device collection timestamps for a snapshot, for the collect gate.
+  Obtainable today through an NQE query over `snapshotInfo`, which is the
+  preferred route precisely because it needs no new endpoint.
+- a path-search call, if and when reachability evidence is wanted. Same
+  posture as predict: absent today, additive when it arrives.
+
+## Validation
+
+- Unit tests for the state machine: every legal transition, and every
+  illegal one refused by name. Specifically `VERIFIED_HOLD -> CLOSED`
+  must be refused, and there must be a test that says so in its name.
+- **The whole machine, driven end to end with predict absent.** Not a
+  variant of the happy path — the default one. `STAGED -> APPROVED ->
+  APPLIED -> COLLECTED -> VERIFIED_PROCEED -> CLOSED` with
+  `predict_change` returning `unavailable` throughout, asserting a
+  `CLOSED` change and a complete change document.
+- A test that the verify gate reads no predict field, enforced
+  structurally rather than by inspection: assert that
+  `ForwardChangeEvidence` is the only model the gate queries, and that
+  the four advisory columns appear in no gate code path. The separation
+  in section 1a is worth nothing if only a comment holds it.
+- All three `PredictOutcome` statuses rendered: `unavailable`,
+  `unsupported`, `answered` (the last with a fake outcome, since nothing
+  can produce a real one yet). Pin that `unavailable` advances the state
+  exactly as a skip does, and that neither `unavailable` nor
+  `unsupported` renders as a pass or as a HOLD.
+- A licence-denial test: `ForwardLicenseTierError` raised inside
+  `predict_change` becomes `status="unavailable"` with the facet sentence
+  as its reason, and does not propagate. A licence limit reaching a
+  caller as an exception is the bug this test exists to prevent.
+- A test that an approval alone does not open the merge gate — the
+  reference plugin's `test_approved_status_alone_does_not_open_the_gate`,
+  restated for a verdict: `test_approval_without_a_proceed_verdict_does_
+  not_merge`.
+- Collect-gate tests, one per refusal: same snapshot as baseline; a
+  scoped device missing from the after-snapshot; a scoped device present
+  but `result != completed`; a device collected before `applied_at`.
+- Regression-flip tests: all four before/after combinations, pinning
+  that `fail -> fail` does not block and `pass -> fail` does.
+- A **structural** contract test against forward-netbox, in the spirit of
+  `test_preview_runner_satisfies_the_priming_contract`: assert that every
+  dotted path in `required_callables` resolves and that its signature
+  still accepts the keywords we pass. Testing one call is what let the
+  2.8.7 priming gap ship; test the contract.
+- A criterion-binding test that a query path which does not resolve
+  refuses the whole SCOPED transition rather than binding the rest.
+- A no-negative-control test: a criterion that has never failed cannot be
+  marked blocking.
+- Full Django suite on NetBox `4.7.0` with branching `1.2.0b1` in the
+  forward-netbox development stack. **One stack, one run**: concurrent
+  targeted runs corrupt the shared `test_netbox` and the symptoms read as
+  code bugs.
+- Live validation against a real Forward org: one change through the full
+  machine to `CLOSED`, and one deliberately broken change that must reach
+  `VERIFIED_HOLD` and must not be closable. A design that has never
+  produced a HOLD has not been tested.
+
+## Rollback
+
+Nothing to roll back in forward-netbox beyond two edits: remove
+`forward_change_control` from `VALIDATED_PLUGIN_APPS` and revert the
+`change_explainability_summary` signature. The plugin itself is removed
+from `PLUGINS` and its migrations reversed; it owns no NetBox core data
+and holds no `PROTECT` reference to a device, so removing it cannot hold
+anything hostage.
+
+The one piece of state that outlives it: any criterion query published
+into the customer's Forward org NQE library. Publishing is additive and
+opt-in, and the uninstall documentation must name the query paths so an
+operator can remove them. Do not delete them automatically — that is a
+write to the customer's Forward library performed during an uninstall,
+which is the worst possible time to be writing anything.
+
+## Decision Log
+
+- **The branch merges at CLOSE, not at APPROVE.** The alternative is the
+  `netbox-change-control` model, where approval opens the merge and the
+  network is never consulted. Refused: that plugin already exists, does
+  it well, and adding Forward to it would buy one more pre-merge check.
+  The reordering is the product.
+
+- **A HOLD is a valid outcome, never an error.** Taken directly from the
+  Skyforge flow. A gate that can only pass or crash gets disabled the
+  first time it is inconvenient.
+
+- **BASELINE precedes STAGE.** The tempting order is stage-then-baseline,
+  because staging is the part that feels like work. Refused: without a
+  before-phase measurement, a criterion that was already failing is
+  indistinguishable from damage the change caused, and the plugin's first
+  false accusation is the last time anyone trusts it.
+
+- **The criterion query text is pinned by `commit_id`, not by path.**
+  A query resolved by path at verify time may not be the query that ran
+  at baseline. forward-netbox already learned this for sync maps
+  (`optin-pinned-query-staleness`); a change gate has strictly less
+  excuse.
+
+- **Forward predict is stubbed, deliberately, and the rest is built.**
+  This is a decision, not an oversight, and it should not be re-opened as
+  one. Three reasons, each sufficient on its own: the predict workflow is
+  **not live** at Forward; it is **licence-gated**, so a meaningful share
+  of customers will never have it; and what exists today is **limited in
+  scope**, so even a licensed customer would find changes it cannot
+  model. Building the product on it would have made the whole thing
+  undeliverable for most of the people it is for.
+
+  What is built instead is the seam: `predict_change()` with a settled
+  signature, a three-status `PredictOutcome`, four advisory columns in
+  the first migration, and three defined UI renderings. The body returns
+  `unavailable`. Filling it in later changes one function and no schema,
+  no state, and no gate.
+
+  The alternative was to make prediction the centre of the design, on the
+  strength of what the Skyforge reference achieves with a transient
+  Forward network and a digital-twin snapshot. Refused twice over: the
+  capability is not there to call, and reaching it that way would mean
+  creating and destroying networks in the customer's Forward org — a far
+  larger break of the read-only contract than publishing a query, with a
+  cost model nobody has measured.
+
+  The verdict was placed on the post-change snapshot for exactly this
+  reason. Verification needs a snapshot and an NQE query, which is the
+  capability every tier already has and the one this plugin's parent has
+  been exercising in production for a year. A design whose load-bearing
+  claim rested on predict would have been a demo; this one is a product
+  on every tier, and better on some.
+
+- **A licence limit reads as "not licensed", never as an error.**
+  `ForwardLicenseTierError` already exists and is documented as "a
+  capability limit, not a fault: retrying, re-authenticating or re-running
+  the sync cannot clear it". `predict_change` catches it and returns a
+  status, so it never reaches an operator as a red banner or a retry
+  button. Health renders it `info`, the status `health_checks.py` already
+  uses for a thing there is simply nothing to say about.
+
+  Corollary, and the part most likely to be got wrong later: **the tier
+  cannot be pre-flighted.** `license_tier.py` records that Forward
+  exposes no endpoint for it, and warns in its own header against adding
+  a "check the tier first" gate on the assumption one exists. Predict
+  availability is discovered the same way everything else is — by asking
+  and reading the refusal.
+
+- **A criterion must have failed at least once before it can block.**
+  A query returning zero rows because it is wrong is indistinguishable
+  from one returning zero because the network is healthy. Skyforge's
+  `break` variant is the same idea. Without a negative control, a green
+  check is not evidence — and a wall of green checks that prove nothing
+  is worse than no checks, because people act on it.
+
+- **Publishing a criterion query to the Forward org library is opt-in and
+  separately permissioned.** It is the only Forward write in the design
+  and it breaks the read-only property in `architecture-flow.md`. It is
+  proposed at all because `run_nqe_diff` requires a `query_id` —
+  inline query text cannot be diffed — so state preservation is
+  unavailable without a published query. Gated on
+  `has_nqe_library_write_permission()`, additive only, never deleting,
+  and the plugin works without it at the cost of the state-preservation
+  gate. Note also that the ADP org token is Basic auth and that a
+  customer's own login often lacks library write permission, so this must
+  degrade rather than fail.
+
+- **The dependency fails closed, inverting the registry's default.**
+  Reusing the registry's shape without its degradation behaviour is
+  deliberate and is the single most likely thing for a future reader to
+  "fix" back. It is called out in `integration.py`'s docstring for that
+  reason.
+
+- **`required_callables`, not just `required_models`.** Content types
+  prove a table exists. This plugin consumes functions.
+
+- **No dependency on any of the five optional plugins.** Not a
+  preference: they cannot be installed on 4.7. A design that assumed
+  Validity for golden-config comparison would have been undeliverable on
+  its own runtime.
+
+- **Policies are the piece to cut if scope must shrink.** The
+  approval-policy machinery is the least Forward-shaped part of the
+  design and the part `netbox-change-control` already does better. A
+  first release could ship with a single site-wide "N approvals"
+  rule and lose almost nothing that Forward provides.
+
+## Open
+
+These are the risks and the unanswered questions. They are stated as
+plainly as possible because a change-control tool that overstates its own
+certainty is worse than none.
+
+### 1. A prediction is not a guarantee, even the one we have
+
+`compare_model_rows` predicts what a *sync* would write to *NetBox*. It
+says nothing about what a device will do when configured. Three further
+limits, each of which matters to a change gate specifically:
+
+**It predicts staging, not merging.** It answers what would be written
+into a branch. It cannot answer which of those writes the merge will
+reject — `ProtectedError`, unique-constraint clashes, NetBox validation
+rules. Those surface only at merge time, which in this machine is
+`CLOSE`, the last step. A change can therefore pass PREDICT, pass VERIFY,
+and still fail to close. That is the correct ordering (the network is
+already correct at that point; only the NetBox record is behind) but the
+UI must not present PREDICT as a merge guarantee.
+
+**It has no delete slot.** The four counts are creates, updates,
+unchanged and rejected. `PreviewRunner._delete_by_coalesce` always
+returns `False`, and a model whose batch contains a delete-classified row
+declines the whole model rather than mis-bucketing it. So a change that
+principally *removes* things is the change the NetBox-side prediction is
+least able to describe.
+
+**A `None` is not a zero.** A model with no comparison returns `None`,
+and the drift report's estate-level `in_sync` stays `None` while any
+model is uncompared. The recorded incident is exact: a model with 45
+Forward rows reached an empty-row shortcut, took the confident zero, and
+displayed `In sync: Yes` — the only affirmative claim on the page, made
+by the one branch that never looked at NetBox. This plugin inherits that
+rule verbatim: unmeasured renders as unmeasured.
+
+And its write firewall is weaker than it looks. `PreviewRunner` is a
+duck-typed stand-in for `ForwardSyncRunner` — a null object, not a
+transaction, not a permission, not a read-only connection. It prevents
+writes by supplying stubs for every method the classification calls. A
+method it fails to stub is a real write on a code path that thought it
+was previewing. This is not hypothetical: 2.8.7 shipped a preview that
+never primed its caches, and 2.8.8 was a hotfix for a priming call
+reaching a method `PreviewRunner` lacked, which killed the whole
+dependency preview on optional-plugin deployments. The mitigation there
+was to test the contract structurally rather than test one model, and
+this plugin must inherit that test, not just that class.
+
+### 2. A passing snapshot is not a passing network
+
+Forward models what it collected. A device whose collection failed is
+**absent from the model**, not flagged: every bundled query filters to
+`snapshotInfo.result == completed`, and a device disabled in Forward
+vanishes from `network.devices` and the REST inventory entirely. So
+"the criterion found no violations" and "the violating device was not in
+the snapshot" produce identical output.
+
+This is why device-set completeness is gate step 2 rather than a nice
+report. It is also why the change document says `unproven` for a device
+it cannot account for, and why `unproven` must never render as green.
+
+### 3. Snapshot timing is not change timing
+
+A snapshot whose creation time post-dates `applied_at` may still contain
+a device that was collected before the change reached it. Forward exposes
+per-device collection information and the gate compares per device — but
+where that information is unavailable for a device, the honest answer is
+`unproven`, and the temptation to fall back to the snapshot-level
+timestamp must be resisted. A snapshot-level comparison is exactly the
+kind of nearly-right check that produces a confident wrong verdict.
+
+### 4. netbox-branching 1.2.0b1 is a beta with no upgrade path
+
+Its own release notes say not to use it in production and that no upgrade
+path to a later release is provided. A branch provisioned under 1.2.0b1
+may need re-provisioning under 1.2.0 final.
+
+Design consequence, and it is a real one: a change branch must be
+**short-lived and reconstructible**. The durable state of a change is its
+criteria, its scope and its evidence — all of which live in this plugin's
+own tables. The branch is a staging artifact. A design that treated a
+long-open change branch as the record would lose changes on the beta-to-
+final move.
+
+### 5. What still needs a human, and always will
+
+- Deciding the change is worth making.
+- Writing the criteria. The plugin can refuse a criterion that does not
+  bind and a criterion that has never failed; it cannot tell whether a
+  criterion asserts the thing the operator meant.
+- Performing the apply.
+- Attesting that the apply happened, and when. `APPLIED` is the one
+  transition in the machine with no evidence behind it at all, and the
+  page must say so rather than dress it up.
+- Interpreting a HOLD. The gate names the failing criterion; it does not
+  know whether the right response is to roll back, to fix forward, or to
+  correct the criterion.
+
+### 6. NQE call volume
+
+A change with ten criteria costs ten executions at baseline, ten at
+verify, one diff per state-preservation family, plus snapshot polling
+during collect — call it twenty-five to forty executions per change,
+before retries. Forward engineering has already raised unnecessary NQE
+runs as a concern. Every path must be accounted through
+`api_usage_summary()`, the per-change execution estimate must be shown on
+the form before the change is saved, and the collect poll must back off
+rather than run at the sync's polling cadence.
+
+### 7. The state-preservation denominator is undecided
+
+"Nothing else changed" over a whole network is unbounded. The gate needs
+a finite list of state families to watch — routing adjacencies, ACL
+hit-ability, interface states, reachability between named sentinel pairs
+— and a rule for what counts as inside the declared blast radius.
+
+**Open question: which families, scoped how, and who decides — the
+policy, the change author, or a shipped default?** A shipped default that
+is too broad makes every change HOLD and gets the gate turned off; one
+that is too narrow makes the "and nothing else broke" claim a lie. This
+is the single largest piece of unbuilt judgement in the design and it
+should be settled with a customer before any code is written.
+
+### 8. Attestation is the weakest joint
+
+**Open question: who attests `APPLIED`, and what stops a change being
+verified against a snapshot that predates the apply on some devices?**
+The collect gate's ordering check is the mitigation, and it is only as
+good as Forward's per-device collection times. If those turn out to be
+coarse or absent for some platforms, the honest fallback is to require a
+minimum interval between `applied_at` and the after-snapshot and to say
+plainly that it is a heuristic — not to compute a verdict as though the
+question were settled.
+
+### 9. Smaller items
+
+- The `ForwardChangePolicy` scoping vocabulary (role / site / tag) is
+  asserted, not validated against a customer. It may want the NetBox
+  `ConditionSet` treatment the reference plugin uses instead.
+- Config before/after via `run_config_backup` gives a git diff of
+  verbatim device configs, which is genuinely valuable and has no
+  consumer on 4.7 now that Validity cannot install. Whether to render
+  that diff in the change document ourselves, or wait for Validity to
+  raise its ceiling, is unresolved.
+- Nothing here has been costed against a real estate. The
+  device-analysis refresh and the drift preview both turned out to be far
+  more expensive than expected on a large deployment (842s to compare
+  357,864 interface rows, before priming); a verify over a large scope
+  deserves the same suspicion before it is promised as interactive.

--- a/docs/03_Plans/active/2026-09-02-netbox-4.7-runtime.md
+++ b/docs/03_Plans/active/2026-09-02-netbox-4.7-runtime.md
@@ -1,0 +1,148 @@
+# Run on NetBox 4.7 with netbox-branching 1.2
+
+## Goal
+
+Move the supported runtime from NetBox 4.6 + Branching 1.1 to NetBox 4.7 +
+Branching 1.2, as a clean break. 2.9.x remains the 4.6 lane.
+
+## Constraints
+
+- **The two versions move together or not at all.** Branching 1.2 requires
+  NetBox 4.7, and 1.1 cannot run on it. There is no straddle to build.
+- `netboxlabs-netbox-branching` **1.2.0 final shipped 2026-09-02**, before 3.0
+  was tagged, so the release pins it rather than the beta. That removes the
+  whole caveat this plan was written around: no "do not use in production", no
+  missing upgrade path, and no forced branch re-provisioning later.
+
+  1.2.0 declares `requires-python >=3.12` where the beta did not. The
+  dependency is scoped `python = ">=3.12,<3.15"` rather than raising the
+  project floor - the same shape the optional plugins already use - because
+  NetBox 4.7 requires 3.12+ anyway, so this states a fact about the dependency
+  instead of working around one.
+
+  The series checks still accept `1.2.0b1`. Anyone who installed the beta in
+  the days before final shipped must not be refused by a check that only ever
+  saw release strings.
+- The plugin has **no version-conditional code**. `series_matches()` takes one
+  series string and every engine fails closed outside it. That is why this is a
+  literal change rather than a compatibility layer, and it must stay that way -
+  a second supported series would need a different mechanism, not an `or`.
+- `series_matches("1.2.0b1", "1.2")` is already true by prefix, so the beta
+  needs no special casing.
+
+## Touched Surfaces
+
+- Runtime gates: `forward_netbox/__init__.py` (`min_version`, `max_version`,
+  `required_series`), `utilities/validated_runtime.py`,
+  `utilities/apply_engine_decision.py`, `utilities/merge_set_based.py`.
+- Pins: `pyproject.toml`, `constraints.txt`, `scripts/tested_runtime.py`,
+  `scripts/validate_sbom.py`, `scripts/validate_installed_artifact.py`,
+  `scripts/check_release_authorization.py`.
+- Stack: `development/Dockerfile`, `development/docker-compose.yml`,
+  `development/configuration/plugins.py`, `tasks.py`.
+
+## Approach
+
+Change the series literals, then let the suite find the rest. The four gates
+are `"4.6"`/`"1.1"` string constants in known places; the interesting work is
+what 4.7 changes underneath them, which is tracked in the 3.0 release plan.
+
+### The optional plugins are out, and this is where they come back
+
+`netbox-dlm`, `netbox-cisco-aci`, `netbox-peering-manager`, `netbox-routing`
+and `netbox-validity` all declare a `max_version` in the 4.6 series. NetBox
+refuses to start with a plugin outside its declared range, so on 4.7 they
+cannot be installed at all - this is not a decision we made about them.
+
+`VALIDATED_PLUGIN_APPS` is an exact-match set that fails **closed and
+silently**: an app in `PLUGINS` but not in the set disables COPY/SQL, the
+set-based merge and the fast baseline with no error, turning a first sync from
+minutes into hours. So the set had to shrink with the image, or 4.7 would have
+been quietly ten times slower.
+
+To restore one when its upstream raises its ceiling, add the app label to
+`VALIDATED_PLUGIN_APPS` and its versions to `VALIDATED_OPTIONAL_DISTRIBUTIONS`.
+The values as of the 4.6 lane, for exactly that purpose:
+
+| Distribution | App label | Validated versions |
+|---|---|---|
+| `netbox-cisco-aci` | `netbox_cisco_aci` | `0.4.0` |
+| `netbox-dlm` | `netbox_dlm` | `0.4.1`, `0.5.0`, `0.6.0`, `0.7.0`, `0.8.0`, `0.9.1` |
+| `netbox-peering-manager` | `netbox_peering_manager` | `0.3.0` |
+| `netbox-routing` | `netbox_routing` | `0.4.3` |
+| `netbox-validity` | `validity` | `3.5.2` |
+
+Nothing else about the integrations changes: the registry, models, sync paths
+and their tests all remain, and the registry already reports an absent plugin
+honestly. Their tests skip on this runtime rather than fail, which is a real
+loss of coverage and is why the 4.6 lane stays alive.
+
+## Validation
+
+Measured on NetBox `4.7.0` with Branching `1.2.0b1`:
+
+- Plugin loads; `manage.py check` clean; migrations apply and
+  `makemigrations --check` reports no drift (migration `0053` included).
+- Full Django suite: **2589 tests, OK, 158 skipped**. Harness suite: **382 OK**.
+- **Each fast path shown ON, not merely not-erroring** - a silently disabled
+  path passes every test it has, so this is asked directly rather than
+  inferred:
+
+  | Path | Enabled | Reason |
+  | --- | --- | --- |
+  | COPY/SQL | yes | `supported_exact_runtime_tuple` |
+  | Set-based merge | yes | `supported_exact_runtime_tuple` |
+  | Fast baseline | yes | `supported_runtime_tuple` |
+
+  Field-contract drift: none. Installed plugin set matches the validated set
+  exactly (`forward_netbox`, `netbox_branching`).
+
+- **Live Forward validation**, which no unit test covers: the plugin's own
+  `ForwardClient` authenticated against production Forward, listed 102
+  networks, resolved the configured network, fetched 100 snapshots, and ran an
+  async NQE query against its newest processed snapshot returning **5228
+  device rows** - the submit, poll and paginate path end to end. The network
+  and snapshot ids are deliberately not recorded here: they identify a
+  customer's estate, and the counts are what make this evidence.
+
+- Still to run in the release gate: the artifact leg and the upgrade leg. The
+  upgrade leg needs the bumped version, so it runs as part of `invoke ci`
+  rather than standalone.
+
+## Rollback
+
+Revert this branch. The runtime returns to 4.6 + 1.1; nothing persisted
+changes, because no migration is involved.
+
+## Decision Log
+
+- **A clean break, not dual support.** Branching forces it, and the codebase
+  has no mechanism for two series. Faking one with prefix matching would defeat
+  the fail-closed property every engine relies on.
+- **The validated set shrank rather than being bypassed.** Leaving the optional
+  apps listed would claim a runtime nobody can assemble; removing the check
+  would give up the protection that makes the fast paths safe.
+- **`allow-prereleases` is scoped to Branching only.** It is not a global
+  resolver setting, so no other dependency can drift onto a pre-release.
+
+## Open
+
+- The upgrade leg crosses a NetBox minor, and the harness already supports
+  that: `artifact_upgrade_test` builds the from-side image on
+  `from_netbox_version` and the to-side on the target, against one database,
+  and its own comment says it exercises the NetBox upgrade as well as the
+  plugin upgrade. An earlier note here claimed it swapped only the plugin;
+  that was wrong.
+
+  What is untested rather than undesigned: 2.9.2 on NetBox 4.6.5 upgrading to
+  3.0 on 4.7.0 in one hop, which is where NetBox's own `ltree_paths` and
+  `denormalization_triggers` migrations run against rows this plugin wrote.
+  Two things to watch when it runs - 4.7's upgrade script also runs
+  `rebuild_config_context_cache`, which the harness does not (the cache falls
+  back to on-demand rendering, so this should be benign but is unverified);
+  and `UPGRADE_FROM_NETBOX_VER` is still `v4.6.5`, the floor for releases
+  before 2.6.7, which is a longer jump than any customer will make.
+- `scripts/tested_runtime.py` still declares no Branching version; the harness
+  reads it from `constraints.txt` by regex, and the escaped `Branching 1\.2\.0b1`
+  form in `check_release_authorization.py` has no pin check because
+  `_check_tested_runtime_pins_agree` only matches versions starting `4.`.

--- a/docs/03_Plans/active/2026-09-02-release-3.0.0.md
+++ b/docs/03_Plans/active/2026-09-02-release-3.0.0.md
@@ -1,0 +1,98 @@
+# Release 3.0.0
+
+## Goal
+
+Ship the NetBox 4.7 runtime as a major version. 3.0 supports NetBox `4.7.x`
+with `netbox-branching` `1.2.x` and nothing else; `2.9.x` remains the
+maintained 4.6 lane.
+
+## Constraints
+
+- **The two versions move together.** Branching `1.2` requires NetBox `4.7`
+  and `1.1` cannot run on it, so there is no straddle and no dual-support
+  matrix. This is why the release is major rather than minor.
+- **`netbox-branching` `1.2.0` final shipped 2026-09-02**, before this was
+  tagged, and is what the release pins. The plan was written expecting the
+  beta: no production use, no upgrade path, forced branch re-provisioning.
+  None of that applies now. 1.2.0 declares `requires-python >=3.12`, scoped on
+  the dependency rather than raised on the project, because NetBox 4.7 needs
+  3.12+ anyway.
+- **No optional plugin can be installed on 4.7.** Each of the five declares a
+  `max_version` in the 4.6 series and NetBox refuses to start outside a
+  plugin's declared range.
+- The plugin still has no version-conditional code, and must not grow any: the
+  fail-closed property every engine relies on depends on one supported series.
+
+## Touched Surfaces
+
+Already merged: #340 (stale-deferral sweep), #341 (the runtime move), #343
+(change control). This release adds only the version bump and its
+authorization record.
+
+3.0 therefore carries two things, not one: the NetBox 4.7 runtime, and a new
+change-control feature. That was a deliberate call - a major-version migration
+and a large feature in the same gate makes a regression harder to attribute,
+and it was weighed and accepted rather than drifted into.
+
+## Approach
+
+The engineering is done and on `main`. What remains is the release itself:
+
+1. `python3 scripts/release.py 3.0.0 --write --publish --auto-finish`, with
+   `--support` and `--requirements` set to the 4.7 text. Those flags exist
+   because the compatibility table reuses the previous row verbatim, which
+   would have published 3.0 as requiring the version it refuses to load on.
+2. The gate runs the artifact leg and the upgrade leg. The upgrade leg is the
+   interesting one: it stands 2.9.x up on NetBox 4.6.5 and upgrades to 3.0 on
+   4.7.0 against one database, so NetBox's own `ltree_paths` and
+   `denormalization_triggers` migrations run over rows this plugin wrote.
+3. Four-commit lineage, then bridge and anchor.
+
+## Validation
+
+Measured on `4.7.0` + `1.2.0` before the gate:
+
+- Full Django suite **2648 OK** (158 skipped); harness **382 OK**.
+- Migrations apply; `makemigrations --check` clean.
+- **All three fast paths ENABLED** with zero field-contract drift. Asked
+  directly, because a silently disabled path passes every test it has.
+- **Live Forward**: the plugin's own client authenticated against production,
+  listed 102 networks, resolved the configured network, fetched 100 snapshots
+  and ran an async NQE query on its newest processed snapshot returning 5228
+  device rows. Identifiers are omitted on purpose - they name a customer's
+  estate, and the counts carry the evidence.
+
+## Rollback
+
+`2.9.x` is the supported path for anyone on NetBox 4.6, and nothing about 3.0
+changes it. A deployment that upgraded and wants to go back must restore its
+database: NetBox 4.7's own migrations are not reversible in practice, so this
+is a NetBox rollback rather than a plugin one. That is the honest answer and
+belongs in the release notes.
+
+## Decision Log
+
+- **Major, not minor.** Dropping a supported NetBox series and changing the
+  branching requirement are both breaking. Calling it 2.10 would have implied
+  an upgrade that silently fails to load.
+- **Shipped against 1.2.0 final.** The plan originally accepted the beta to
+  make 4.7 available now, with a 3.0.1 to move the pin later. 1.2.0 landed
+  first, the running gate was stopped, and the pin moved - so there is no
+  3.0.1 owed and no re-provisioning to warn about.
+- **The optional integrations were not removed.** Their code, models, sync
+  paths and registry entries all remain and report an absent plugin honestly.
+  Only the validated runtime set changed, so restoring one is a data edit in
+  one file.
+- **Coverage loss is stated, not hidden.** 158 skips are real: the optional
+  adapters are exercised on the 2.9.x lane until an upstream raises its
+  ceiling.
+
+## Open
+
+- The upgrade leg has not run yet; it needs the bumped version and so runs
+  inside the gate.
+- `UPGRADE_FROM_NETBOX_VER` is still `v4.6.5`, the floor for releases before
+  2.6.7 - a longer hop than any customer will make. Correct but worth revisiting.
+- NetBox 4.7's upgrade script also runs `rebuild_config_context_cache`, which
+  the harness does not. The cache falls back to on-demand rendering, so this
+  should be benign, and it is unverified.

--- a/forward_netbox/__init__.py
+++ b/forward_netbox/__init__.py
@@ -7,8 +7,8 @@ class NetboxForwardConfig(PluginConfig):
     description = "Sync Forward data into NetBox using built-in NQE queries."
     version = "2.9.2"
     base_url = "forward"
-    min_version = "4.6.5"
-    max_version = "4.6.99"
+    min_version = "4.7.0"
+    max_version = "4.7.99"
 
     def ready(self):
         super().ready()
@@ -31,7 +31,7 @@ def _check_runtime_dependencies():
     # loading at all — the same hard block `max_version` imposed for NetBox
     # patches. Behaviour we actually depend on is checked per engine against the
     # live runtime, not inferred from a version string.
-    required_series = "1.1"
+    required_series = "1.2"
     label = "netbox_branching"
 
     try:

--- a/forward_netbox/change_control/__init__.py
+++ b/forward_netbox/change_control/__init__.py
@@ -1,0 +1,12 @@
+# Change control: a Forward-backed gate around a NetBox branch.
+#
+# The one structural idea here is that the branch merges at CLOSE, not at
+# APPROVE. Human approval is a necessary condition; the sufficient one is a
+# post-change Forward snapshot showing the network is actually the way the
+# branch says it is. Every generic change-control tool merges when the humans
+# say yes, and cannot do otherwise, because it has no network model to consult.
+#
+# This ships inside forward_netbox rather than as a sibling plugin because
+# every capability it needs - the client, snapshot resolution, run_nqe_diff,
+# compare_model_rows, PreviewRunner - is private API. See
+# `docs/03_Plans/active/2026-09-02-forward-change-control-concept.md`.

--- a/forward_netbox/change_control/choices.py
+++ b/forward_netbox/change_control/choices.py
@@ -1,0 +1,136 @@
+# The workflow vocabulary. Deliberately the terms already used in the field
+# rather than invented ones, because a HOLD that is a VALID RESULT rather than
+# an error is the property most home-grown change gates get wrong, and naming
+# it the same way everywhere is most of what stops that.
+from django.utils.translation import gettext_lazy as _
+from utilities.choices import ChoiceSet
+
+
+class ForwardChangeStateChoices(ChoiceSet):
+    """Eleven states, ten of them mandatory.
+
+    `PREDICTED` is the optional one: `STAGED -> APPROVED` is a first-class
+    transition, not a degradation. Forward's predict workflow is not live, is
+    licence-gated when it ships, and is limited in scope today, so the machine
+    is designed to be correct without it and to treat its arrival as additive.
+    """
+
+    DRAFT = "draft"
+    SCOPED = "scoped"
+    BASELINED = "baselined"
+    STAGED = "staged"
+    PREDICTED = "predicted"
+    APPROVED = "approved"
+    APPLIED = "applied"
+    COLLECTED = "collected"
+    VERIFIED_PROCEED = "verified-proceed"
+    VERIFIED_HOLD = "verified-hold"
+    CLOSED = "closed"
+    ABANDONED = "abandoned"
+
+    CHOICES = [
+        (DRAFT, _("Draft"), "gray"),
+        (SCOPED, _("Scoped"), "gray"),
+        (BASELINED, _("Baselined"), "cyan"),
+        (STAGED, _("Staged"), "cyan"),
+        (PREDICTED, _("Predicted"), "blue"),
+        (APPROVED, _("Approved"), "blue"),
+        (APPLIED, _("Applied"), "purple"),
+        (COLLECTED, _("Collected"), "purple"),
+        (VERIFIED_PROCEED, _("Verified - proceed"), "green"),
+        (VERIFIED_HOLD, _("Verified - hold"), "orange"),
+        (CLOSED, _("Closed"), "green"),
+        (ABANDONED, _("Abandoned"), "red"),
+    ]
+
+    # A hold is not terminal and is never closed: it is fixed and re-verified.
+    # Only PROCEED reaches CLOSED.
+    TERMINAL = frozenset({CLOSED, ABANDONED})
+    OPEN = frozenset(
+        {
+            DRAFT,
+            SCOPED,
+            BASELINED,
+            STAGED,
+            PREDICTED,
+            APPROVED,
+            APPLIED,
+            COLLECTED,
+            VERIFIED_PROCEED,
+            VERIFIED_HOLD,
+        }
+    )
+
+
+class ForwardChangeVerdictChoices(ChoiceSet):
+    """The verify gate's answer. `HOLD` is a result, not a failure to answer."""
+
+    PROCEED = "proceed"
+    HOLD = "hold"
+
+    CHOICES = [
+        (PROCEED, _("Proceed"), "green"),
+        (HOLD, _("Hold"), "orange"),
+    ]
+
+
+class ForwardCriterionFamilyChoices(ChoiceSet):
+    """What a criterion is for.
+
+    ACCEPTANCE asserts the change achieved its intent. STATE_PRESERVATION
+    asserts nothing else moved - the denominator for that is a genuinely open
+    question, recorded in the plan, and is why the family is a field rather
+    than an assumption.
+    """
+
+    ACCEPTANCE = "acceptance"
+    STATE_PRESERVATION = "state-preservation"
+
+    CHOICES = [
+        (ACCEPTANCE, _("Acceptance"), "blue"),
+        (STATE_PRESERVATION, _("State preservation"), "purple"),
+    ]
+
+
+class ForwardCriterionExpectationChoices(ChoiceSet):
+    """How a criterion's rows are turned into pass or fail."""
+
+    NO_ROWS = "no-rows"
+    SOME_ROWS = "some-rows"
+    NO_DIFF = "no-diff"
+
+    CHOICES = [
+        (NO_ROWS, _("No rows"), "green"),
+        (SOME_ROWS, _("At least one row"), "blue"),
+        (NO_DIFF, _("No change from baseline"), "purple"),
+    ]
+
+
+class ForwardEvidencePhaseChoices(ChoiceSet):
+    """Evidence is recorded at two pinned snapshots, never at "now"."""
+
+    BEFORE = "before"
+    AFTER = "after"
+
+    CHOICES = [
+        (BEFORE, _("Before")),
+        (AFTER, _("After")),
+    ]
+
+
+class ForwardReviewPhaseChoices(ChoiceSet):
+    """Which gate a review opens.
+
+    PRE approves the plan: the branch and the baseline evidence. POST approves
+    the CLOSURE, after verification, which is where the branch actually
+    merges - the consequential act, and the reason a machine verdict alone is
+    not enough to reach it.
+    """
+
+    PRE = "pre"
+    POST = "post"
+
+    CHOICES = [
+        (PRE, _("Pre-change"), "blue"),
+        (POST, _("Post-change"), "green"),
+    ]

--- a/forward_netbox/change_control/criteria.py
+++ b/forward_netbox/change_control/criteria.py
@@ -1,0 +1,106 @@
+# Binding a criterion to a committed query version, and evaluating it.
+#
+# Binding is the gate that makes a verdict mean anything. An unbound criterion
+# is evaluated against whatever its query says at the time, so the assertion
+# could move under the change it is judging - and the before/after comparison
+# would silently compare two different questions.
+from dataclasses import dataclass
+
+from ..utilities.query_execution_contract import query_source_sha256
+from .choices import ForwardCriterionExpectationChoices as Expectation
+
+
+@dataclass(frozen=True)
+class BindResult:
+    bound: bool
+    query_id: str = ""
+    commit_id: str = ""
+    source_sha256: str = ""
+    error: str = ""
+
+
+def bind_criterion(criterion, client) -> BindResult:
+    """Resolve a criterion's query path to a concrete id at a concrete commit.
+
+    Reuses `resolve_nqe_query_reference`, which is the same resolution the sync
+    already performs for NQE maps. A criterion is not a map - it binds a query
+    to an ASSERTION rather than to a NetBox model, and is constrained to no
+    model list - but the resolution is identical and duplicating it would mean
+    two places to get commit pinning wrong.
+    """
+    if not criterion.query_path:
+        return BindResult(False, error="The criterion has no query path to bind.")
+    try:
+        resolved = client.resolve_nqe_query_reference(
+            repository="org",
+            query_path=criterion.query_path,
+            commit_id=criterion.commit_id or None,
+        )
+    except Exception as exc:  # noqa: BLE001 - surfaced to the operator verbatim
+        return BindResult(False, error=f"{type(exc).__name__}: {exc}")
+
+    query_id = str(resolved.get("queryId") or resolved.get("query_id") or "").strip()
+    commit_id = str(resolved.get("commitId") or resolved.get("commit_id") or "").strip()
+    if not query_id or not commit_id:
+        return BindResult(
+            False,
+            error=(
+                "Forward resolved the path but returned no query id and commit "
+                "pair, so the criterion cannot be pinned to a version."
+            ),
+        )
+    return BindResult(
+        bound=True,
+        query_id=query_id,
+        commit_id=commit_id,
+        source_sha256=query_source_sha256(resolved.get("source")),
+    )
+
+
+def evaluate_expectation(expectation: str, rows, baseline_rows=None) -> bool:
+    """Turn rows into pass or fail.
+
+    Deliberately three narrow rules rather than an expression language. A
+    criterion an operator cannot predict the meaning of is a criterion they
+    will stop trusting, and every rule here fits in a sentence on the page.
+    """
+    count = len(rows or ())
+    if expectation == Expectation.NO_ROWS:
+        return count == 0
+    if expectation == Expectation.SOME_ROWS:
+        return count > 0
+    if expectation == Expectation.NO_DIFF:
+        # Compared against the baseline's rows rather than against zero: a
+        # query that legitimately returns rows in both phases preserves state
+        # as long as the SET has not moved.
+        return _row_key_set(rows) == _row_key_set(baseline_rows)
+    raise ValueError(f"unknown expectation {expectation!r}")
+
+
+def _row_key_set(rows) -> frozenset:
+    """A comparable, order-independent view of a result set.
+
+    Values are hashed into the key rather than kept, because evidence is
+    support-bundle content and a diff must not become a place customer data
+    accumulates.
+    """
+    keyed = set()
+    for row in rows or ():
+        if isinstance(row, dict):
+            keyed.add(tuple(sorted((str(k), str(v)) for k, v in row.items())))
+        else:
+            keyed.add((("value", str(row)),))
+    return frozenset(keyed)
+
+
+def result_shape(rows) -> dict:
+    """Schema identifiers only - never values.
+
+    The same rule ingestion-issue diagnosis follows: key names are schema, and
+    payload values are the customer's.
+    """
+    keys = set()
+    for row in rows or ():
+        if isinstance(row, dict):
+            keys.update(str(k) for k in row)
+    return {"columns": sorted(keys), "row_count": len(rows or ())}

--- a/forward_netbox/change_control/evidence.py
+++ b/forward_netbox/change_control/evidence.py
@@ -1,0 +1,167 @@
+# Turning two snapshots of criterion results into a verdict.
+#
+# The regression-flip comparison is the whole reason evidence is recorded at a
+# baseline as well as after the change. Without a before-phase row, a criterion
+# that was ALREADY failing gets counted as damage this change caused, and the
+# gate blocks a change that fixed nothing and broke nothing.
+from dataclasses import dataclass
+
+from .choices import ForwardChangeVerdictChoices
+from .choices import ForwardCriterionFamilyChoices
+
+
+# What a before/after pair means. Only two of the four block, and saying so in
+# one table is clearer than four branches in the gate.
+FIX = "fix"
+REGRESSION = "regression"
+PRE_EXISTING = "pre-existing"
+PRESERVED = "preserved"
+
+_FLIP = {
+    (False, True): FIX,
+    (True, False): REGRESSION,
+    (False, False): PRE_EXISTING,
+    (True, True): PRESERVED,
+}
+
+# State preservation blocks only on a regression: a criterion that was already
+# failing is pre-existing and this change neither caused it nor was asked to
+# fix it.
+BLOCKING_FLIPS = frozenset({REGRESSION})
+
+# Acceptance is a different question and needs a different rule. It asserts the
+# change ACHIEVED ITS INTENT, so what matters is the after state on its own:
+# `fail -> fail` means the change did not work, and letting that through
+# because "it was already failing" would verify a change that accomplished
+# nothing. The before phase is still recorded, because it is what distinguishes
+# "did not work" from "broke something".
+ACCEPTANCE_BLOCKING_FLIPS = frozenset({REGRESSION, PRE_EXISTING})
+
+
+@dataclass(frozen=True)
+class CriterionOutcome:
+    """One criterion across both phases."""
+
+    criterion: object
+    before_passed: bool | None
+    after_passed: bool | None
+    flip: str
+    blocking: bool
+
+    @property
+    def blocks(self) -> bool:
+        if not self.blocking:
+            return False
+        return self.flip in self.blocking_flips
+
+    @property
+    def blocking_flips(self) -> frozenset:
+        """Which flips block, which depends on what the criterion asserts."""
+        from .choices import ForwardCriterionFamilyChoices
+
+        family = getattr(self.criterion, "family", None)
+        if family == ForwardCriterionFamilyChoices.ACCEPTANCE:
+            return ACCEPTANCE_BLOCKING_FLIPS
+        return BLOCKING_FLIPS
+
+    @property
+    def block_reason(self) -> str:
+        """Why it blocks, in the operator's terms rather than the flip's."""
+        if not self.blocks:
+            return ""
+        if self.flip == REGRESSION:
+            return "passed at the baseline and fails now: this change regressed it"
+        return "still fails: the change did not achieve what it asserted"
+
+
+def classify_flip(before_passed: bool | None, after_passed: bool | None) -> str:
+    """The before/after pair, named.
+
+    A missing phase is NOT coerced to a pass or a fail. "Not measured" is a
+    third answer and it must reach the verdict as one, because a criterion
+    nobody evaluated is not a criterion that passed - that coercion is exactly
+    how an empty comparison once read as a successful one.
+    """
+    if before_passed is None or after_passed is None:
+        return ""
+    return _FLIP[(bool(before_passed), bool(after_passed))]
+
+
+def criterion_outcomes(change) -> list[CriterionOutcome]:
+    """Pair up each criterion's before and after evidence."""
+    from ..models import ForwardChangeEvidence
+    from .choices import ForwardEvidencePhaseChoices as Phase
+
+    criteria = list(change.criteria.all())
+    if not criteria:
+        # Nothing to pair, so nothing to fetch. The caller turns this into an
+        # honest HOLD rather than an empty PROCEED.
+        return []
+
+    rows = ForwardChangeEvidence.objects.filter(criterion__change=change)
+    by_criterion: dict[int, dict[str, bool]] = {}
+    for row in rows:
+        by_criterion.setdefault(row.criterion_id, {})[row.phase] = row.passed
+
+    outcomes = []
+    for criterion in criteria:
+        phases = by_criterion.get(criterion.pk, {})
+        before = phases.get(Phase.BEFORE)
+        after = phases.get(Phase.AFTER)
+        outcomes.append(
+            CriterionOutcome(
+                criterion=criterion,
+                before_passed=before,
+                after_passed=after,
+                flip=classify_flip(before, after),
+                blocking=criterion.blocking,
+            )
+        )
+    return outcomes
+
+
+def compute_verdict(change) -> tuple[str, list[str]]:
+    """PROCEED or HOLD, and the reasons for a HOLD.
+
+    A HOLD is a valid result. It is returned with its reasons, not raised, and
+    the workflow keeps it open for a fix and a re-verify rather than closing
+    it.
+    """
+    outcomes = criterion_outcomes(change)
+    reasons = []
+
+    if not outcomes:
+        return ForwardChangeVerdictChoices.HOLD, [
+            "No criteria were evaluated, so there is nothing to verify against."
+        ]
+
+    unmeasured = [o for o in outcomes if o.blocking and not o.flip]
+    for outcome in unmeasured:
+        missing = "before" if outcome.before_passed is None else "after"
+        reasons.append(
+            f"'{outcome.criterion.name}' has no {missing} evidence, so it was "
+            f"not measured. That is not the same as passing."
+        )
+
+    for outcome in outcomes:
+        if outcome.blocks:
+            reasons.append(f"'{outcome.criterion.name}' {outcome.block_reason}.")
+
+    moved = [
+        o
+        for o in outcomes
+        if o.criterion.family == ForwardCriterionFamilyChoices.STATE_PRESERVATION
+        and o.flip == REGRESSION
+    ]
+    if moved:
+        reasons.append(
+            f"{len(moved)} state-preservation criterion(s) moved, so something "
+            f"outside the change's declared scope is no longer as it was."
+        )
+
+    verdict = (
+        ForwardChangeVerdictChoices.HOLD
+        if reasons
+        else ForwardChangeVerdictChoices.PROCEED
+    )
+    return verdict, reasons

--- a/forward_netbox/change_control/gates.py
+++ b/forward_netbox/change_control/gates.py
@@ -1,0 +1,164 @@
+# The two gates that need Forward: collect and verify.
+#
+# The single most important thing in this file is device-set completeness, and
+# it is step one rather than a report at the end. A device that failed
+# collection is ABSENT from the Forward model rather than flagged in it, so
+# "no violations found" and "the broken device was not in the snapshot" are
+# indistinguishable from the rows alone. That is the same shape as a customer's
+# 552 "uncovered" devices: absence reads as health unless something asks.
+from dataclasses import dataclass
+from dataclasses import field
+
+from .choices import ForwardChangeVerdictChoices
+from .evidence import compute_verdict
+from .evidence import criterion_outcomes
+from .evidence import FIX
+from .evidence import REGRESSION
+
+
+@dataclass(frozen=True)
+class GateResult:
+    passed: bool
+    reasons: tuple[str, ...] = ()
+    context: dict = field(default_factory=dict)
+
+    def __bool__(self):
+        return self.passed
+
+
+def device_set_complete(change, observed_device_keys) -> GateResult:
+    """Every in-scope device must appear in the snapshot being verified.
+
+    Refuses rather than warns. A verdict computed over a snapshot that is
+    missing some of the devices the change touched is not a weaker verdict, it
+    is a different question answered confidently.
+    """
+    scoped = {
+        d.forward_device_key: d for d in change.devices.all() if d.forward_device_key
+    }
+    observed = {str(k) for k in (observed_device_keys or ())}
+    missing = sorted(set(scoped) - observed)
+    if not missing:
+        return GateResult(True, context={"devices": len(scoped)})
+
+    names = ", ".join(str(scoped[k].device) for k in missing[:5])
+    return GateResult(
+        False,
+        (
+            f"{len(missing)} of {len(scoped)} in-scope device(s) are absent "
+            f"from this snapshot, so nothing can be concluded about them: "
+            f"{names}. A device that failed collection is missing from the "
+            f"model rather than marked failed, which is why this refuses "
+            f"instead of reporting a pass over a smaller set.",
+        ),
+        {"missing": missing, "scoped": len(scoped)},
+    )
+
+
+def collection_postdates_apply(change, device_collection_times) -> GateResult:
+    """The snapshot must have seen the network AFTER the change was applied.
+
+    The weakest joint in the workflow, and it is named as such rather than
+    presented as a computed fact: `applied_at` is a human attestation, and
+    per-device collection times are only as precise as Forward's collectors
+    report. When a device has no collection time this HOLDS rather than
+    assuming the snapshot is new enough.
+    """
+    if not change.applied_at:
+        return GateResult(False, ("No apply time was attested.",))
+
+    scoped = {
+        d.forward_device_key: d for d in change.devices.all() if d.forward_device_key
+    }
+    stale, unknown = [], []
+    for key, scoped_device in scoped.items():
+        collected = (device_collection_times or {}).get(key)
+        if collected is None:
+            unknown.append(str(scoped_device.device))
+        elif collected < change.applied_at:
+            stale.append(str(scoped_device.device))
+
+    reasons = []
+    if stale:
+        reasons.append(
+            f"{len(stale)} device(s) were last collected before the change was "
+            f"applied, so this snapshot cannot show its effect: "
+            f"{', '.join(sorted(stale)[:5])}."
+        )
+    if unknown:
+        reasons.append(
+            f"{len(unknown)} device(s) report no collection time, so whether "
+            f"this snapshot postdates the change is unknown for them: "
+            f"{', '.join(sorted(unknown)[:5])}. Unknown is held, not assumed."
+        )
+    return GateResult(not reasons, tuple(reasons))
+
+
+def attestation_looks_premature(change, outcomes) -> GateResult:
+    """Forward sees no difference at all between the two snapshots.
+
+    `APPLIED` is a human claim and cannot be proved from here. But its most
+    common failure - verifying before the change actually landed, or attesting
+    a change that silently did nothing - IS detectable: if every criterion
+    reports an identical result before and after, the network Forward observed
+    did not move.
+
+    That is not proof the change was never applied. A change can legitimately
+    leave every criterion where it was. So this is a HOLD with a question
+    rather than an accusation, and it names the alternative explanation.
+    """
+    measured = [o for o in outcomes if o.flip]
+    if not measured:
+        return GateResult(True)
+
+    moved = [o for o in measured if o.flip in (FIX, REGRESSION)]
+    if moved:
+        return GateResult(True, context={"moved": len(moved)})
+
+    return GateResult(
+        False,
+        (
+            "Every criterion returned the same result before and after, so "
+            "Forward observed no change to the network. Either the change has "
+            "not landed yet and this was verified too early, or it landed and "
+            "changed nothing the criteria ask about. The apply time is "
+            "attested rather than measured, so this cannot be settled from "
+            "here - check the snapshot is newer than the work.",
+        ),
+        {"measured": len(measured)},
+    )
+
+
+def verify(change, *, observed_device_keys=None, device_collection_times=None):
+    """The verify gate, in order. Returns (verdict, reasons).
+
+    Order matters: completeness and timing come before the criteria, because a
+    criterion evaluated over an incomplete or stale snapshot produces a
+    confident wrong answer rather than an obviously missing one.
+    """
+    reasons: list[str] = []
+
+    completeness = device_set_complete(change, observed_device_keys)
+    if not completeness:
+        reasons.extend(completeness.reasons)
+
+    timing = collection_postdates_apply(change, device_collection_times)
+    if not timing:
+        reasons.extend(timing.reasons)
+
+    if reasons:
+        # Short-circuit deliberately: the criteria are not evaluated at all,
+        # so no evidence row is written that would later read as a real
+        # measurement of this snapshot.
+        return ForwardChangeVerdictChoices.HOLD, reasons
+
+    verdict, criteria_reasons = compute_verdict(change)
+
+    # Asked after the criteria, not before: it needs their outcomes, and a
+    # change that already has a real reason to hold does not need this one too.
+    if not criteria_reasons:
+        premature = attestation_looks_premature(change, criterion_outcomes(change))
+        if not premature:
+            return ForwardChangeVerdictChoices.HOLD, list(premature.reasons)
+
+    return verdict, criteria_reasons

--- a/forward_netbox/change_control/policy.py
+++ b/forward_netbox/change_control/policy.py
@@ -1,0 +1,111 @@
+# How many approvals a change needs, and from whom.
+#
+# One helper for both gates so the count rule lives in one place. Before this,
+# ForwardChangePolicy was inert: nothing read `min_approvals`, nothing
+# evaluated a rule, and `_approved()` accepted any single approving row.
+from .choices import ForwardReviewPhaseChoices
+
+# With no policy matching a change, require one approval at each gate rather
+# than none. An unmatched change must not be EASIER to merge than a matched
+# one - that is the failure mode where adding a policy to cover one estate
+# quietly leaves everything else ungoverned.
+DEFAULT_REQUIRED_APPROVALS = 1
+
+
+def applicable_policies(change):
+    """Enabled policies whose rules match the change's device scope.
+
+    Scoped by device role, site or tag - the properties a NETWORK change has -
+    rather than by NetBox object type, because that is how an operator reasons
+    about which changes need which approvers.
+
+    A policy with NO rules applies to every change. A policy with rules
+    applies when any rule matches any device in scope.
+    """
+    from ..models import ForwardChangePolicy
+
+    devices = [scoped.device for scoped in change.devices.select_related("device")]
+    matched = []
+    for policy in ForwardChangePolicy.objects.filter(enabled=True).prefetch_related(
+        "rules"
+    ):
+        rules = list(policy.rules.all())
+        if not rules:
+            matched.append(policy)
+            continue
+        if any(_rule_matches(rule, devices) for rule in rules):
+            matched.append(policy)
+    return matched
+
+
+def _rule_matches(rule, devices) -> bool:
+    for device in devices:
+        if rule.device_role_id and device.role_id != rule.device_role_id:
+            continue
+        if rule.site_id and device.site_id != rule.site_id:
+            continue
+        if rule.tag_slug and not device.tags.filter(slug=rule.tag_slug).exists():
+            continue
+        # Every populated facet matched, and an empty facet is a wildcard.
+        if rule.device_role_id or rule.site_id or rule.tag_slug:
+            return True
+    return False
+
+
+def required_approvals(change, phase: str) -> int:
+    """How many distinct approvals this gate needs.
+
+    The STRICTEST applicable policy wins. Overlapping policies are a way to
+    add requirements, never to relax them - otherwise attaching a permissive
+    policy would weaken a stricter one that already covered the estate.
+    """
+    policies = applicable_policies(change)
+    if not policies:
+        return DEFAULT_REQUIRED_APPROVALS
+    field = (
+        "min_pre_approvals"
+        if phase == ForwardReviewPhaseChoices.PRE
+        else "min_post_approvals"
+    )
+    return max(
+        getattr(policy, field, DEFAULT_REQUIRED_APPROVALS) for policy in policies
+    )
+
+
+def distinct_approvers(change, phase: str) -> set:
+    """Reviewer ids that approved this gate, excluding the requester.
+
+    Self-approval is not an approval. The requester is excluded here rather
+    than at write time so an existing review cannot become valid by someone
+    later being made the requester.
+    """
+    approved = change.reviews.filter(phase=phase, approved=True)
+    return {
+        review.reviewer_id
+        for review in approved
+        if review.reviewer_id and review.reviewer_id != change.requester_id
+    }
+
+
+def stale_approvals(change, phase: str) -> list:
+    """Approvals whose anchors no longer match the change.
+
+    An approval that survives an edit to the thing it approved is not an
+    approval. The two gates anchor to different evidence because they are
+    approving different things.
+    """
+    stale = []
+    for review in change.reviews.filter(phase=phase, approved=True):
+        if phase == ForwardReviewPhaseChoices.PRE:
+            moved = (
+                review.branch_change_time != change.branch_last_change_time
+                or review.baseline_snapshot_id != change.before_snapshot_id
+            )
+        else:
+            moved = (
+                review.after_snapshot_id != change.after_snapshot_id
+                or review.verdict != change.verdict
+            )
+        if moved:
+            stale.append(review)
+    return stale

--- a/forward_netbox/change_control/predict.py
+++ b/forward_netbox/change_control/predict.py
@@ -1,0 +1,128 @@
+# Forward's predict workflow, stubbed behind a real interface.
+#
+# Three facts shape this. Predict is not live at Forward. It is licence-gated
+# when it does ship. What exists today is limited in scope. So the workflow is
+# designed to be correct with predict entirely absent, and its arrival is
+# additive: filling this in must not reshape the state machine or any model,
+# which is why the advisory columns ship in the first migration.
+#
+# Availability is discovered by ASKING and reading the refusal, never by
+# consulting a licence tier first. `utilities/license_tier.py` says the tier is
+# not readable from the API and warns against exactly that gate; a wrong
+# capability table sends an operator to buy the wrong thing.
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PredictOutcome:
+    """What a prediction attempt produced. Never an exception at the caller.
+
+    `status` is one of:
+      unavailable  - not live, or this licence does not include it
+      unsupported  - live, but it cannot answer THIS question yet
+      answered     - a real prediction
+
+    The two non-answers are distinct on purpose. "We could not ask" and "we
+    asked and it could not say" mean different things to someone deciding
+    whether to approve, and collapsing them into one greyed-out panel is how a
+    reader concludes the change was checked when it was not.
+    """
+
+    status: str
+    reason: str = ""
+    predicted_snapshot_id: str = ""
+    criteria: tuple = ()
+    pre_verdict: str = ""
+
+    UNAVAILABLE = "unavailable"
+    UNSUPPORTED = "unsupported"
+    ANSWERED = "answered"
+
+    @property
+    def is_answer(self) -> bool:
+        return self.status == self.ANSWERED
+
+
+def predict_change(
+    *,
+    source,
+    snapshot_id: str,
+    devices=(),
+    proposal=None,
+    criteria=(),
+) -> PredictOutcome:
+    """Ask Forward what this change would do. Today: always `unavailable`.
+
+    The signature is the contract, not a placeholder. When predict ships, this
+    body calls it and returns `answered`; everything above it - the state
+    machine, the models, the page - already handles all three statuses.
+
+    It returns rather than raises even for a licence denial, because a
+    capability the customer has not bought is not a fault. `ForwardLicenseTierError`
+    is already documented that way, and the caller must not have to know.
+    """
+    if not predict_enabled(source):
+        return PredictOutcome(
+            status=PredictOutcome.UNAVAILABLE,
+            reason=(
+                "Predict is not enabled on this Forward source, so it was not "
+                "asked. The change can still be approved and verified: the "
+                "verdict is computed from the post-change snapshot, which "
+                "does not depend on predict."
+            ),
+        )
+
+    # Enabled, and still unavailable: the workflow is not generally available
+    # at Forward yet. Kept distinct from the not-enabled case above because an
+    # operator who turned it ON deserves to know the answer is upstream, not a
+    # setting they missed.
+    return PredictOutcome(
+        status=PredictOutcome.UNAVAILABLE,
+        reason=(
+            "Predict is enabled for this source but Forward's predict "
+            "workflow is not available on this deployment - it is licensed "
+            "separately and is limited in scope today. Nothing is wrong with "
+            "the change, and the verdict does not depend on predict."
+        ),
+    )
+
+
+def predict_enabled(source) -> bool:
+    """Whether this source opts in to asking Forward to predict.
+
+    Off unless a deployment says otherwise, and read with `.get(..., False)`
+    so an existing source with no such key is off without a data migration.
+    Fails closed for the same reason every other capability here does: a
+    missing setting must never read as permission.
+    """
+    parameters = getattr(source, "parameters", None) or {}
+    return bool(parameters.get("enable_predict", False))
+
+
+def render_predict_panel(outcome: PredictOutcome) -> dict:
+    """How the page shows it. Informational, never an error.
+
+    A non-answer renders as a plain panel with a sentence. No red, no retry
+    button, no empty result table that reads as "nothing found" - because
+    "we asked and got no answer" must never render as "we asked and it was
+    fine".
+    """
+    if outcome.is_answer:
+        return {
+            "level": "info",
+            "heading": "Forward prediction",
+            "message": outcome.reason or "Forward predicted this change.",
+            "verdict": outcome.pre_verdict,
+            "advisory": True,
+        }
+    heading = {
+        PredictOutcome.UNAVAILABLE: "Forward prediction not available",
+        PredictOutcome.UNSUPPORTED: "Forward cannot predict this change yet",
+    }.get(outcome.status, "Forward prediction")
+    return {
+        "level": "info",
+        "heading": heading,
+        "message": outcome.reason,
+        "verdict": "",
+        "advisory": True,
+    }

--- a/forward_netbox/change_control/state_machine.py
+++ b/forward_netbox/change_control/state_machine.py
@@ -1,0 +1,246 @@
+# The transitions, and what each one demands before it will happen.
+#
+# Pure functions over the database: no request object, no client, no job. A
+# transition returns a TransitionResult rather than raising, because "this
+# cannot proceed yet, and here is precisely what is missing" is the normal
+# case in a change workflow, not an error condition.
+from dataclasses import dataclass
+from dataclasses import field
+
+from .choices import ForwardChangeStateChoices as State
+from .choices import ForwardReviewPhaseChoices
+
+
+@dataclass(frozen=True)
+class TransitionResult:
+    """Whether a transition may happen, and what is missing when it may not.
+
+    `blockers` are operator-facing sentences. They are the entire value of this
+    module: a gate that says "not ready" without saying what is missing gets
+    turned off.
+    """
+
+    allowed: bool
+    blockers: tuple[str, ...] = ()
+    context: dict = field(default_factory=dict)
+
+    def __bool__(self):
+        return self.allowed
+
+
+# Every legal edge. PREDICTED has two ways in and two ways out because it is
+# optional; STAGED -> APPROVED is a first-class transition, not a fallback.
+#
+# VERIFIED_HOLD deliberately has no edge to CLOSED. A hold is fixed and
+# re-verified - it goes back to APPLIED to await a fresh collection, or is
+# abandoned. Closing a hold is the exact mistake this vocabulary exists to
+# prevent, so the graph refuses to express it.
+TRANSITIONS: dict[str, frozenset[str]] = {
+    State.DRAFT: frozenset({State.SCOPED, State.ABANDONED}),
+    State.SCOPED: frozenset({State.BASELINED, State.DRAFT, State.ABANDONED}),
+    State.BASELINED: frozenset({State.STAGED, State.SCOPED, State.ABANDONED}),
+    State.STAGED: frozenset({State.PREDICTED, State.APPROVED, State.ABANDONED}),
+    State.PREDICTED: frozenset({State.APPROVED, State.STAGED, State.ABANDONED}),
+    State.APPROVED: frozenset({State.APPLIED, State.STAGED, State.ABANDONED}),
+    State.APPLIED: frozenset({State.COLLECTED, State.ABANDONED}),
+    State.COLLECTED: frozenset(
+        {State.VERIFIED_PROCEED, State.VERIFIED_HOLD, State.ABANDONED}
+    ),
+    State.VERIFIED_PROCEED: frozenset({State.CLOSED, State.ABANDONED}),
+    State.VERIFIED_HOLD: frozenset({State.APPLIED, State.ABANDONED}),
+    State.CLOSED: frozenset(),
+    State.ABANDONED: frozenset(),
+}
+
+
+def legal_transition(current: str, target: str) -> bool:
+    """Whether the graph has this edge at all, before any evidence is read."""
+    return target in TRANSITIONS.get(current, frozenset())
+
+
+def available_transitions(current: str) -> tuple[str, ...]:
+    return tuple(sorted(TRANSITIONS.get(current, frozenset())))
+
+
+def check_transition(change, target: str) -> TransitionResult:
+    """Whether `change` may move to `target`, and what is missing if not."""
+    current = change.state
+    if current == target:
+        return TransitionResult(False, (f"The change is already {target}.",))
+    if not legal_transition(current, target):
+        return TransitionResult(
+            False,
+            (
+                f"{current} does not lead to {target}. "
+                f"From here: {', '.join(available_transitions(current)) or 'nowhere'}.",
+            ),
+        )
+    checker = _ENTRY_CHECKS.get(target)
+    if checker is None:
+        return TransitionResult(True)
+    return checker(change)
+
+
+def _scoped(change) -> TransitionResult:
+    """Every device must be one Forward knows, and something must be asserted."""
+    blockers = []
+    devices = list(change.devices.all())
+    if not devices:
+        blockers.append("Add at least one device to the change's scope.")
+    unresolved = [d for d in devices if not d.forward_device_key]
+    if unresolved:
+        names = ", ".join(sorted(str(d.device) for d in unresolved[:5]))
+        blockers.append(
+            f"{len(unresolved)} device(s) have no Forward identity for this "
+            f"source, so Forward cannot be asked about them: {names}."
+        )
+    if not change.criteria.filter(blocking=True).exists():
+        blockers.append(
+            "Add at least one blocking acceptance criterion. A change with "
+            "nothing asserted cannot be verified, only asserted to have "
+            "happened."
+        )
+    return TransitionResult(not blockers, tuple(blockers))
+
+
+def _baselined(change) -> TransitionResult:
+    """Criteria must BIND before anything is measured against them.
+
+    Binding is resolution to a concrete `query_id` at a concrete `commit_id`.
+    An unbound criterion would be measured against whatever the query happens
+    to say later, which is how a moving assertion silently passes.
+    """
+    blockers = []
+    unbound = [c for c in change.criteria.all() if not (c.query_id and c.commit_id)]
+    if unbound:
+        names = ", ".join(sorted(c.name for c in unbound[:5]))
+        blockers.append(
+            f"{len(unbound)} criterion(s) are not bound to a committed query "
+            f"version: {names}."
+        )
+    if not change.before_snapshot_id:
+        blockers.append(
+            "Pin a baseline snapshot. A selector is not enough: the id is "
+            "recorded literally so the same snapshot is used at verify."
+        )
+    return TransitionResult(not blockers, tuple(blockers))
+
+
+def _staged(change) -> TransitionResult:
+    blockers = []
+    if not change.branch_id:
+        blockers.append("Create the NetBox branch holding the intended changes.")
+    if not change.before_snapshot_id:
+        blockers.append("Baseline the change before staging it.")
+    return TransitionResult(not blockers, tuple(blockers))
+
+
+def _approval_gate(change, phase, what) -> TransitionResult:
+    """Shared by both gates: enough distinct, non-stale, non-self approvals.
+
+    `what` names the evidence the reviewer signed off on, so the blocker reads
+    as an instruction rather than a code.
+    """
+    from .policy import distinct_approvers
+    from .policy import required_approvals
+    from .policy import stale_approvals
+
+    blockers = []
+    needed = required_approvals(change, phase)
+    approvers = distinct_approvers(change, phase)
+    stale = stale_approvals(change, phase)
+
+    if len(approvers) < needed:
+        shortfall = needed - len(approvers)
+        blockers.append(
+            f"{shortfall} more approval(s) needed ({len(approvers)} of "
+            f"{needed}). Approvals are counted per distinct reviewer, and the "
+            f"requester's own does not count."
+        )
+    if stale:
+        blockers.append(
+            f"{len(stale)} approval(s) are stale: {what} moved after they were "
+            f"given, so they approved a different change."
+        )
+    return TransitionResult(not blockers, tuple(blockers))
+
+
+def _approved(change) -> TransitionResult:
+    """The PRE gate: approving the plan, anchored to the branch and baseline.
+
+    Both anchors, because a change can be re-baselined without touching the
+    branch and the reviewer would have seen evidence from the old snapshot.
+    """
+    return _approval_gate(
+        change,
+        ForwardReviewPhaseChoices.PRE,
+        "the branch or the baseline",
+    )
+
+
+def _applied(change) -> TransitionResult:
+    """The one transition with no computed evidence, and it says so.
+
+    Nothing here can observe that a network engineer pushed configuration. The
+    attestation is a human claim, recorded as one, and the page must not
+    present it as a measurement.
+    """
+    blockers = []
+    if not change.applied_at:
+        blockers.append(
+            "Record when the change was applied. Nothing here can observe "
+            "that, so it is attested rather than measured."
+        )
+    if not change.applied_by:
+        blockers.append("Record who attested the change was applied.")
+    return TransitionResult(not blockers, tuple(blockers))
+
+
+def _collected(change) -> TransitionResult:
+    """A snapshot that is not the baseline and post-dates the apply.
+
+    The plugin waits; it has no way to ask Forward to collect. The
+    per-device timing check is the gate's real content and lives in
+    `gates.py`, because it needs the client.
+    """
+    blockers = []
+    if not change.after_snapshot_id:
+        blockers.append("No post-change snapshot has been pinned yet.")
+    elif change.after_snapshot_id == change.before_snapshot_id:
+        blockers.append(
+            "The post-change snapshot is the baseline. Verifying a change "
+            "against the snapshot taken before it would pass by construction."
+        )
+    return TransitionResult(not blockers, tuple(blockers))
+
+
+def _closed(change) -> TransitionResult:
+    """The POST gate. CLOSE is where the branch merges, so it gets its own.
+
+    A PROCEED verdict opens this gate; it does not walk through it. The
+    machine says the network looks right, and a human still decides to merge -
+    which is the consequential, irreversible half.
+
+    Anchored to the after-snapshot and the verdict: re-verifying against a
+    newer snapshot, or the verdict changing, voids a closure sign-off.
+    """
+    if change.state != State.VERIFIED_PROCEED:
+        return TransitionResult(
+            False, ("Only a change that verified PROCEED may be closed.",)
+        )
+    return _approval_gate(
+        change,
+        ForwardReviewPhaseChoices.POST,
+        "the post-change snapshot or the verdict",
+    )
+
+
+_ENTRY_CHECKS = {
+    State.SCOPED: _scoped,
+    State.BASELINED: _baselined,
+    State.STAGED: _staged,
+    State.APPROVED: _approved,
+    State.APPLIED: _applied,
+    State.COLLECTED: _collected,
+    State.CLOSED: _closed,
+}

--- a/forward_netbox/forms.py
+++ b/forward_netbox/forms.py
@@ -23,6 +23,9 @@ from .choices import ForwardSourceStatusChoices
 from .choices import ForwardSyncStatusChoices
 from .exceptions import ForwardConnectivityError
 from .exceptions import ForwardSyncError
+from .models import ForwardChange
+from .models import ForwardChangePolicy
+from .models import ForwardChangePolicyRule
 from .models import ForwardDriftPolicy
 from .models import ForwardNQEMap
 from .models import ForwardSource
@@ -522,6 +525,17 @@ class ForwardSourceForm(NetBoxModelForm):
                 "is transferred. On, the fetch is the whole collected estate."
             ),
         )
+        self.fields["enable_predict"] = forms.BooleanField(
+            required=False,
+            label="Ask Forward to predict change-control changes",
+            help_text=(
+                "Off by default. Forward's predict workflow is not generally "
+                "available, is licensed separately, and is limited in scope "
+                "today, so change control never asks unless this is on. The "
+                "verdict does not depend on it either way: it is computed "
+                "from the post-change snapshot, which every licence tier has."
+            ),
+        )
         self.fields["sync_device_tags"] = FlexibleMultipleChoiceField(
             required=False,
             choices=(),
@@ -651,6 +665,7 @@ class ForwardSourceForm(NetBoxModelForm):
         self.fields["config_backup_include_unmanaged"].initial = bool(
             parameters.get("config_backup_include_unmanaged")
         )
+        self.fields["enable_predict"].initial = bool(parameters.get("enable_predict"))
         self.fields["sync_generic_endpoints"].initial = bool(
             parameters.get("sync_generic_endpoints")
         )
@@ -729,6 +744,7 @@ class ForwardSourceForm(NetBoxModelForm):
                     "scope_endpoints_by_include_tags",
                     "config_backup_data_source",
                     "config_backup_include_unmanaged",
+                    "enable_predict",
                     name="Parameters",
                 )
             )
@@ -765,6 +781,7 @@ class ForwardSourceForm(NetBoxModelForm):
                     "scope_endpoints_by_include_tags",
                     "config_backup_data_source",
                     "config_backup_include_unmanaged",
+                    "enable_predict",
                     name="Parameters",
                 )
             )
@@ -925,6 +942,7 @@ class ForwardSourceForm(NetBoxModelForm):
             "config_backup_include_unmanaged": bool(
                 cleaned.get("config_backup_include_unmanaged")
             ),
+            "enable_predict": bool(cleaned.get("enable_predict")),
             "sync_generic_endpoints": bool(cleaned.get("sync_generic_endpoints")),
             "scope_endpoints_by_include_tags": bool(
                 cleaned.get("scope_endpoints_by_include_tags")
@@ -2065,3 +2083,75 @@ class ForwardDriftPolicyBulkEditForm(NetBoxModelBulkEditForm):
     enabled = forms.NullBooleanField(required=False, label="Enabled")
     model = ForwardDriftPolicy
     fields = ("enabled",)
+
+
+class ForwardChangeForm(NetBoxModelForm):
+    """Author a change. State is NOT editable here.
+
+    The workflow moves through `state_machine.check_transition`, which refuses
+    with reasons; a form field would let an operator type their way past a gate
+    that exists to stop exactly that.
+    """
+
+    class Meta:
+        model = ForwardChange
+        fields = (
+            "ref",
+            "title",
+            "source",
+            "requester",
+            "window_start",
+            "window_end",
+            "description",
+            "comments",
+            "tags",
+        )
+
+    fieldsets = (
+        FieldSet("ref", "title", "source", "requester", name="Change"),
+        FieldSet("window_start", "window_end", name="Window"),
+        FieldSet("description", "comments", "tags", name="Notes"),
+    )
+
+
+class ForwardChangePolicyForm(NetBoxModelForm):
+    class Meta:
+        model = ForwardChangePolicy
+        fields = (
+            "name",
+            "enabled",
+            "min_pre_approvals",
+            "min_post_approvals",
+            "description",
+            "comments",
+            "tags",
+        )
+
+    fieldsets = (
+        FieldSet(
+            "name",
+            "enabled",
+            "min_pre_approvals",
+            "min_post_approvals",
+            name="Policy",
+        ),
+        FieldSet("description", "comments", "tags", name="Notes"),
+    )
+
+
+class ForwardChangePolicyRuleForm(NetBoxModelForm):
+    """Scope a policy to the properties a network change has.
+
+    Without this the rules were creatable only through the ORM, so the scoping
+    that decides how many approvals a change needs was unreachable to the
+    operator who has to live with it.
+    """
+
+    class Meta:
+        model = ForwardChangePolicyRule
+        fields = ("policy", "device_role", "site", "tag_slug")
+
+    fieldsets = (
+        FieldSet("policy", name="Policy"),
+        FieldSet("device_role", "site", "tag_slug", name="Scope"),
+    )

--- a/forward_netbox/jobs.py
+++ b/forward_netbox/jobs.py
@@ -8,7 +8,7 @@ from core.exceptions import SyncError
 from core.models import Job
 from django.db import IntegrityError
 from django.db import transaction
-from django_pglocks import advisory_lock
+from django_pg_utils import advisory_lock
 from netbox.constants import ADVISORY_LOCK_KEYS
 from netbox.context_managers import event_tracking
 from netbox.jobs import JobRunner

--- a/forward_netbox/migrations/0042_device_generic_relation_guards.py
+++ b/forward_netbox/migrations/0042_device_generic_relation_guards.py
@@ -81,15 +81,45 @@ def install_guards(apps, schema_editor):
 
 
 def remove_guards(apps, schema_editor):
-    connection = schema_editor.connection
-    existing_tables = set(connection.introspection.table_names())
-    with connection.cursor() as cursor:
-        for table_name, _content_type_column, _object_id_column in GUARDS:
-            if table_name not in existing_tables:
-                continue
+    """Drop this guard's triggers in EVERY schema that carries one.
+
+    The original sweep walked `introspection.table_names()`, which sees only
+    the schema on the current search_path. netbox-branching 1.2 replicates
+    triggers into each branch schema when it provisions one, so on NetBox 4.7
+    the copies in `branch_*` survived this and the following DROP FUNCTION
+    failed outright:
+
+        cannot drop function forward_netbox_enforce_device_generic_relation()
+        because other objects depend on it
+
+    Asking the catalogue instead of guessing at schemas removes exactly the
+    triggers that carry this name and call this function - our own, wherever
+    branching put them - and leaves anything else alone. That is also why this
+    does not reach for DROP FUNCTION ... CASCADE: CASCADE would work today
+    only because every current dependent happens to be ours, which is a fact
+    about this moment rather than a rule the database enforces.
+
+    Reverse path only. Forward application is unchanged, so no deployed
+    database's state differs because of this.
+    """
+    with schema_editor.connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT n.nspname, c.relname
+            FROM pg_trigger t
+            JOIN pg_class c ON c.oid = t.tgrelid
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            JOIN pg_proc p ON p.oid = t.tgfoid
+            WHERE t.tgname = %s AND p.proname = %s AND NOT t.tgisinternal
+            """,
+            [GUARD_TRIGGER, GUARD_FUNCTION],
+        )
+        targets = cursor.fetchall()
+        for schema_name, table_name in targets:
             cursor.execute(
                 "DROP TRIGGER IF EXISTS "
                 f"{schema_editor.quote_name(GUARD_TRIGGER)} ON "
+                f"{schema_editor.quote_name(schema_name)}."
                 f"{schema_editor.quote_name(table_name)}"
             )
 

--- a/forward_netbox/migrations/0053_alter_forwardsource_owner.py
+++ b/forward_netbox/migrations/0053_alter_forwardsource_owner.py
@@ -1,0 +1,39 @@
+# Record NetBox 4.7 dropping OwnerMixin's automatic reverse relation.
+#
+# `owner` is inherited, not declared here: NetBox 4.7 removed the reverse
+# accessor `OwnerMixin` used to create (`forwardsource_set` and friends), which
+# changes the field's migration state to `related_name="+"`. No column moves and
+# no data is touched - without this migration `makemigrations --check` fails on
+# every run.
+#
+# The resulting relation is both PROTECT and hidden. Django omits
+# `related_name="+"` relations from `_meta.related_objects`, which is how an
+# undeletable-ingestion bug once hid; `protecting_relations()` reads them with
+# `include_hidden=True` for exactly that reason. This one points from
+# ForwardSource at `users.Owner`, so it protects Owner deletion rather than
+# anything this sync manages - but it is the same shape, and here it is NetBox's
+# choice rather than ours.
+import django.db.models.deletion
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("forward_netbox", "0052_device_absence_quarantine"),
+        ("users", "0016_default_ordering_indexes"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="forwardsource",
+            name="owner",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="+",
+                to="users.owner",
+            ),
+        ),
+    ]

--- a/forward_netbox/migrations/0054_forwardchange_forwardchangecriterion_and_more.py
+++ b/forward_netbox/migrations/0054_forwardchange_forwardchangecriterion_and_more.py
@@ -1,0 +1,461 @@
+# Change control: seven tables for the Forward-backed change gate.
+#
+# Two things in here are deliberate and worth not "tidying" later.
+#
+# ForwardChange carries four advisory columns - predict_status,
+# predict_reason, predict_pre_verdict, netbox_impact - while Forward's predict
+# workflow is not live. They ship now so its arrival is additive: filling in
+# the stub must not require a schema change. They are also quarantined from
+# the verify gate by construction, because the gate reads
+# ForwardChangeEvidence and nothing else. Making a prediction into a verdict
+# would mean moving a column into that table, which is a visible act rather
+# than a quiet drift.
+#
+# ForwardChangeEvidence is unique on (criterion, phase, snapshot_id) rather
+# than (criterion, phase). Evidence belongs to a PINNED snapshot; re-running a
+# criterion against a different snapshot is a new row, not an overwrite, so
+# the before/after comparison a verdict rests on cannot be silently rebased.
+import django.db.models.deletion
+import django.utils.timezone
+import netbox.models.deletion
+import taggit.managers
+import utilities.json
+from django.conf import settings
+from django.db import migrations
+from django.db import models
+
+import forward_netbox.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        # `0001_initial`, not the migration makemigrations picked. These FKs
+        # only need the dcim/extras models to EXIST, and naming a recent
+        # migration pins a NetBox version the plugin does not actually require
+        # - which `test_migration_dependencies` refuses for exactly that
+        # reason.
+        ("dcim", "0001_initial"),
+        ("extras", "0001_initial"),
+        ("forward_netbox", "0053_alter_forwardsource_owner"),
+        ("netbox_branching", "0009_changediff_last_updated_auto_now"),
+        ("users", "0016_default_ordering_indexes"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ForwardChange",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "custom_field_data",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        encoder=utilities.json.CustomFieldJSONEncoder,
+                    ),
+                ),
+                ("description", models.CharField(blank=True, max_length=200)),
+                ("comments", models.TextField(blank=True)),
+                ("ref", models.CharField(blank=True, default="", max_length=100)),
+                ("title", models.CharField(max_length=200)),
+                ("state", models.CharField(default="draft", max_length=32)),
+                ("verdict", models.CharField(blank=True, default="", max_length=16)),
+                (
+                    "branch_name",
+                    models.CharField(blank=True, default="", max_length=200),
+                ),
+                (
+                    "branch_last_change_time",
+                    models.DateTimeField(blank=True, null=True),
+                ),
+                (
+                    "before_snapshot_id",
+                    models.CharField(blank=True, default="", max_length=100),
+                ),
+                (
+                    "after_snapshot_id",
+                    models.CharField(blank=True, default="", max_length=100),
+                ),
+                ("window_start", models.DateTimeField(blank=True, null=True)),
+                ("window_end", models.DateTimeField(blank=True, null=True)),
+                ("applied_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "applied_ref",
+                    models.CharField(blank=True, default="", max_length=200),
+                ),
+                (
+                    "predict_status",
+                    models.CharField(blank=True, default="", max_length=32),
+                ),
+                ("predict_reason", models.TextField(blank=True, default="")),
+                (
+                    "predict_pre_verdict",
+                    models.CharField(blank=True, default="", max_length=32),
+                ),
+                ("netbox_impact", models.JSONField(blank=True, default=dict)),
+                (
+                    "applied_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "branch",
+                    models.OneToOneField(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="netbox_branching.branch",
+                    ),
+                ),
+                (
+                    "owner",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="+",
+                        to="users.owner",
+                    ),
+                ),
+                (
+                    "requester",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "source",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="changes",
+                        to="forward_netbox.forwardsource",
+                    ),
+                ),
+                (
+                    "tags",
+                    taggit.managers.TaggableManager(
+                        through="extras.TaggedItem", to="extras.Tag"
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Forward Change",
+                "verbose_name_plural": "Forward Changes",
+                "db_table": "forward_netbox_change",
+                "ordering": ("-created",),
+            },
+            bases=(
+                forward_netbox.models.ForwardPluginModelDocsMixin,
+                netbox.models.deletion.DeleteMixin,
+                models.Model,
+            ),
+        ),
+        migrations.CreateModel(
+            name="ForwardChangeCriterion",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                ("name", models.CharField(max_length=200)),
+                ("family", models.CharField(default="acceptance", max_length=32)),
+                ("expectation", models.CharField(default="no-rows", max_length=32)),
+                ("blocking", models.BooleanField(default=True)),
+                (
+                    "query_path",
+                    models.CharField(blank=True, default="", max_length=500),
+                ),
+                ("query_id", models.CharField(blank=True, default="", max_length=100)),
+                ("commit_id", models.CharField(blank=True, default="", max_length=100)),
+                (
+                    "source_sha256",
+                    models.CharField(blank=True, default="", max_length=64),
+                ),
+                (
+                    "change",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="criteria",
+                        to="forward_netbox.forwardchange",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Forward Change Criterion",
+                "verbose_name_plural": "Forward Change Criteria",
+                "db_table": "forward_netbox_change_criterion",
+                "ordering": ("change", "name"),
+            },
+            bases=(
+                forward_netbox.models.ForwardPluginModelDocsMixin,
+                netbox.models.deletion.DeleteMixin,
+                models.Model,
+            ),
+        ),
+        migrations.CreateModel(
+            name="ForwardChangeDevice",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+                (
+                    "forward_device_key",
+                    models.CharField(blank=True, default="", max_length=255),
+                ),
+                (
+                    "change",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="devices",
+                        to="forward_netbox.forwardchange",
+                    ),
+                ),
+                (
+                    "device",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="+",
+                        to="dcim.device",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Forward Change Device",
+                "verbose_name_plural": "Forward Change Devices",
+                "db_table": "forward_netbox_change_device",
+                "ordering": ("device__name",),
+            },
+        ),
+        migrations.CreateModel(
+            name="ForwardChangeEvidence",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+                ("phase", models.CharField(max_length=16)),
+                ("passed", models.BooleanField()),
+                ("row_count", models.PositiveIntegerField(default=0)),
+                ("snapshot_id", models.CharField(max_length=100)),
+                ("commit_id", models.CharField(blank=True, default="", max_length=100)),
+                (
+                    "executed_at",
+                    models.DateTimeField(default=django.utils.timezone.now),
+                ),
+                ("duration_ms", models.PositiveIntegerField(default=0)),
+                ("shape", models.JSONField(blank=True, default=dict)),
+                (
+                    "criterion",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="evidence",
+                        to="forward_netbox.forwardchangecriterion",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Forward Change Evidence",
+                "verbose_name_plural": "Forward Change Evidence",
+                "db_table": "forward_netbox_change_evidence",
+                "ordering": ("criterion", "phase"),
+            },
+        ),
+        migrations.CreateModel(
+            name="ForwardChangePolicy",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "custom_field_data",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        encoder=utilities.json.CustomFieldJSONEncoder,
+                    ),
+                ),
+                ("description", models.CharField(blank=True, max_length=200)),
+                ("comments", models.TextField(blank=True)),
+                ("name", models.CharField(max_length=100, unique=True)),
+                ("enabled", models.BooleanField(default=True)),
+                ("min_approvals", models.PositiveSmallIntegerField(default=1)),
+                (
+                    "owner",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="+",
+                        to="users.owner",
+                    ),
+                ),
+                (
+                    "tags",
+                    taggit.managers.TaggableManager(
+                        through="extras.TaggedItem", to="extras.Tag"
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Forward Change Policy",
+                "verbose_name_plural": "Forward Change Policies",
+                "db_table": "forward_netbox_change_policy",
+                "ordering": ("name",),
+            },
+            bases=(
+                forward_netbox.models.ForwardPluginModelDocsMixin,
+                netbox.models.deletion.DeleteMixin,
+                models.Model,
+            ),
+        ),
+        migrations.CreateModel(
+            name="ForwardChangePolicyRule",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                ("tag_slug", models.CharField(blank=True, default="", max_length=100)),
+                (
+                    "device_role",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="+",
+                        to="dcim.devicerole",
+                    ),
+                ),
+                (
+                    "policy",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="rules",
+                        to="forward_netbox.forwardchangepolicy",
+                    ),
+                ),
+                (
+                    "site",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="+",
+                        to="dcim.site",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Forward Change Policy Rule",
+                "verbose_name_plural": "Forward Change Policy Rules",
+                "db_table": "forward_netbox_change_policy_rule",
+                "ordering": ("policy", "pk"),
+            },
+            bases=(netbox.models.deletion.DeleteMixin, models.Model),
+        ),
+        migrations.CreateModel(
+            name="ForwardChangeReview",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                ("approved", models.BooleanField(default=False)),
+                ("comment", models.TextField(blank=True, default="")),
+                ("branch_change_time", models.DateTimeField(blank=True, null=True)),
+                (
+                    "baseline_snapshot_id",
+                    models.CharField(blank=True, default="", max_length=100),
+                ),
+                (
+                    "change",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="reviews",
+                        to="forward_netbox.forwardchange",
+                    ),
+                ),
+                (
+                    "reviewer",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Forward Change Review",
+                "verbose_name_plural": "Forward Change Reviews",
+                "db_table": "forward_netbox_change_review",
+                "ordering": ("-created",),
+            },
+            bases=(
+                forward_netbox.models.ForwardPluginModelDocsMixin,
+                netbox.models.deletion.DeleteMixin,
+                models.Model,
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="forwardchangecriterion",
+            constraint=models.UniqueConstraint(
+                fields=("change", "name"), name="forward_change_criterion_unique_name"
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="forwardchangedevice",
+            constraint=models.UniqueConstraint(
+                fields=("change", "device"), name="forward_change_device_unique"
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="forwardchangeevidence",
+            constraint=models.UniqueConstraint(
+                fields=("criterion", "phase", "snapshot_id"),
+                name="forward_change_evidence_unique",
+            ),
+        ),
+    ]

--- a/forward_netbox/migrations/0055_change_control_approvals.py
+++ b/forward_netbox/migrations/0055_change_control_approvals.py
@@ -1,0 +1,75 @@
+# Pre/post approvals, and the permission that guards them.
+#
+# `min_approvals` is REMOVED and two fields added rather than renamed. It is
+# not a rename: one number cannot say "two sign-offs on the plan, one on the
+# closure", which is the common real shape. Nothing is lost because 0054 has
+# not shipped - 3.0 is the release that introduces all of this - so there are
+# no policy rows anywhere holding a value to migrate.
+#
+# The unique constraint on (change, reviewer, phase) is the one that matters:
+# without it, N approvals from the same person satisfy an N-approval policy
+# alone, which makes the count meaningless.
+from django.conf import settings
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("forward_netbox", "0054_forwardchange_forwardchangecriterion_and_more"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="forwardchange",
+            options={
+                "ordering": ("-created",),
+                "permissions": (
+                    ("approve_forwardchange", "Can approve Forward change"),
+                ),
+                "verbose_name": "Forward Change",
+                "verbose_name_plural": "Forward Changes",
+            },
+        ),
+        migrations.RemoveField(
+            model_name="forwardchangepolicy",
+            name="min_approvals",
+        ),
+        migrations.AddField(
+            model_name="forwardchangepolicy",
+            name="min_pre_approvals",
+            field=models.PositiveSmallIntegerField(default=1),
+        ),
+        migrations.AddField(
+            model_name="forwardchangepolicy",
+            name="min_post_approvals",
+            field=models.PositiveSmallIntegerField(default=1),
+        ),
+        migrations.AddField(
+            model_name="forwardchangereview",
+            name="phase",
+            field=models.CharField(
+                choices=[("pre", "Pre-change"), ("post", "Post-change")],
+                default="pre",
+                max_length=16,
+            ),
+        ),
+        migrations.AddField(
+            model_name="forwardchangereview",
+            name="after_snapshot_id",
+            field=models.CharField(blank=True, default="", max_length=100),
+        ),
+        migrations.AddField(
+            model_name="forwardchangereview",
+            name="verdict",
+            field=models.CharField(blank=True, default="", max_length=16),
+        ),
+        migrations.AddConstraint(
+            model_name="forwardchangereview",
+            constraint=models.UniqueConstraint(
+                fields=("change", "reviewer", "phase"),
+                name="forward_change_review_one_per_reviewer_phase",
+            ),
+        ),
+    ]

--- a/forward_netbox/models.py
+++ b/forward_netbox/models.py
@@ -22,6 +22,12 @@ from netbox_branching.models import Branch
 from rq.timeouts import JobTimeoutException
 from utilities.querysets import RestrictedQuerySet
 
+from .change_control.choices import ForwardChangeStateChoices
+from .change_control.choices import ForwardChangeVerdictChoices
+from .change_control.choices import ForwardCriterionExpectationChoices
+from .change_control.choices import ForwardCriterionFamilyChoices
+from .change_control.choices import ForwardEvidencePhaseChoices
+from .change_control.choices import ForwardReviewPhaseChoices
 from .choices import forward_configured_models
 from .choices import FORWARD_OPTIONAL_MODELS
 from .choices import FORWARD_SUPPORTED_MODELS
@@ -212,9 +218,15 @@ class ForwardSource(ForwardPluginModelDocsMixin, JobsMixin, PrimaryModel):
         super().save(*args, **kwargs)
 
     def delete(self, *args, **kwargs):
+        from .signals import enforce_sync_job_safety
         from .utilities.ownership import release_source_ownership
 
         with transaction.atomic():
+            # Deleting a source cascades to its syncs WITHOUT calling their
+            # own delete(), so each one's job guard has to run from here or it
+            # never runs at all.
+            for sync in ForwardSync.objects.filter(source=self):
+                enforce_sync_job_safety(sync)
             release_source_ownership(self)
             return super().delete(*args, **kwargs)
 
@@ -517,9 +529,17 @@ class ForwardSync(ForwardPluginModelDocsMixin, JobsMixin, TagsMixin, ChangeLogge
         return reverse("plugins:forward_netbox:forwardsync", args=[self.pk])
 
     def delete(self, *args, **kwargs):
+        from .signals import enforce_sync_job_safety
         from .utilities.ownership import release_sync_ownership
 
         with transaction.atomic():
+            # Before anything is collected. Django 6.1 deletes the `jobs`
+            # GenericRelation rows ahead of this model's `pre_delete`, so the
+            # signal that used to hold this guard now runs with nothing left to
+            # see - a running worker's Job row would be deleted out from under
+            # it, losing terminal diagnostics, and a standing RQ schedule would
+            # keep firing against a sync that no longer exists.
+            enforce_sync_job_safety(self)
             release_sync_ownership(self)
             return super().delete(*args, **kwargs)
 
@@ -1830,3 +1850,355 @@ class ForwardDeviceAnalysis(ForwardPluginModelDocsMixin, ChangeLoggedModel):
         source = getattr(self.sync, "source", None)
         url = (getattr(source, "url", "") or "").rstrip("/")
         return url or None
+
+
+class ForwardChange(ForwardPluginModelDocsMixin, PrimaryModel):
+    """A network change, gated on what Forward saw before and after it.
+
+    The branch merges when this reaches CLOSED, not when it is APPROVED.
+    Approval is a necessary condition; the sufficient one is a post-change
+    snapshot showing the network is the way the branch says it is.
+    """
+
+    source = models.ForeignKey(
+        ForwardSource,
+        on_delete=models.PROTECT,
+        related_name="changes",
+    )
+    ref = models.CharField(max_length=100, blank=True, default="")
+    title = models.CharField(max_length=200)
+    state = models.CharField(
+        max_length=32,
+        choices=ForwardChangeStateChoices,
+        default=ForwardChangeStateChoices.DRAFT,
+    )
+    verdict = models.CharField(
+        max_length=16,
+        choices=ForwardChangeVerdictChoices,
+        blank=True,
+        default="",
+    )
+    requester = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        blank=True,
+        null=True,
+        related_name="+",
+    )
+    branch = models.OneToOneField(
+        Branch,
+        on_delete=models.SET_NULL,
+        blank=True,
+        null=True,
+        related_name="+",
+    )
+    # Denormalized so the record stays readable after the branch is merged or
+    # discarded; the FK is SET_NULL and a merged branch is routinely removed.
+    branch_name = models.CharField(max_length=200, blank=True, default="")
+    branch_last_change_time = models.DateTimeField(blank=True, null=True)
+
+    # Pinned as literal ids, never selectors. A selector re-resolved at verify
+    # time would compare the change against a different snapshot than the one
+    # it was baselined and approved against.
+    before_snapshot_id = models.CharField(max_length=100, blank=True, default="")
+    after_snapshot_id = models.CharField(max_length=100, blank=True, default="")
+
+    window_start = models.DateTimeField(blank=True, null=True)
+    window_end = models.DateTimeField(blank=True, null=True)
+
+    # Attested, not measured. Nothing here can observe a network being changed.
+    applied_at = models.DateTimeField(blank=True, null=True)
+    applied_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        blank=True,
+        null=True,
+        related_name="+",
+    )
+    applied_ref = models.CharField(max_length=200, blank=True, default="")
+
+    # Advisory columns, quarantined from the verify gate by construction: the
+    # gate reads ForwardChangeEvidence and nothing else. Making the verdict
+    # depend on a prediction would mean moving a column into that table, which
+    # is a visible, migration-shaped act rather than a quiet drift. They ship
+    # now, while predict is stubbed, so its arrival needs no schema change.
+    predict_status = models.CharField(max_length=32, blank=True, default="")
+    predict_reason = models.TextField(blank=True, default="")
+    predict_pre_verdict = models.CharField(max_length=32, blank=True, default="")
+    netbox_impact = models.JSONField(blank=True, default=dict)
+
+    class Meta:
+        ordering = ("-created",)
+        verbose_name = _("Forward Change")
+        verbose_name_plural = _("Forward Changes")
+        db_table = "forward_netbox_change"
+        # Approving is a distinct right from editing, following the
+        # `run_forwardsync` precedent. Anyone who can change a record should
+        # not thereby be able to sign it off.
+        permissions = (("approve_forwardchange", "Can approve Forward change"),)
+
+    def __str__(self):
+        return self.ref and f"{self.ref} {self.title}" or self.title
+
+    def get_absolute_url(self):
+        return reverse("plugins:forward_netbox:forwardchange", args=[self.pk])
+
+    def get_state_color(self):
+        return ForwardChangeStateChoices.colors.get(self.state)
+
+    def get_verdict_color(self):
+        return ForwardChangeVerdictChoices.colors.get(self.verdict)
+
+
+class ForwardChangeDevice(models.Model):
+    """One device in a change's scope.
+
+    `forward_device_key` is copied at scope time rather than resolved on
+    demand: a device removed from NetBox later must still leave a readable
+    record of what the change covered.
+    """
+
+    change = models.ForeignKey(
+        ForwardChange,
+        on_delete=models.CASCADE,
+        related_name="devices",
+    )
+    device = models.ForeignKey(
+        "dcim.Device",
+        on_delete=models.CASCADE,
+        related_name="+",
+    )
+    forward_device_key = models.CharField(max_length=255, blank=True, default="")
+
+    class Meta:
+        ordering = ("device__name",)
+        verbose_name = _("Forward Change Device")
+        verbose_name_plural = _("Forward Change Devices")
+        db_table = "forward_netbox_change_device"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["change", "device"],
+                name="forward_change_device_unique",
+            )
+        ]
+
+    def __str__(self):
+        return f"{self.change}: {self.device}"
+
+
+class ForwardChangeCriterion(ForwardPluginModelDocsMixin, ChangeLoggedModel):
+    """One assertion, bound to a committed query version.
+
+    The query-identity triple is why binding is a gate: an unbound criterion
+    would be evaluated against whatever the query says at the time, so an
+    assertion could change under the change it is judging.
+    """
+
+    change = models.ForeignKey(
+        ForwardChange,
+        on_delete=models.CASCADE,
+        related_name="criteria",
+    )
+    name = models.CharField(max_length=200)
+    family = models.CharField(
+        max_length=32,
+        choices=ForwardCriterionFamilyChoices,
+        default=ForwardCriterionFamilyChoices.ACCEPTANCE,
+    )
+    expectation = models.CharField(
+        max_length=32,
+        choices=ForwardCriterionExpectationChoices,
+        default=ForwardCriterionExpectationChoices.NO_ROWS,
+    )
+    blocking = models.BooleanField(default=True)
+
+    query_path = models.CharField(max_length=500, blank=True, default="")
+    query_id = models.CharField(max_length=100, blank=True, default="")
+    commit_id = models.CharField(max_length=100, blank=True, default="")
+    source_sha256 = models.CharField(max_length=64, blank=True, default="")
+
+    class Meta:
+        ordering = ("change", "name")
+        verbose_name = _("Forward Change Criterion")
+        verbose_name_plural = _("Forward Change Criteria")
+        db_table = "forward_netbox_change_criterion"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["change", "name"],
+                name="forward_change_criterion_unique_name",
+            )
+        ]
+
+    def __str__(self):
+        return self.name
+
+    @property
+    def is_bound(self) -> bool:
+        return bool(self.query_id and self.commit_id)
+
+
+class ForwardChangeEvidence(models.Model):
+    """One criterion's result at one pinned snapshot.
+
+    This table IS the verify gate's input. Nothing advisory is recorded here -
+    that separation is what keeps a prediction from becoming a verdict.
+
+    `shape` holds schema identifiers only, never row values, following the same
+    rule as ingestion-issue diagnosis: evidence is support-bundle content.
+    """
+
+    criterion = models.ForeignKey(
+        ForwardChangeCriterion,
+        on_delete=models.CASCADE,
+        related_name="evidence",
+    )
+    phase = models.CharField(max_length=16, choices=ForwardEvidencePhaseChoices)
+    passed = models.BooleanField()
+    row_count = models.PositiveIntegerField(default=0)
+    snapshot_id = models.CharField(max_length=100)
+    commit_id = models.CharField(max_length=100, blank=True, default="")
+    executed_at = models.DateTimeField(default=timezone.now)
+    duration_ms = models.PositiveIntegerField(default=0)
+    shape = models.JSONField(blank=True, default=dict)
+
+    class Meta:
+        ordering = ("criterion", "phase")
+        verbose_name = _("Forward Change Evidence")
+        verbose_name_plural = _("Forward Change Evidence")
+        db_table = "forward_netbox_change_evidence"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["criterion", "phase", "snapshot_id"],
+                name="forward_change_evidence_unique",
+            )
+        ]
+
+    def __str__(self):
+        return f"{self.criterion} @ {self.phase}"
+
+
+class ForwardChangeReview(ForwardPluginModelDocsMixin, ChangeLoggedModel):
+    """One reviewer's decision, anchored to what they actually saw.
+
+    Staleness is anchored to the branch AND the baseline. A change can be
+    re-baselined without touching the branch, and a reviewer who approved
+    against the old snapshot approved different evidence.
+    """
+
+    change = models.ForeignKey(
+        ForwardChange,
+        on_delete=models.CASCADE,
+        related_name="reviews",
+    )
+    reviewer = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        blank=True,
+        null=True,
+        related_name="+",
+    )
+    phase = models.CharField(
+        max_length=16,
+        choices=ForwardReviewPhaseChoices,
+        default=ForwardReviewPhaseChoices.PRE,
+    )
+    approved = models.BooleanField(default=False)
+    comment = models.TextField(blank=True, default="")
+
+    # Pre-phase anchors: what the reviewer saw of the PLAN.
+    branch_change_time = models.DateTimeField(blank=True, null=True)
+    baseline_snapshot_id = models.CharField(max_length=100, blank=True, default="")
+
+    # Post-phase anchors: what the reviewer saw of the RESULT. Re-verifying
+    # against a newer snapshot, or the verdict changing, voids a closure
+    # sign-off - the reviewer approved specific evidence.
+    after_snapshot_id = models.CharField(max_length=100, blank=True, default="")
+    verdict = models.CharField(max_length=16, blank=True, default="")
+
+    class Meta:
+        ordering = ("-created",)
+        verbose_name = _("Forward Change Review")
+        verbose_name_plural = _("Forward Change Reviews")
+        db_table = "forward_netbox_change_review"
+        constraints = [
+            # One reviewer, one decision per gate. Without this, N approvals
+            # from the same person satisfy an N-approval policy alone, which
+            # makes the count meaningless.
+            models.UniqueConstraint(
+                fields=["change", "reviewer", "phase"],
+                name="forward_change_review_one_per_reviewer_phase",
+            )
+        ]
+
+    def __str__(self):
+        verdict = "approved" if self.approved else "rejected"
+        return f"{self.change} {verdict} by {self.reviewer}"
+
+
+class ForwardChangePolicy(ForwardPluginModelDocsMixin, PrimaryModel):
+    """Who must approve, scoped by the properties a NETWORK change has.
+
+    Scoped by device role, site or tag rather than by NetBox object type: an
+    operator reasons about "changes touching core routers at this site", not
+    about which model rows a branch happens to contain.
+    """
+
+    name = models.CharField(max_length=100, unique=True)
+    enabled = models.BooleanField(default=True)
+    # Split per gate. A team that wants two sign-offs on the plan and one on
+    # the closure cannot say so with a single number, and that is the common
+    # real shape.
+    min_pre_approvals = models.PositiveSmallIntegerField(default=1)
+    # 0 lets a PROCEED verdict close on its own. That is the escape hatch for
+    # low-risk automation and is deliberately not the default: CLOSE is where
+    # the branch merges.
+    min_post_approvals = models.PositiveSmallIntegerField(default=1)
+
+    class Meta:
+        ordering = ("name",)
+        verbose_name = _("Forward Change Policy")
+        verbose_name_plural = _("Forward Change Policies")
+        db_table = "forward_netbox_change_policy"
+
+    def __str__(self):
+        return self.name
+
+    def get_absolute_url(self):
+        return reverse("plugins:forward_netbox:forwardchangepolicy", args=[self.pk])
+
+
+class ForwardChangePolicyRule(ChangeLoggedModel):
+    """One scoping rule on a policy."""
+
+    policy = models.ForeignKey(
+        ForwardChangePolicy,
+        on_delete=models.CASCADE,
+        related_name="rules",
+    )
+    device_role = models.ForeignKey(
+        "dcim.DeviceRole",
+        on_delete=models.CASCADE,
+        blank=True,
+        null=True,
+        related_name="+",
+    )
+    site = models.ForeignKey(
+        "dcim.Site",
+        on_delete=models.CASCADE,
+        blank=True,
+        null=True,
+        related_name="+",
+    )
+    tag_slug = models.CharField(max_length=100, blank=True, default="")
+
+    class Meta:
+        ordering = ("policy", "pk")
+        verbose_name = _("Forward Change Policy Rule")
+        verbose_name_plural = _("Forward Change Policy Rules")
+        db_table = "forward_netbox_change_policy_rule"
+
+    def __str__(self):
+        parts = [
+            str(x) for x in (self.device_role, self.site, self.tag_slug or None) if x
+        ]
+        return f"{self.policy}: {' / '.join(parts) or 'any'}"

--- a/forward_netbox/navigation.py
+++ b/forward_netbox/navigation.py
@@ -78,12 +78,41 @@ device_analysis = PluginMenuItem(
     permissions=["forward_netbox.view_forwarddeviceanalysis"],
 )
 
+change = PluginMenuItem(
+    link="plugins:forward_netbox:forwardchange_list",
+    link_text=_("Changes"),
+    buttons=[
+        PluginMenuButton(
+            link="plugins:forward_netbox:forwardchange_add",
+            title=_("Add"),
+            icon_class="mdi mdi-plus-thick",
+            permissions=["forward_netbox.add_forwardchange"],
+        )
+    ],
+    permissions=["forward_netbox.view_forwardchange"],
+)
+
+change_policy = PluginMenuItem(
+    link="plugins:forward_netbox:forwardchangepolicy_list",
+    link_text=_("Change Policies"),
+    buttons=[
+        PluginMenuButton(
+            link="plugins:forward_netbox:forwardchangepolicy_add",
+            title=_("Add"),
+            icon_class="mdi mdi-plus-thick",
+            permissions=["forward_netbox.add_forwardchangepolicy"],
+        )
+    ],
+    permissions=["forward_netbox.view_forwardchangepolicy"],
+)
+
 menu = PluginMenu(
     label="Forward",
     icon_class="mdi mdi-cloud-sync",
     groups=(
         ("Data Sync", (source, sync, ingestion, validation_run)),
+        ("Change Control", (change,)),
         ("Analysis", (device_analysis,)),
-        ("Configuration", (nqe_map, drift_policy)),
+        ("Configuration", (nqe_map, drift_policy, change_policy)),
     ),
 )

--- a/forward_netbox/signals.py
+++ b/forward_netbox/signals.py
@@ -98,6 +98,24 @@ def seed_builtin_nqe_maps(sender, **kwargs):
 
 @receiver(pre_delete, sender=ForwardSync)
 def cancel_enqueued_jobs_on_sync_delete(sender, instance, **kwargs):
+    """Signal entry point, kept for any delete path that skips the override.
+
+    On Django 6.1 (NetBox 4.7) this fires TOO LATE to do its job: the
+    collector removes the `jobs` GenericRelation rows before sending
+    `pre_delete` for the ForwardSync, so by the time this runs there is
+    nothing left to find. Verified directly - `Job.objects.count()` is 0
+    inside this handler while a RUNNING job existed a moment earlier.
+
+    That is why `ForwardSync.delete()` calls `enforce_sync_job_safety()`
+    itself, before anything is collected. This receiver stays because a delete
+    path that bypasses the model override would otherwise have no guard at
+    all, and running it twice is harmless: the refusal is a read, and the
+    cancellation is idempotent.
+    """
+    enforce_sync_job_safety(instance)
+
+
+def enforce_sync_job_safety(instance):
     """Cancel queued work and reject deletion while a worker is running.
 
     The JobsMixin GenericRelation cascade removes Job rows through the SQL

--- a/forward_netbox/tables.py
+++ b/forward_netbox/tables.py
@@ -8,6 +8,9 @@ from netbox.tables import columns
 from netbox.tables import NetBoxTable
 from netbox_branching.models import ChangeDiff
 
+from .models import ForwardChange
+from .models import ForwardChangeCriterion
+from .models import ForwardChangePolicy
 from .models import ForwardDeviceAnalysis
 from .models import ForwardDriftPolicy
 from .models import ForwardIngestion
@@ -358,4 +361,82 @@ class ForwardIngestionIssueTable(NetBoxTable):
             "coalesce_fields",
             "defaults",
             "message",
+        )
+
+
+class ForwardChangeTable(NetBoxTable):
+    title = tables.Column(linkify=True)
+    source = tables.Column(linkify=True)
+    state = columns.ChoiceFieldColumn()
+    verdict = columns.ChoiceFieldColumn()
+
+    class Meta(NetBoxTable.Meta):
+        model = ForwardChange
+        fields = (
+            "pk",
+            "ref",
+            "title",
+            "source",
+            "state",
+            "verdict",
+            "branch_name",
+            "before_snapshot_id",
+            "after_snapshot_id",
+            "applied_at",
+            "created",
+        )
+        default_columns = (
+            "pk",
+            "ref",
+            "title",
+            "source",
+            "state",
+            "verdict",
+            "applied_at",
+        )
+
+
+class ForwardChangeCriterionTable(NetBoxTable):
+    name = tables.Column(linkify=False)
+    change = tables.Column(linkify=True)
+    family = columns.ChoiceFieldColumn()
+    expectation = columns.ChoiceFieldColumn()
+    blocking = columns.BooleanColumn()
+    actions = columns.ActionsColumn(actions=())
+
+    class Meta(NetBoxTable.Meta):
+        model = ForwardChangeCriterion
+        fields = (
+            "pk",
+            "name",
+            "change",
+            "family",
+            "expectation",
+            "blocking",
+            "query_path",
+            "query_id",
+            "commit_id",
+        )
+        default_columns = (
+            "name",
+            "change",
+            "family",
+            "expectation",
+            "blocking",
+            "commit_id",
+        )
+
+
+class ForwardChangePolicyTable(NetBoxTable):
+    name = tables.Column(linkify=True)
+
+    class Meta(NetBoxTable.Meta):
+        model = ForwardChangePolicy
+        fields = ("pk", "name", "enabled", "min_pre_approvals", "min_post_approvals")
+        default_columns = (
+            "pk",
+            "name",
+            "enabled",
+            "min_pre_approvals",
+            "min_post_approvals",
         )

--- a/forward_netbox/templates/forward_netbox/forwardchange.html
+++ b/forward_netbox/templates/forward_netbox/forwardchange.html
@@ -1,0 +1,245 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+{% load i18n %}
+
+{% block content %}
+<div class="row mb-3">
+  <div class="col col-md-6">
+    <div class="card">
+      <h5 class="card-header">{% trans "Change" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Reference" %}</th>
+            <td>{{ object.ref|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Source" %}</th>
+            <td>{{ object.source|linkify }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "State" %}</th>
+            <td>{% badge object.get_state_display bg_color=object.get_state_color %}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Verdict" %}</th>
+            <td>
+              {% if object.verdict %}
+                {% badge object.get_verdict_display bg_color=object.get_verdict_color %}
+              {% else %}
+                <span class="text-muted">{% trans "Not yet verified" %}</span>
+              {% endif %}
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Requester" %}</th>
+            <td>{{ object.requester|placeholder }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+
+    <div class="card">
+      <h5 class="card-header">{% trans "Snapshots" %}</h5>
+      <div class="card-body">
+        {# Pinned as literal ids, never selectors: verifying against a #}
+        {# re-resolved snapshot would judge the change against a different #}
+        {# network than the one it was approved against. #}
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Baseline (before)" %}</th>
+            <td><code>{{ object.before_snapshot_id|placeholder }}</code></td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Post-change (after)" %}</th>
+            <td><code>{{ object.after_snapshot_id|placeholder }}</code></td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Branch" %}</th>
+            <td>{{ object.branch_name|placeholder }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+
+    <div class="card">
+      <h5 class="card-header">{% trans "Applied" %}</h5>
+      <div class="card-body">
+        <p class="text-muted small">
+          {% trans "Attested, not measured. Nothing here can observe the network being changed, so this is a human claim about when it happened." %}
+        </p>
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "When" %}</th>
+            <td>{{ object.applied_at|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Attested by" %}</th>
+            <td>{{ object.applied_by|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Reference" %}</th>
+            <td>{{ object.applied_ref|placeholder }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <div class="col col-md-6">
+    <div class="card">
+      <h5 class="card-header">{% trans "Evidence" %}</h5>
+      <div class="card-body">
+        <p class="text-muted small">
+          {% trans "This is what the verdict is computed from, and the only thing it is computed from." %}
+        </p>
+        {% if criterion_outcomes %}
+          <table class="table table-hover">
+            <thead>
+              <tr>
+                <th>{% trans "Criterion" %}</th>
+                <th>{% trans "Before" %}</th>
+                <th>{% trans "After" %}</th>
+                <th>{% trans "Result" %}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for outcome in criterion_outcomes %}
+                <tr>
+                  <td>
+                    {{ outcome.criterion.name }}
+                    {% if not outcome.blocking %}
+                      <span class="badge text-bg-gray">{% trans "advisory" %}</span>
+                    {% endif %}
+                  </td>
+                  <td>{% checkmark outcome.before_passed %}</td>
+                  <td>{% checkmark outcome.after_passed %}</td>
+                  <td>
+                    {% if outcome.flip %}
+                      {% if outcome.blocks %}
+                        <span class="badge text-bg-red">{% trans "regression" %}</span>
+                      {% else %}
+                        <span class="badge text-bg-green">{{ outcome.flip }}</span>
+                      {% endif %}
+                    {% else %}
+                      {# Never rendered as a pass. A criterion nobody #}
+                      {# evaluated is not a criterion that passed. #}
+                      <span class="badge text-bg-orange">{% trans "not measured" %}</span>
+                    {% endif %}
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        {% else %}
+          <p class="text-muted mb-0">
+            {% trans "No criteria have been evaluated. A change with nothing asserted cannot be verified, only asserted to have happened." %}
+          </p>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="card">
+      <h5 class="card-header">{{ predict_panel.heading }}</h5>
+      <div class="card-body">
+        {# Advisory, and separated from Evidence above on purpose. An #}
+        {# advisory panel that looks like evidence is how a prediction #}
+        {# quietly becomes a decision. #}
+        <p class="text-muted small">
+          {% trans "Advisory only. The verdict does not depend on this." %}
+        </p>
+        <p class="mb-0">{{ predict_panel.message }}</p>
+      </div>
+    </div>
+
+    <div class="card">
+      <h5 class="card-header">{% trans "Scope" %}</h5>
+      <div class="card-body">
+        {% if scoped_devices %}
+          <ul class="list-unstyled mb-0">
+            {% for scoped in scoped_devices %}
+              <li>
+                {{ scoped.device|linkify }}
+                {% if not scoped.forward_device_key %}
+                  <span class="badge text-bg-orange">{% trans "no Forward identity" %}</span>
+                {% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p class="text-muted mb-0">{% trans "No devices in scope." %}</p>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="card">
+      <h5 class="card-header">{% trans "Reviews" %}</h5>
+      <div class="card-body">
+        {# Two gates. The pre gate approves the PLAN; the post gate approves #}
+        {# the CLOSURE, which is where the branch actually merges. A PROCEED #}
+        {# verdict opens that gate rather than walking through it. #}
+        {% if reviews %}
+          <table class="table table-hover">
+            {% for review in reviews %}
+              <tr>
+                <td>{{ review.reviewer|placeholder }}</td>
+                <td><span class="badge text-bg-gray">{{ review.phase }}</span></td>
+                <td>
+                  {% if review.approved %}
+                    <span class="badge text-bg-green">{% trans "approved" %}</span>
+                  {% else %}
+                    <span class="badge text-bg-red">{% trans "rejected" %}</span>
+                  {% endif %}
+                </td>
+                <td class="text-muted small">{{ review.comment }}</td>
+              </tr>
+            {% endfor %}
+          </table>
+        {% else %}
+          <p class="text-muted">{% trans "No reviews yet." %}</p>
+        {% endif %}
+
+        {% if perms.forward_netbox.approve_forwardchange %}
+          <form method="post" action="{% url 'plugins:forward_netbox:forwardchange_review' pk=object.pk %}">
+            {% csrf_token %}
+            <input type="text" name="comment" class="form-control mb-2"
+                   placeholder="{% trans 'Comment (optional)' %}">
+            <button type="submit" name="decision" value="approve"
+                    class="btn btn-green">{% trans "Approve" %}</button>
+            <button type="submit" name="decision" value="reject"
+                    class="btn btn-red">{% trans "Reject" %}</button>
+          </form>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="card">
+      <h5 class="card-header">{% trans "Next steps" %}</h5>
+      <div class="card-body">
+        {% if transitions %}
+          <table class="table table-hover">
+            {% for transition in transitions %}
+              <tr>
+                <th scope="row">{{ transition.target }}</th>
+                <td>
+                  {% if transition.allowed %}
+                    <span class="badge text-bg-green">{% trans "ready" %}</span>
+                  {% else %}
+                    <ul class="list-unstyled mb-0 small text-muted">
+                      {% for blocker in transition.blockers %}
+                        <li>{{ blocker }}</li>
+                      {% endfor %}
+                    </ul>
+                  {% endif %}
+                </td>
+              </tr>
+            {% endfor %}
+          </table>
+        {% else %}
+          <p class="text-muted mb-0">{% trans "This change is finished; there is nowhere further to go." %}</p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/forward_netbox/templates/forward_netbox/forwardchangepolicy.html
+++ b/forward_netbox/templates/forward_netbox/forwardchangepolicy.html
@@ -1,0 +1,55 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+{% load i18n %}
+
+{% block content %}
+<div class="row mb-3">
+  <div class="col col-md-6">
+    <div class="card">
+      <h5 class="card-header">{% trans "Policy" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Enabled" %}</th>
+            <td>{{ object.enabled|yesno:"Yes,No" }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Approvals before apply" %}</th>
+            <td>{{ object.min_pre_approvals }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Approvals before close" %}</th>
+            <td>
+              {{ object.min_post_approvals }}
+              {% if not object.min_post_approvals %}
+                <span class="text-muted small">
+                  {% trans "a PROCEED verdict closes on its own" %}
+                </span>
+              {% endif %}
+            </td>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div class="col col-md-6">
+    <div class="card">
+      <h5 class="card-header">{% trans "Scope rules" %}</h5>
+      <div class="card-body">
+        {# Scoped by the properties a NETWORK change has - role, site, tag - #}
+        {# rather than by NetBox object type, because that is how an operator #}
+        {# reasons about which changes need which approvers. #}
+        {% if rules %}
+          <ul class="list-unstyled mb-0">
+            {% for rule in rules %}<li>{{ rule }}</li>{% endfor %}
+          </ul>
+        {% else %}
+          <p class="text-muted mb-0">
+            {% trans "No rules: this policy applies to every change." %}
+          </p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/forward_netbox/tests/test_aci_drift_comparison.py
+++ b/forward_netbox/tests/test_aci_drift_comparison.py
@@ -1,3 +1,15 @@
+import unittest
+
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import Manufacturer
+from dcim.models import Site
+from django.apps import apps
+from django.test import TestCase
+
+from forward_netbox.utilities.drift_comparison import compare_model_rows
+
 # Slice nine of the adapter-only drift comparison: the eight netbox-cisco-aci
 # models. The one #206 never named, because the ACI maps postdate it - and the
 # largest block left after slice eight, so `in_sync` was unanswerable for any
@@ -14,14 +26,13 @@
 #
 # The verdict rule is the leaf rule. Every ACI model has its own query and its
 # own rows, so a parent create is the parent model's drift.
-from dcim.models import Device
-from dcim.models import DeviceRole
-from dcim.models import DeviceType
-from dcim.models import Manufacturer
-from dcim.models import Site
-from django.test import TestCase
 
-from forward_netbox.utilities.drift_comparison import compare_model_rows
+# These models only exist when the optional plugin is installed, and on
+# NetBox 4.7 it cannot be: netbox-cisco-aci declares a max_version in the 4.6
+# series, so NetBox refuses to start with it. The suite skips rather than
+# fails - but this IS lost coverage, not a clean pass, and the 4.6 lane on
+# 2.9.x is where these adapters stay exercised until that ceiling moves.
+NETBOX_CISCO_ACI_INSTALLED = apps.is_installed("netbox_cisco_aci")
 
 FABRIC = "netbox_cisco_aci.acifabric"
 POD = "netbox_cisco_aci.acipod"
@@ -46,6 +57,7 @@ def _counts(model_string, rows):
     return compare_model_rows(None, model_string, rows)
 
 
+@unittest.skipUnless(NETBOX_CISCO_ACI_INSTALLED, "netbox-cisco-aci is not installed")
 class AciPreviewTest(TestCase):
     """Real plugin models, one existing object per level, then a preview."""
 

--- a/forward_netbox/tests/test_bulk_merge.py
+++ b/forward_netbox/tests/test_bulk_merge.py
@@ -1,11 +1,7 @@
-# Integration tests for the production single-branch bulk merge.
-#
-# Provisions a real netbox_branching branch, stages changes into it, and merges
-# via bulk_merge_changes, proving batched writes, bounded framework fallbacks,
-# atomic audit evidence, relationship convergence, and idempotent retries.
 import logging
 import threading
 import time
+import unittest
 import uuid
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -23,6 +19,7 @@ from dcim.models import ModuleType
 from dcim.models import Platform
 from dcim.models import Region
 from dcim.models import Site
+from django.apps import apps
 from django.db import connection
 from django.db import DEFAULT_DB_ALIAS
 from django.db import transaction
@@ -45,6 +42,18 @@ from forward_netbox.models import ForwardSource
 from forward_netbox.models import ForwardSync
 from forward_netbox.utilities.bulk_merge import bulk_merge_changes
 from forward_netbox.utilities.merge import merge_branch
+
+# Integration tests for the production single-branch bulk merge.
+#
+# Provisions a real netbox_branching branch, stages changes into it, and merges
+# via bulk_merge_changes, proving batched writes, bounded framework fallbacks,
+# atomic audit evidence, relationship convergence, and idempotent retries.
+
+# netbox-dlm cannot be installed on NetBox 4.7: it declares a max_version in
+# the 4.6 series and NetBox refuses to start with a plugin outside its range.
+# These skip rather than fail, which IS lost coverage - the 4.6 lane on 2.9.x
+# is where the DLM paths stay exercised until that ceiling moves.
+DLM_INSTALLED = apps.is_installed("netbox_dlm")
 
 
 def provision_branch(*, user, name="Test Branch", **kwargs):
@@ -994,6 +1003,7 @@ class BulkMergeIntegrationTest(CleanTransactionTestCase):
         )
         self.assertFalse(ForwardVirtualParentClaim.objects.exists())
 
+    @unittest.skipUnless(DLM_INSTALLED, "netbox-dlm is not installed")
     def test_dlm_association_and_catalog_deletes_merge_in_one_branch(self):
         from django.apps import apps
 
@@ -1078,6 +1088,7 @@ class BulkMergeIntegrationTest(CleanTransactionTestCase):
             SoftwareVersion.objects.filter(pk=software_version.pk).exists()
         )
 
+    @unittest.skipUnless(DLM_INSTALLED, "netbox-dlm is not installed")
     def test_m2m_target_create_precedes_existing_source_update_on_first_merge(self):
         from django.apps import apps
 
@@ -1151,6 +1162,7 @@ class BulkMergeIntegrationTest(CleanTransactionTestCase):
 
         self.assertEqual(accepted, [])
 
+    @unittest.skipUnless(DLM_INSTALLED, "netbox-dlm is not installed")
     def test_dlm_protected_version_delete_follows_destination_fk_reassignment(self):
         from django.apps import apps
         from netbox_branching.merge_strategies.squash import SquashMergeStrategy
@@ -2887,7 +2899,20 @@ class BulkMergeIntegrationTest(CleanTransactionTestCase):
             staged_tag.object_types.add(ContentType.objects.get_for_model(Site))
 
         changes = branch.get_unmerged_changes().order_by("time")
-        apply_one = self._real_apply_one(branch)
+        # The fallback is disabled on purpose. Patching the relationship write
+        # proves the BULK batch rolls its create and m2m back together - and
+        # then the per-object fallback re-applies the row through
+        # netbox_branching, which for a non-MPTT create calls
+        # `deserialized.save()` and writes the m2m inside the library, out of
+        # reach of any patch here. With the fallback live the row lands
+        # complete and `applied` is 1, which reads as an atomicity failure when
+        # it is nothing of the kind: verified on 4.7 that the Tag exists WITH
+        # its object_types, not half-written.
+        #
+        # So this pins what it can actually speak to. If the bulk create and
+        # its m2m did not roll back together, the Tag would survive below even
+        # though the fallback refused it.
+        apply_one = Mock(side_effect=RuntimeError("fallback disabled for this test"))
         with patch.object(
             manager_class,
             "set",

--- a/forward_netbox/tests/test_change_control_evidence.py
+++ b/forward_netbox/tests/test_change_control_evidence.py
@@ -1,0 +1,136 @@
+# The regression-flip comparison, which is why evidence is recorded at a
+# baseline as well as after the change.
+#
+# Without a before phase, a criterion that was ALREADY failing is counted as
+# damage this change caused, and the gate holds a change that broke nothing.
+from django.test import SimpleTestCase
+
+from forward_netbox.change_control.evidence import BLOCKING_FLIPS
+from forward_netbox.change_control.evidence import classify_flip
+from forward_netbox.change_control.evidence import FIX
+from forward_netbox.change_control.evidence import PRE_EXISTING
+from forward_netbox.change_control.evidence import PRESERVED
+from forward_netbox.change_control.evidence import REGRESSION
+
+
+class TheFourFlipsTest(SimpleTestCase):
+    def test_pass_then_fail_is_a_regression(self):
+        self.assertEqual(classify_flip(True, False), REGRESSION)
+
+    def test_fail_then_pass_is_a_fix(self):
+        self.assertEqual(classify_flip(False, True), FIX)
+
+    def test_fail_then_fail_is_pre_existing(self):
+        # The case the baseline exists for. This must NOT block: the change
+        # neither caused it nor was asked to fix it.
+        self.assertEqual(classify_flip(False, False), PRE_EXISTING)
+
+    def test_pass_then_pass_is_preserved(self):
+        self.assertEqual(classify_flip(True, True), PRESERVED)
+
+
+class OnlyARegressionBlocksTest(SimpleTestCase):
+    def test_exactly_one_flip_blocks(self):
+        self.assertEqual(BLOCKING_FLIPS, frozenset({REGRESSION}))
+
+    def test_pre_existing_failure_does_not_block(self):
+        self.assertNotIn(PRE_EXISTING, BLOCKING_FLIPS)
+
+    def test_a_fix_does_not_block(self):
+        self.assertNotIn(FIX, BLOCKING_FLIPS)
+
+    def test_preserved_state_does_not_block(self):
+        self.assertNotIn(PRESERVED, BLOCKING_FLIPS)
+
+
+class NotMeasuredIsNotAPassTest(SimpleTestCase):
+    """A missing phase must stay a third answer all the way to the verdict.
+
+    Coercing it to a pass is precisely how an empty comparison once read as a
+    successful one, which cost a release to find and another to explain.
+    """
+
+    def test_a_missing_before_phase_has_no_flip(self):
+        self.assertEqual(classify_flip(None, True), "")
+
+    def test_a_missing_after_phase_has_no_flip(self):
+        self.assertEqual(classify_flip(True, None), "")
+
+    def test_both_missing_has_no_flip(self):
+        self.assertEqual(classify_flip(None, None), "")
+
+
+class TheTwoFamiliesBlockDifferentlyTest(SimpleTestCase):
+    """Acceptance and state preservation ask different questions.
+
+    Acceptance asserts the change ACHIEVED ITS INTENT, so what matters is the
+    after state on its own: a criterion still failing means the change did not
+    work, and letting that through because it was already failing would verify
+    a change that accomplished nothing.
+
+    State preservation asserts nothing ELSE moved, so a pre-existing failure is
+    genuinely not this change's business.
+    """
+
+    # NOT `_outcome`: unittest.TestCase sets an internal `_outcome`
+    # attribute during run(), which shadows a method of that name and
+    # fails with "'_Outcome' object is not callable".
+    def _make_outcome(self, family, flip):
+        from types import SimpleNamespace
+
+        from forward_netbox.change_control.evidence import CriterionOutcome
+
+        return CriterionOutcome(
+            criterion=SimpleNamespace(name="c", family=family),
+            before_passed=None,
+            after_passed=None,
+            flip=flip,
+            blocking=True,
+        )
+
+    def test_a_failing_acceptance_criterion_blocks_even_if_pre_existing(self):
+        from forward_netbox.change_control.choices import (
+            ForwardCriterionFamilyChoices,
+        )
+
+        outcome = self._make_outcome(
+            ForwardCriterionFamilyChoices.ACCEPTANCE, PRE_EXISTING
+        )
+
+        self.assertTrue(outcome.blocks)
+        self.assertIn("did not achieve", outcome.block_reason)
+
+    def test_a_pre_existing_state_preservation_failure_does_not_block(self):
+        from forward_netbox.change_control.choices import (
+            ForwardCriterionFamilyChoices,
+        )
+
+        outcome = self._make_outcome(
+            ForwardCriterionFamilyChoices.STATE_PRESERVATION, PRE_EXISTING
+        )
+
+        self.assertFalse(outcome.blocks)
+
+    def test_a_regression_blocks_in_both_families(self):
+        from forward_netbox.change_control.choices import (
+            ForwardCriterionFamilyChoices,
+        )
+
+        for family in (
+            ForwardCriterionFamilyChoices.ACCEPTANCE,
+            ForwardCriterionFamilyChoices.STATE_PRESERVATION,
+        ):
+            with self.subTest(family=family):
+                self.assertTrue(self._make_outcome(family, REGRESSION).blocks)
+
+    def test_a_fix_never_blocks(self):
+        from forward_netbox.change_control.choices import (
+            ForwardCriterionFamilyChoices,
+        )
+
+        for family in (
+            ForwardCriterionFamilyChoices.ACCEPTANCE,
+            ForwardCriterionFamilyChoices.STATE_PRESERVATION,
+        ):
+            with self.subTest(family=family):
+                self.assertFalse(self._make_outcome(family, FIX).blocks)

--- a/forward_netbox/tests/test_change_control_gates.py
+++ b/forward_netbox/tests/test_change_control_gates.py
@@ -1,0 +1,172 @@
+# The verify gate's ordering, and the absence problem it exists to catch.
+#
+# A device that failed collection is ABSENT from the Forward model rather than
+# flagged in it, so "no violations found" and "the broken device was not in the
+# snapshot" look identical from the rows alone. That is the same shape as a
+# customer's 552 uncovered devices, and it is why completeness is step one
+# rather than a footnote on the report.
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase
+
+from forward_netbox.change_control.choices import ForwardChangeVerdictChoices
+from forward_netbox.change_control.gates import collection_postdates_apply
+from forward_netbox.change_control.gates import device_set_complete
+from forward_netbox.change_control.gates import verify
+
+APPLIED = datetime(2026, 9, 2, 12, 0, tzinfo=timezone.utc)
+
+
+def _change(*, keys=("dev-a", "dev-b"), applied_at=APPLIED):
+    devices = [
+        SimpleNamespace(forward_device_key=k, device=f"device-{k}") for k in keys
+    ]
+    return SimpleNamespace(
+        applied_at=applied_at,
+        devices=SimpleNamespace(all=lambda: devices),
+        criteria=SimpleNamespace(all=lambda: []),
+    )
+
+
+class AnAbsentDeviceRefusesTheVerdictTest(SimpleTestCase):
+    def test_a_complete_device_set_passes(self):
+        result = device_set_complete(_change(), ["dev-a", "dev-b"])
+
+        self.assertTrue(result)
+
+    def test_a_missing_device_refuses_rather_than_warns(self):
+        result = device_set_complete(_change(), ["dev-a"])
+
+        self.assertFalse(result)
+        self.assertIn("absent from this snapshot", result.reasons[0])
+
+    def test_the_reason_explains_why_absence_is_not_a_pass(self):
+        # The sentence matters: an operator who reads "1 device missing" may
+        # accept it, and one who reads why absence is indistinguishable from
+        # health will not.
+        result = device_set_complete(_change(), [])
+
+        self.assertIn("failed collection", result.reasons[0])
+        self.assertIn("rather than marked failed", result.reasons[0])
+
+
+class CollectionMustPostdateTheApplyTest(SimpleTestCase):
+    def test_collection_after_the_apply_passes(self):
+        times = {
+            "dev-a": APPLIED + timedelta(minutes=5),
+            "dev-b": APPLIED + timedelta(minutes=6),
+        }
+
+        self.assertTrue(collection_postdates_apply(_change(), times))
+
+    def test_collection_before_the_apply_holds(self):
+        times = {
+            "dev-a": APPLIED - timedelta(minutes=1),
+            "dev-b": APPLIED + timedelta(minutes=5),
+        }
+        result = collection_postdates_apply(_change(), times)
+
+        self.assertFalse(result)
+        self.assertIn("collected before the change was applied", result.reasons[0])
+
+    def test_an_unknown_collection_time_is_held_not_assumed(self):
+        # The weakest joint in the workflow. Assuming the snapshot is new
+        # enough is how a verdict gets computed against the wrong network.
+        result = collection_postdates_apply(
+            _change(), {"dev-a": APPLIED + timedelta(minutes=5)}
+        )
+
+        self.assertFalse(result)
+        self.assertIn("Unknown is held, not assumed", result.reasons[-1])
+
+    def test_no_attested_apply_time_holds(self):
+        result = collection_postdates_apply(_change(applied_at=None), {})
+
+        self.assertFalse(result)
+
+
+class TheGateRunsInOrderTest(SimpleTestCase):
+    def test_an_incomplete_device_set_short_circuits_the_criteria(self):
+        # The criteria are not evaluated at all, so no evidence row is written
+        # that would later read as a real measurement of this snapshot.
+        verdict, reasons = verify(
+            _change(),
+            observed_device_keys=["dev-a"],
+            device_collection_times={"dev-a": APPLIED + timedelta(minutes=5)},
+        )
+
+        self.assertEqual(verdict, ForwardChangeVerdictChoices.HOLD)
+        self.assertTrue(any("absent from this snapshot" in r for r in reasons))
+
+    def test_a_complete_and_timely_snapshot_reaches_the_criteria(self):
+        # With no criteria defined, the verdict falls through to the criteria
+        # stage and holds for a different, honest reason.
+        verdict, reasons = verify(
+            _change(),
+            observed_device_keys=["dev-a", "dev-b"],
+            device_collection_times={
+                "dev-a": APPLIED + timedelta(minutes=5),
+                "dev-b": APPLIED + timedelta(minutes=5),
+            },
+        )
+
+        self.assertEqual(verdict, ForwardChangeVerdictChoices.HOLD)
+        self.assertTrue(any("nothing to verify against" in r for r in reasons))
+
+
+class APrematureAttestationIsCaughtTest(SimpleTestCase):
+    """APPLIED cannot be proved from here, but its usual failure is detectable.
+
+    If every criterion reports the same result before and after, Forward
+    observed no change. That is not proof the change never landed - a change
+    can legitimately leave every criterion where it was - so it holds with a
+    question rather than an accusation.
+    """
+
+    # NOT `_outcome`: unittest.TestCase sets an internal `_outcome`
+    # attribute during run(), which shadows a method of that name and
+    # fails with "'_Outcome' object is not callable".
+    def _make_outcome(self, flip):
+        return SimpleNamespace(flip=flip)
+
+    def test_no_movement_at_all_holds(self):
+        from forward_netbox.change_control.evidence import PRESERVED
+        from forward_netbox.change_control.gates import attestation_looks_premature
+
+        result = attestation_looks_premature(
+            _change(), [self._make_outcome(PRESERVED), self._make_outcome(PRESERVED)]
+        )
+
+        self.assertFalse(result)
+        self.assertIn("observed no change to the network", result.reasons[0])
+
+    def test_the_reason_offers_the_innocent_explanation_too(self):
+        from forward_netbox.change_control.evidence import PRESERVED
+        from forward_netbox.change_control.gates import attestation_looks_premature
+
+        result = attestation_looks_premature(_change(), [self._make_outcome(PRESERVED)])
+
+        self.assertIn("changed nothing the criteria ask about", result.reasons[0])
+
+    def test_any_movement_satisfies_it(self):
+        from forward_netbox.change_control.evidence import FIX
+        from forward_netbox.change_control.evidence import PRESERVED
+        from forward_netbox.change_control.gates import attestation_looks_premature
+
+        result = attestation_looks_premature(
+            _change(), [self._make_outcome(PRESERVED), self._make_outcome(FIX)]
+        )
+
+        self.assertTrue(result)
+
+    def test_nothing_measured_is_not_treated_as_no_movement(self):
+        # An unmeasured criterion says nothing about whether the network moved,
+        # and must not be turned into evidence that it did not.
+        from forward_netbox.change_control.gates import attestation_looks_premature
+
+        self.assertTrue(
+            attestation_looks_premature(_change(), [self._make_outcome("")])
+        )

--- a/forward_netbox/tests/test_change_control_policy.py
+++ b/forward_netbox/tests/test_change_control_policy.py
@@ -1,0 +1,133 @@
+# How many approvals a gate needs, and who counts.
+#
+# Before this module, ForwardChangePolicy was inert: nothing read
+# min_approvals, nothing evaluated a rule, and any single approving row opened
+# the gate. An approval policy nobody enforces is worse than none, because the
+# page implies a control that is not there.
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase
+from django.test import TestCase
+
+from forward_netbox.change_control.choices import ForwardReviewPhaseChoices
+from forward_netbox.change_control.policy import DEFAULT_REQUIRED_APPROVALS
+from forward_netbox.change_control.policy import distinct_approvers
+from forward_netbox.change_control.policy import required_approvals
+from forward_netbox.change_control.policy import stale_approvals
+
+
+class AnUnmatchedChangeIsNotEasierToMergeTest(TestCase):
+    def test_no_policy_still_requires_an_approval(self):
+        # The failure mode this guards: adding a policy to cover one estate
+        # quietly leaving everything else ungoverned.
+        change = SimpleNamespace(
+            devices=SimpleNamespace(select_related=lambda *a: []),
+        )
+
+        self.assertEqual(
+            required_approvals(change, ForwardReviewPhaseChoices.PRE),
+            DEFAULT_REQUIRED_APPROVALS,
+        )
+        self.assertEqual(
+            required_approvals(change, ForwardReviewPhaseChoices.POST),
+            DEFAULT_REQUIRED_APPROVALS,
+        )
+
+
+class SelfApprovalIsNotApprovalTest(SimpleTestCase):
+    def _change(self, reviews, requester_id=7):
+        return SimpleNamespace(
+            requester_id=requester_id,
+            reviews=SimpleNamespace(filter=lambda **kw: reviews),
+        )
+
+    def test_the_requester_does_not_count(self):
+        reviews = [SimpleNamespace(reviewer_id=7)]
+
+        self.assertEqual(
+            distinct_approvers(self._change(reviews), ForwardReviewPhaseChoices.PRE),
+            set(),
+        )
+
+    def test_one_reviewer_counts_once(self):
+        # The uniqueness constraint stops this at write time; counting
+        # distinctly means a bypass of that constraint still cannot inflate.
+        reviews = [SimpleNamespace(reviewer_id=3), SimpleNamespace(reviewer_id=3)]
+
+        self.assertEqual(
+            distinct_approvers(self._change(reviews), ForwardReviewPhaseChoices.PRE),
+            {3},
+        )
+
+    def test_a_review_with_no_reviewer_does_not_count(self):
+        reviews = [SimpleNamespace(reviewer_id=None)]
+
+        self.assertEqual(
+            distinct_approvers(self._change(reviews), ForwardReviewPhaseChoices.PRE),
+            set(),
+        )
+
+
+class TheTwoGatesAnchorToDifferentEvidenceTest(SimpleTestCase):
+    def _change(self, reviews, **kw):
+        base = dict(
+            branch_last_change_time="t1",
+            before_snapshot_id="snap-before",
+            after_snapshot_id="snap-after",
+            verdict="proceed",
+        )
+        base.update(kw)
+        return SimpleNamespace(
+            reviews=SimpleNamespace(filter=lambda **f: reviews), **base
+        )
+
+    def test_a_pre_approval_is_voided_by_a_new_baseline(self):
+        review = SimpleNamespace(
+            branch_change_time="t1",
+            baseline_snapshot_id="snap-old",
+            after_snapshot_id="",
+            verdict="",
+        )
+        change = self._change([review])
+
+        self.assertEqual(len(stale_approvals(change, ForwardReviewPhaseChoices.PRE)), 1)
+
+    def test_a_post_approval_is_voided_by_re_verification(self):
+        # The reviewer signed off on specific evidence; a newer snapshot is
+        # different evidence.
+        review = SimpleNamespace(
+            branch_change_time="t1",
+            baseline_snapshot_id="snap-before",
+            after_snapshot_id="snap-older",
+            verdict="proceed",
+        )
+        change = self._change([review])
+
+        self.assertEqual(
+            len(stale_approvals(change, ForwardReviewPhaseChoices.POST)), 1
+        )
+
+    def test_a_post_approval_is_voided_by_the_verdict_changing(self):
+        review = SimpleNamespace(
+            branch_change_time="t1",
+            baseline_snapshot_id="snap-before",
+            after_snapshot_id="snap-after",
+            verdict="hold",
+        )
+        change = self._change([review])
+
+        self.assertEqual(
+            len(stale_approvals(change, ForwardReviewPhaseChoices.POST)), 1
+        )
+
+    def test_matching_anchors_are_not_stale(self):
+        review = SimpleNamespace(
+            branch_change_time="t1",
+            baseline_snapshot_id="snap-before",
+            after_snapshot_id="snap-after",
+            verdict="proceed",
+        )
+        change = self._change([review])
+
+        self.assertEqual(stale_approvals(change, ForwardReviewPhaseChoices.PRE), [])
+        self.assertEqual(stale_approvals(change, ForwardReviewPhaseChoices.POST), [])

--- a/forward_netbox/tests/test_change_control_predict.py
+++ b/forward_netbox/tests/test_change_control_predict.py
@@ -1,0 +1,121 @@
+# The predict stub's contract.
+#
+# Predict is not live, is licence-gated when it ships, and is limited today.
+# The workflow must be correct without it, so these pin the two things that
+# make its absence safe: it never raises, and "we could not ask" never renders
+# as "we asked and it was fine".
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase
+
+from forward_netbox.change_control.predict import predict_change
+from forward_netbox.change_control.predict import PredictOutcome
+from forward_netbox.change_control.predict import render_predict_panel
+
+
+class TheStubAnswersRatherThanRaisesTest(SimpleTestCase):
+    def test_predict_returns_unavailable_today(self):
+        outcome = predict_change(
+            source=SimpleNamespace(parameters={}),
+            snapshot_id="1",
+            devices=(),
+            criteria=(),
+        )
+
+        self.assertEqual(outcome.status, PredictOutcome.UNAVAILABLE)
+        self.assertFalse(outcome.is_answer)
+
+    def test_the_reason_says_the_verdict_does_not_depend_on_it(self):
+        # An operator reading this must not conclude the change cannot be
+        # verified. The verdict comes from the post-change snapshot, which is
+        # available on every licence tier.
+        outcome = predict_change(source=SimpleNamespace(parameters={}), snapshot_id="1")
+
+        self.assertIn("verified", outcome.reason)
+        self.assertIn("post-change snapshot", outcome.reason)
+
+
+class ANonAnswerNeverRendersAsSuccessTest(SimpleTestCase):
+    def test_unavailable_is_informational_not_an_error(self):
+        panel = render_predict_panel(
+            PredictOutcome(status=PredictOutcome.UNAVAILABLE, reason="not licensed")
+        )
+
+        self.assertEqual(panel["level"], "info")
+        self.assertIn("not available", panel["heading"])
+        self.assertEqual(panel["verdict"], "")
+
+    def test_unsupported_is_distinct_from_unavailable(self):
+        # "We could not ask" and "we asked and it could not say" mean different
+        # things to someone deciding whether to approve.
+        unavailable = render_predict_panel(
+            PredictOutcome(status=PredictOutcome.UNAVAILABLE)
+        )
+        unsupported = render_predict_panel(
+            PredictOutcome(status=PredictOutcome.UNSUPPORTED)
+        )
+
+        self.assertNotEqual(unavailable["heading"], unsupported["heading"])
+
+    def test_every_panel_is_marked_advisory(self):
+        for status in (
+            PredictOutcome.UNAVAILABLE,
+            PredictOutcome.UNSUPPORTED,
+            PredictOutcome.ANSWERED,
+        ):
+            with self.subTest(status=status):
+                panel = render_predict_panel(PredictOutcome(status=status))
+                self.assertTrue(panel["advisory"])
+
+
+class ThePredictFlagIsOffByDefaultTest(SimpleTestCase):
+    """Off unless a deployment opts in, and the three cases stay distinct.
+
+    "Not enabled here", "not licensed" and "not live yet" mean different things
+    to someone deciding whether to approve, and collapsing them into one greyed
+    panel is how a reader concludes the change was checked when it was not.
+    """
+
+    def test_a_source_with_no_parameters_is_off(self):
+        from forward_netbox.change_control.predict import predict_enabled
+
+        self.assertFalse(predict_enabled(SimpleNamespace(parameters={})))
+
+    def test_a_missing_key_is_off_rather_than_permission(self):
+        # No data migration: every existing source simply lacks the key.
+        from forward_netbox.change_control.predict import predict_enabled
+
+        self.assertFalse(
+            predict_enabled(SimpleNamespace(parameters={"something_else": True}))
+        )
+
+    def test_none_parameters_is_off(self):
+        from forward_netbox.change_control.predict import predict_enabled
+
+        self.assertFalse(predict_enabled(SimpleNamespace(parameters=None)))
+
+    def test_the_flag_turns_it_on(self):
+        from forward_netbox.change_control.predict import predict_enabled
+
+        self.assertTrue(
+            predict_enabled(SimpleNamespace(parameters={"enable_predict": True}))
+        )
+
+    def test_disabled_says_it_was_not_asked(self):
+        outcome = predict_change(source=SimpleNamespace(parameters={}), snapshot_id="1")
+
+        self.assertEqual(outcome.status, PredictOutcome.UNAVAILABLE)
+        self.assertIn("not enabled on this Forward source", outcome.reason)
+        self.assertIn("was not asked", outcome.reason)
+
+    def test_enabled_but_upstream_missing_says_so_differently(self):
+        # An operator who turned it ON deserves to know the answer is
+        # upstream, not a setting they missed.
+        outcome = predict_change(
+            source=SimpleNamespace(parameters={"enable_predict": True}),
+            snapshot_id="1",
+        )
+
+        self.assertEqual(outcome.status, PredictOutcome.UNAVAILABLE)
+        self.assertIn("enabled for this source", outcome.reason)
+        self.assertIn("licensed separately", outcome.reason)

--- a/forward_netbox/tests/test_change_control_state_machine.py
+++ b/forward_netbox/tests/test_change_control_state_machine.py
@@ -1,0 +1,89 @@
+# The change workflow's graph, and the two properties that are the whole point.
+#
+# A HOLD is a valid result, not an error, and it is never closed - it is fixed
+# and re-verified. Most home-grown change gates get that wrong by treating a
+# failed check as an exception, which pushes operators towards closing it to
+# clear the queue. Here the graph simply has no edge that expresses it.
+from django.test import SimpleTestCase
+
+from forward_netbox.change_control.choices import ForwardChangeStateChoices as State
+from forward_netbox.change_control.state_machine import available_transitions
+from forward_netbox.change_control.state_machine import legal_transition
+from forward_netbox.change_control.state_machine import TRANSITIONS
+
+
+class TheGraphRefusesToCloseAHoldTest(SimpleTestCase):
+    def test_a_hold_cannot_reach_closed(self):
+        self.assertNotIn(State.CLOSED, TRANSITIONS[State.VERIFIED_HOLD])
+
+    def test_a_hold_goes_back_for_a_fix_or_is_abandoned(self):
+        # Re-verifying means a fresh collection, so it returns to APPLIED
+        # rather than jumping straight to COLLECTED with the stale snapshot.
+        self.assertEqual(
+            TRANSITIONS[State.VERIFIED_HOLD],
+            frozenset({State.APPLIED, State.ABANDONED}),
+        )
+
+    def test_only_a_proceed_reaches_closed(self):
+        closers = [s for s, targets in TRANSITIONS.items() if State.CLOSED in targets]
+        self.assertEqual(closers, [State.VERIFIED_PROCEED])
+
+
+class PredictIsOptionalTest(SimpleTestCase):
+    def test_staged_reaches_approved_directly(self):
+        # Not a degradation: predict is not live, is licence-gated when it
+        # ships, and is limited today, so this is the DEFAULT path.
+        self.assertTrue(legal_transition(State.STAGED, State.APPROVED))
+
+    def test_staged_may_also_go_through_predicted(self):
+        self.assertTrue(legal_transition(State.STAGED, State.PREDICTED))
+        self.assertTrue(legal_transition(State.PREDICTED, State.APPROVED))
+
+    def test_predict_is_the_only_skippable_state(self):
+        # Every other state is on every path from DRAFT to CLOSED. If this ever
+        # fails, a mandatory gate has become bypassable.
+        mandatory = {
+            State.DRAFT,
+            State.SCOPED,
+            State.BASELINED,
+            State.STAGED,
+            State.APPROVED,
+            State.APPLIED,
+            State.COLLECTED,
+        }
+        for state in mandatory:
+            with self.subTest(state=state):
+                self.assertTrue(
+                    any(state in targets for targets in TRANSITIONS.values())
+                    or state == State.DRAFT
+                )
+
+
+class TerminalStatesTest(SimpleTestCase):
+    def test_closed_and_abandoned_lead_nowhere(self):
+        self.assertEqual(available_transitions(State.CLOSED), ())
+        self.assertEqual(available_transitions(State.ABANDONED), ())
+
+    def test_a_hold_is_not_terminal(self):
+        self.assertNotIn(State.VERIFIED_HOLD, State.TERMINAL)
+        self.assertIn(State.VERIFIED_HOLD, State.OPEN)
+
+    def test_every_open_state_can_be_abandoned(self):
+        for state in State.OPEN:
+            with self.subTest(state=state):
+                self.assertIn(State.ABANDONED, TRANSITIONS[state])
+
+
+class BaselineComesBeforeStagingTest(SimpleTestCase):
+    def test_staging_is_only_reachable_from_baselined(self):
+        # Deliberate ordering: a criterion must be measured against the network
+        # BEFORE anyone edits NetBox, or a criterion that was already failing
+        # gets counted as damage this change caused.
+        stagers = [s for s, targets in TRANSITIONS.items() if State.STAGED in targets]
+        self.assertEqual(
+            sorted(stagers),
+            sorted([State.BASELINED, State.PREDICTED, State.APPROVED]),
+        )
+
+    def test_the_forward_path_from_baselined_is_staged(self):
+        self.assertIn(State.STAGED, TRANSITIONS[State.BASELINED])

--- a/forward_netbox/tests/test_copy_sql_apply_engine.py
+++ b/forward_netbox/tests/test_copy_sql_apply_engine.py
@@ -60,13 +60,16 @@ class CopySQLSelectionTest(TestCase):
     def test_unsupported_version_tuple_fails_closed(self):
         cases = (
             # Out of series, not merely a later patch: the gate accepts any
-            # 4.6.x and any 1.1.x, so a rejection case has to leave the series.
-            (("4.7.0", "1.1.1", ()), "unsupported_netbox_version"),
-            (("4.6.5", "1.2.0", ()), "unsupported_branching_version"),
+            # 4.7.x and any 1.2.x, so a rejection case has to leave the series.
+            # 4.6/1.1 are the rejections that matter now - that pair is the
+            # previous lane, and it is the one somebody could plausibly still
+            # be running.
+            (("4.6.8", "1.2.0", ()), "unsupported_netbox_version"),
+            (("4.7.0", "1.1.3", ()), "unsupported_branching_version"),
             (
                 (
-                    "4.6.5",
-                    "1.1.1",
+                    "4.7.0",
+                    "1.2.0",
                     (("netbox-cisco-aci", "9.9.9"),),
                 ),
                 "unsupported_optional_plugin_version",

--- a/forward_netbox/tests/test_dlm_catalogue_conflicts.py
+++ b/forward_netbox/tests/test_dlm_catalogue_conflicts.py
@@ -1,3 +1,5 @@
+import unittest
+
 """A shared DLM catalogue row must never be created twice in one branch.
 
 `netbox_dlm.cve` is a global catalogue keyed by `cve_id`, created from two
@@ -28,6 +30,12 @@ from forward_netbox.models import ForwardSource
 from forward_netbox.models import ForwardSync
 from forward_netbox.utilities.sync import ForwardSyncRunner
 from forward_netbox.utilities.sync_primitives import UNIQUE_LOOKUP_CACHE_FIELD_SETS
+
+# netbox-dlm cannot be installed on NetBox 4.7: it declares a max_version in
+# the 4.6 series and NetBox refuses to start with a plugin outside its range.
+# These skip rather than fail, which IS lost coverage - the 4.6 lane on 2.9.x
+# is where the DLM paths stay exercised until that ceiling moves.
+DLM_INSTALLED = apps.is_installed("netbox_dlm")
 
 
 class DLMCatalogueConflictPolicyTest(SimpleTestCase):
@@ -88,6 +96,7 @@ class DLMCatalogueConflictPolicyTest(SimpleTestCase):
         )
 
 
+@unittest.skipUnless(DLM_INSTALLED, "netbox-dlm is not installed")
 class DLMCatalogueConflictBehaviourTest(TestCase):
     """The policy is only worth anything if a real conflict actually reuses."""
 

--- a/forward_netbox/tests/test_dlm_inventoryitem_drift_comparison.py
+++ b/forward_netbox/tests/test_dlm_inventoryitem_drift_comparison.py
@@ -1,9 +1,5 @@
-# The two netbox-dlm models slice six left unmeasured: `inventoryitemsoftware`
-# and `inventoryitemroleplatform`. Deferred because their chains had not been
-# audited for the writes-behind-a-runner-call trap; the audit found two reads
-# that raise a dependency skip, a platform ensure and an upsert the preview
-# overrides, and the same software-version upsert already previewed - and one
-# guard to add, in the ensure, for the absent-platform case.
+import unittest
+
 from dcim.models import Device
 from dcim.models import DeviceRole
 from dcim.models import DeviceType
@@ -17,6 +13,20 @@ from django.test import TestCase
 
 from forward_netbox.utilities.drift_comparison import compare_model_rows
 
+# The two netbox-dlm models slice six left unmeasured: `inventoryitemsoftware`
+# and `inventoryitemroleplatform`. Deferred because their chains had not been
+# audited for the writes-behind-a-runner-call trap; the audit found two reads
+# that raise a dependency skip, a platform ensure and an upsert the preview
+# overrides, and the same software-version upsert already previewed - and one
+# guard to add, in the ensure, for the absent-platform case.
+
+# These models only exist when the optional plugin is installed, and on
+# NetBox 4.7 it cannot be: netbox-dlm declares a max_version in the 4.6
+# series, so NetBox refuses to start with it. The suite skips rather than
+# fails - but this IS lost coverage, not a clean pass, and the 4.6 lane on
+# 2.9.x is where these adapters stay exercised until that ceiling moves.
+NETBOX_DLM_INSTALLED = apps.is_installed("netbox_dlm")
+
 SOFTWARE = "netbox_dlm.inventoryitemsoftware"
 MAPPING = "netbox_dlm.inventoryitemroleplatform"
 
@@ -25,6 +35,7 @@ def _dlm(name):
     return apps.get_model("netbox_dlm", name)
 
 
+@unittest.skipUnless(NETBOX_DLM_INSTALLED, "netbox-dlm is not installed")
 class InventoryItemSoftwarePreviewTest(TestCase):
     def setUp(self):
         site = Site.objects.create(name="IIS Site", slug="iis-site")

--- a/forward_netbox/tests/test_fast_baseline.py
+++ b/forward_netbox/tests/test_fast_baseline.py
@@ -1,4 +1,5 @@
 import json
+import unittest
 from dataclasses import replace
 from io import StringIO
 from types import SimpleNamespace
@@ -6,6 +7,7 @@ from unittest.mock import patch
 
 from core.models import ObjectChange
 from dcim.models import Site
+from django.apps import apps
 from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from django.db import connections
@@ -14,7 +16,6 @@ from netbox.context import current_request
 from netbox_branching.models import AppliedChange
 from netbox_branching.models import Branch
 from netbox_branching.models import ChangeDiff
-from netbox_dlm.models import CVE
 from rest_framework.test import APIRequestFactory
 
 from forward_netbox.api.serializers import ForwardIngestionSerializer
@@ -43,6 +44,18 @@ from forward_netbox.utilities.workload_state import build_state_entries
 from forward_netbox.utilities.workload_state import decode_state_entries
 from forward_netbox.utilities.workload_state import encode_state_entries
 from forward_netbox.utilities.workload_state import PendingWorkloadState
+
+
+# The fast-baseline contracts cover ten models, four of which belong to
+# optional plugins that cannot be installed on NetBox 4.7 - each caps at a
+# max_version in the 4.6 series. Tests that build rows for those models can
+# only run where the plugin exists. Skipping is honest here in a way it would
+# not be for the core models: the contract for netbox_routing rows is not
+# WEAKER on 4.7, it is unreachable, because rows for an absent plugin are
+# refused before any contract is consulted.
+OPTIONAL_ADAPTER_PLUGINS_INSTALLED = apps.is_installed(
+    "netbox_dlm"
+) and apps.is_installed("netbox_routing")
 
 
 class FastBaselineLoadTest(TransactionTestCase):
@@ -189,6 +202,10 @@ class FastBaselineLoadTest(TransactionTestCase):
         self.assertFalse(decision.enabled)
         self.assertEqual(decision.reason_code, "delete_rows_not_supported")
 
+    @unittest.skipUnless(
+        OPTIONAL_ADAPTER_PLUGINS_INSTALLED,
+        "netbox-dlm and netbox-routing are not installed",
+    )
     def test_relationship_adapter_contract_covers_all_ten_models(self):
         workloads = [
             BranchWorkload(
@@ -641,6 +658,7 @@ class FastBaselineLoadTest(TransactionTestCase):
         self.assertTrue(Manufacturer.objects.filter(slug="implicit-vendor").exists())
         self.assertIn(Manufacturer, _side_models({"dcim.inventoryitem"}))
 
+    @unittest.skipUnless(apps.is_installed("netbox_dlm"), "netbox-dlm is not installed")
     def test_locked_selection_rejects_nonempty_target_and_prior_ingestion(self):
         Site.objects.create(name="Existing Site", slug="existing-site")
         from django.db import transaction
@@ -663,6 +681,7 @@ class FastBaselineLoadTest(TransactionTestCase):
         self.assertFalse(decision.enabled)
         self.assertEqual(decision.reason_code, "prior_ingestion_present")
 
+    @unittest.skipUnless(apps.is_installed("netbox_dlm"), "netbox-dlm is not installed")
     def test_direct_baseline_preserves_durable_completion_without_branch_audit(self):
         logger = SyncLogging()
         executor = ForwardExecutorBase(
@@ -793,7 +812,13 @@ class FastBaselineLoadTest(TransactionTestCase):
             attestation,
         )
 
+    @unittest.skipUnless(apps.is_installed("netbox_dlm"), "netbox-dlm is not installed")
     def test_direct_baseline_omits_only_proven_cve_tombstones(self):
+        # Imported here, not at module scope: netbox-dlm cannot be installed
+        # on NetBox 4.7, and a module-level import made the WHOLE file fail
+        # to load, taking 30-odd unrelated fast-baseline tests with it.
+        from netbox_dlm.models import CVE
+
         self.sync.parameters["dcim.site"] = False
         self.sync.parameters["netbox_dlm.cve"] = True
         workload = BranchWorkload(
@@ -879,6 +904,7 @@ class FastBaselineLoadTest(TransactionTestCase):
         )
         self.assertEqual(ObjectChange.objects.count(), 0)
 
+    @unittest.skipUnless(apps.is_installed("netbox_dlm"), "netbox-dlm is not installed")
     def test_fault_rolls_back_target_and_ingestion(self):
         logger = SyncLogging()
         executor = ForwardExecutorBase(

--- a/forward_netbox/tests/test_fast_paths_report_when_disabled.py
+++ b/forward_netbox/tests/test_fast_paths_report_when_disabled.py
@@ -65,12 +65,15 @@ class AnUnvalidatedPluginIsNamedTest(SimpleTestCase):
         self.assertIn("still succeed", message)
 
     def test_a_missing_validated_plugin_is_also_named(self):
-        reduced = sorted(COPY_SQL_SUPPORTED_PLUGIN_APPS - {"netbox_dlm"})
+        # netbox_branching, not an optional plugin: the validated set holds no
+        # optional plugin on NetBox 4.7, so removing one would leave the set
+        # unchanged and this would assert nothing.
+        reduced = sorted(COPY_SQL_SUPPORTED_PLUGIN_APPS - {"netbox_branching"})
         with patch("django.conf.settings.PLUGINS", reduced):
             check = _fast_path_runtime_check()
 
         self.assertIsNotNone(check)
-        self.assertIn("netbox_dlm", check["message"])
+        self.assertIn("netbox_branching", check["message"])
         self.assertIn("not installed", check["message"])
 
     def test_the_check_survives_a_broken_fast_baseline_probe(self):

--- a/forward_netbox/tests/test_model_view_routes.py
+++ b/forward_netbox/tests/test_model_view_routes.py
@@ -51,6 +51,46 @@ class EveryModelWithADetailViewCanReverseItsListTest(TestCase):
         self.assertTrue(reverse("plugins:forward_netbox:forwardingestionissue_list"))
 
 
+class EveryRegisteredModelIsRoutableTest(TestCase):
+    """A model with views registered must also be reachable.
+
+    The sweeps above both start by reversing the DETAIL route and `continue`
+    when it is missing, so a model whose views exist but whose URLs were never
+    added to `urls.py` is silently skipped by every one of them. That is
+    exactly what happened to the change-control models: views, tables, forms
+    and a menu entry all existed, `forwardchange_list` did not resolve, and 25
+    unrelated tests failed with NoReverseMatch when the nav menu rendered.
+
+    This asserts the other direction - if a model has an ObjectListView
+    registered, its list route must reverse.
+    """
+
+    def test_every_model_with_a_list_view_has_a_list_route(self):
+        from netbox.registry import registry
+
+        missing = []
+        for model in apps.get_app_config("forward_netbox").get_models():
+            name = model._meta.model_name
+            views = registry["views"].get("forward_netbox", {}).get(name, {})
+            # A registered LIST view specifically, not any view. NetBox
+            # auto-registers changelog and journal views for every
+            # ChangeLoggedModel, so "has views" is true of child models that
+            # are only ever rendered inside a parent's page and correctly have
+            # no list route of their own.
+            if "list" not in views:
+                continue
+            try:
+                reverse(f"plugins:forward_netbox:{name}_list")
+            except NoReverseMatch:
+                missing.append(name)
+        self.assertEqual(
+            missing,
+            [],
+            "these models register views but have no list route, so every page "
+            f"that renders the plugin menu raises NoReverseMatch: {missing}",
+        )
+
+
 class EveryDetailViewHasATemplateTest(TestCase):
     """`generic.ObjectView` resolves a template by name, or raises at render.
 

--- a/forward_netbox/tests/test_optional_plugin_versions.py
+++ b/forward_netbox/tests/test_optional_plugin_versions.py
@@ -1,3 +1,17 @@
+import unittest
+from unittest.mock import patch
+
+from django.apps import apps
+from django.test import SimpleTestCase
+
+from forward_netbox.utilities.apply_engine_decision import (
+    COPY_SQL_SUPPORTED_OPTIONAL_DISTRIBUTIONS,
+)
+from forward_netbox.utilities.merge_set_based import (
+    SET_BASED_MERGE_SUPPORTED_OPTIONAL_DISTRIBUTIONS,
+)
+from forward_netbox.utilities.version_series import series_matches
+
 # An optional NetBox plugin upgrade must not silently disable the fast paths.
 #
 # The runtime gates for the fast baseline, set-based merge and COPY/SQL each
@@ -25,56 +39,63 @@
 # roughly half an hour before 0.9.1 with a NoReverseMatch on every one of its
 # view URLs; 0.9.1 is that fix. Skipping a version that cannot render is not the
 # same as failing to validate it.
-from unittest.mock import patch
-
-from django.test import SimpleTestCase
-
-from forward_netbox.utilities.apply_engine_decision import (
-    COPY_SQL_SUPPORTED_OPTIONAL_DISTRIBUTIONS,
-)
-from forward_netbox.utilities.merge_set_based import (
-    SET_BASED_MERGE_SUPPORTED_OPTIONAL_DISTRIBUTIONS,
-)
-from forward_netbox.utilities.version_series import series_matches
 
 
 class OptionalDistributionVersionSetTest(SimpleTestCase):
-    def test_every_gate_accepts_all_validated_dlm_versions(self):
-        for name, supported in (
+    """The validated optional-distribution sets, whatever they currently hold.
+
+    On NetBox 4.7 they hold nothing. Every optional plugin - netbox-dlm,
+    netbox-cisco-aci, netbox-peering-manager, netbox-routing, netbox-validity -
+    declares a max_version in the 4.6 series, and NetBox refuses to start with a
+    plugin outside its declared range, so none of them can be installed on this
+    runtime at all. Claiming a validated version for a plugin nobody can install
+    would be a claim about a runtime nobody can assemble.
+
+    These assertions are therefore about the INVARIANTS rather than the
+    contents, so they keep working in both directions: they hold today with the
+    sets empty, and they hold the day an upstream raises its ceiling and entries
+    come back. The per-version assertions that used to live here (netbox-dlm
+    0.4.1 through 0.9.1) are recorded in
+    `docs/03_Plans/active/2026-09-02-netbox-4.7-runtime.md`, because those
+    versions were validated against 4.6 and none of them is evidence about 4.7.
+    """
+
+    def test_both_gates_read_the_same_declaration(self):
+        # One source, two consumers. When these diverge the fast paths disable
+        # themselves silently, which is the failure this module exists to catch.
+        self.assertIs(
+            COPY_SQL_SUPPORTED_OPTIONAL_DISTRIBUTIONS,
+            SET_BASED_MERGE_SUPPORTED_OPTIONAL_DISTRIBUTIONS,
+        )
+
+    def test_no_distribution_is_validated_on_this_runtime(self):
+        self.assertEqual(
+            dict(COPY_SQL_SUPPORTED_OPTIONAL_DISTRIBUTIONS),
+            {},
+            "an optional plugin cannot be installed on NetBox 4.7, so a "
+            "validated version for one is a claim about an unbuildable runtime",
+        )
+
+    def test_any_entry_that_returns_names_a_real_version(self):
+        # Guards the way back in: an empty frozenset would accept nothing while
+        # reading as configured, and a bare string would accept every substring.
+        for name, supported in COPY_SQL_SUPPORTED_OPTIONAL_DISTRIBUTIONS.items():
+            with self.subTest(distribution=name):
+                self.assertIsInstance(supported, frozenset)
+                self.assertTrue(supported)
+                for version in supported:
+                    self.assertRegex(version, r"^\d+\.\d+")
+
+    def test_an_unvalidated_version_is_refused_whatever_the_set_holds(self):
+        # The gates fail closed; widening must never become "any version".
+        for gate, supported in (
             ("copy_sql", COPY_SQL_SUPPORTED_OPTIONAL_DISTRIBUTIONS),
             ("set_based", SET_BASED_MERGE_SUPPORTED_OPTIONAL_DISTRIBUTIONS),
         ):
-            with self.subTest(gate=name):
-                self.assertIn("0.4.1", supported["netbox-dlm"])
-                self.assertIn("0.5.0", supported["netbox-dlm"])
-                self.assertIn("0.6.0", supported["netbox-dlm"])
-                self.assertIn("0.8.0", supported["netbox-dlm"])
-                self.assertIn("0.9.1", supported["netbox-dlm"])
-
-    def test_an_unvalidated_version_is_still_refused(self):
-        # The gates fail closed; widening must not become "any version".
-        for supported in (
-            COPY_SQL_SUPPORTED_OPTIONAL_DISTRIBUTIONS,
-            SET_BASED_MERGE_SUPPORTED_OPTIONAL_DISTRIBUTIONS,
-        ):
-            self.assertNotIn("0.6.1", supported["netbox-dlm"])
-            self.assertNotIn("0.3.3", supported["netbox-dlm"])
-            # Released, and still refused: 0.9.0 cannot render any of its own
-            # views. Widening to 0.9.1 must not sweep it in by proximity.
-            self.assertNotIn("0.9.0", supported["netbox-dlm"])
-
-    def test_the_other_distributions_stay_single_valued(self):
-        # Only netbox-dlm has a second validated version so far.
-        for supported in (
-            COPY_SQL_SUPPORTED_OPTIONAL_DISTRIBUTIONS,
-            SET_BASED_MERGE_SUPPORTED_OPTIONAL_DISTRIBUTIONS,
-        ):
-            for name in (
-                "netbox-cisco-aci",
-                "netbox-peering-manager",
-                "netbox-routing",
-            ):
-                self.assertEqual(len(supported[name]), 1, name)
+            with self.subTest(gate=gate):
+                self.assertNotIn(
+                    "999.999.999", supported.get("netbox-dlm", frozenset())
+                )
 
 
 class FastBaselineRuntimeTupleTest(SimpleTestCase):
@@ -83,40 +104,37 @@ class FastBaselineRuntimeTupleTest(SimpleTestCase):
         # not silently switch an engine off.
         for version in ("4.6.5", "4.6.6", "4.6.12", "4.6"):
             self.assertTrue(series_matches(version, "4.6"), version)
-        for version in ("1.1.1", "1.1.2", "1.1.9"):
-            self.assertTrue(series_matches(version, "1.1"), version)
+        # The prerelease stays: anyone who installed the beta before 1.2.0
+        # shipped must not be refused by a series check that only ever saw
+        # release strings.
+        for version in ("1.2.0b1", "1.2.0", "1.2.9"):
+            self.assertTrue(series_matches(version, "1.2"), version)
 
     def test_a_different_series_is_still_refused(self):
         # Permissive within a series is not permissive across one.
-        for version in ("4.7.0", "4.5.9", "5.0.0", "", None, "4.60.1"):
-            self.assertFalse(series_matches(version, "4.6"), version)
-        for version in ("1.2.0", "1.0.9", "2.0.0"):
-            self.assertFalse(series_matches(version, "1.1"), version)
+        for version in ("4.6.8", "4.5.9", "5.0.0", "", None, "4.70.1"):
+            self.assertFalse(series_matches(version, "4.7"), version)
+        for version in ("1.1.3", "1.0.9", "2.0.0"):
+            self.assertFalse(series_matches(version, "1.2"), version)
 
-    def _decide(self, dlm_version):
+    def _decide(self, *, optional_plugins=None, plugin_apps=None, netbox="4.7.0"):
+        """A runtime tuple in the 4.7 shape: no optional plugin can be there.
+
+        The old helper varied a netbox-dlm version, because on 4.6 that was the
+        thing customers changed under us. On 4.7 no optional plugin can be
+        installed at all, so the interesting variable is now whether an
+        UNEXPECTED app is present - which must fail closed exactly as a wrong
+        version did.
+        """
         from forward_netbox.utilities import fast_baseline
 
         tuple_ = {
-            "netbox": "4.6.5",
-            "branching": "1.1.1",
+            "netbox": netbox,
+            "branching": "1.2.0",
             "forward_netbox": fast_baseline.forward_config.version,
-            "optional_plugins": {
-                "netbox-cisco-aci": "0.4.0",
-                "netbox-dlm": dlm_version,
-                "netbox-peering-manager": "0.3.0",
-                "netbox-routing": "0.4.3",
-                "netbox-validity": "3.5.2",
-            },
+            "optional_plugins": optional_plugins or {},
             "plugin_apps": sorted(
-                {
-                    "forward_netbox",
-                    "netbox_branching",
-                    "netbox_cisco_aci",
-                    "netbox_dlm",
-                    "netbox_peering_manager",
-                    "netbox_routing",
-                    "validity",
-                }
+                plugin_apps or {"forward_netbox", "netbox_branching"}
             ),
         }
         with patch.object(
@@ -124,70 +142,48 @@ class FastBaselineRuntimeTupleTest(SimpleTestCase):
         ):
             return fast_baseline._runtime_decision()
 
+    def test_the_validated_runtime_keeps_the_fast_baseline(self):
+        self.assertNotEqual(self._decide().reason_code, "unsupported_runtime_tuple")
+
     def test_a_later_netbox_patch_keeps_the_fast_baseline(self):
-        from forward_netbox.utilities import fast_baseline
-
-        tuple_ = {
-            "netbox": "4.6.9",
-            "branching": "1.1.3",
-            "forward_netbox": fast_baseline.forward_config.version,
-            "optional_plugins": {
-                "netbox-cisco-aci": "0.4.0",
-                "netbox-dlm": "0.5.0",
-                "netbox-peering-manager": "0.3.0",
-                "netbox-routing": "0.4.3",
-                "netbox-validity": "3.5.2",
-            },
-            "plugin_apps": sorted(
-                {
-                    "forward_netbox",
-                    "netbox_branching",
-                    "netbox_cisco_aci",
-                    "netbox_dlm",
-                    "netbox_peering_manager",
-                    "netbox_routing",
-                    "validity",
-                }
-            ),
-        }
-        with patch.object(
-            fast_baseline, "fast_baseline_runtime_tuple", return_value=tuple_
-        ):
-            self.assertNotEqual(
-                fast_baseline._runtime_decision().reason_code,
-                "unsupported_runtime_tuple",
-            )
-
-    def test_the_previously_pinned_version_is_still_supported(self):
+        # Series matching, not an exact pin: a 4.7 patch must not silently drop
+        # a deployment onto the slow path.
         self.assertNotEqual(
-            self._decide("0.4.1").reason_code, "unsupported_runtime_tuple"
+            self._decide(netbox="4.7.9").reason_code, "unsupported_runtime_tuple"
         )
 
-    def test_the_upgraded_version_no_longer_disables_the_fast_baseline(self):
-        # The customer-visible symptom: upgrading netbox-dlm made a first sync
-        # fall back to the slow path with nothing explaining why.
-        self.assertNotEqual(
-            self._decide("0.5.0").reason_code, "unsupported_runtime_tuple"
+    def test_an_optional_plugin_that_cannot_run_here_fails_closed(self):
+        # Nothing validates netbox-dlm on 4.7 - it cannot be installed - so a
+        # runtime reporting one is a runtime this was never checked against.
+        decision = self._decide(
+            optional_plugins={"netbox-dlm": "0.9.1"},
+            plugin_apps={"forward_netbox", "netbox_branching", "netbox_dlm"},
         )
 
-    def test_an_unvalidated_version_still_fails_closed(self):
-        decision = self._decide("0.6.1")
+        self.assertFalse(decision.enabled)
+        self.assertEqual(decision.reason_code, "unsupported_runtime_tuple")
+
+    def test_an_unexpected_plugin_app_fails_closed(self):
+        # The app set is exact equality: an extra app is an unvalidated runtime
+        # even when it declares no version at all.
+        decision = self._decide(
+            plugin_apps={"forward_netbox", "netbox_branching", "some_other_plugin"}
+        )
 
         self.assertFalse(decision.enabled)
         self.assertEqual(decision.reason_code, "unsupported_runtime_tuple")
 
     def test_the_rejection_detail_stays_serialisable(self):
-        # `expected` holds sets now; it is persisted as job evidence, so it must
+        # `expected` holds sets; it is persisted as job evidence, so it must
         # render as sorted lists rather than blow up on JSON encoding.
         import json
 
-        detail = self._decide("0.6.1").context
+        detail = self._decide(
+            plugin_apps={"forward_netbox", "netbox_branching", "some_other_plugin"}
+        ).context
 
         json.dumps(detail)
-        self.assertEqual(
-            detail["expected"]["optional_plugins"]["netbox-dlm"],
-            ["0.4.1", "0.5.0", "0.6.0", "0.7.0", "0.8.0", "0.9.1"],
-        )
+        self.assertEqual(detail["expected"]["optional_plugins"], {})
 
 
 class FastBaselineFieldContractTest(SimpleTestCase):
@@ -220,6 +216,7 @@ class FastBaselineFieldContractTest(SimpleTestCase):
 
         self.assertEqual([entry["model"] for entry in drift], ["dcim.site"])
 
+    @unittest.skipUnless(apps.is_installed("netbox_dlm"), "netbox-dlm is not installed")
     def test_an_optional_field_does_not_trip_it(self):
         # netbox-dlm 0.5.0 adds SoftwareVersion.release_designation as a blank
         # CharField. bulk_create fills that in without help, so it must not be

--- a/forward_netbox/tests/test_ospf_drift_comparison.py
+++ b/forward_netbox/tests/test_ospf_drift_comparison.py
@@ -1,3 +1,17 @@
+import unittest
+
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import Interface
+from dcim.models import Manufacturer
+from dcim.models import Site
+from django.apps import apps
+from django.test import TestCase
+from ipam.models import VRF
+
+from forward_netbox.utilities.drift_comparison import compare_model_rows
+
 # Slice eight of the adapter-only drift comparison, and the last one:
 # `netbox_routing.ospfinstance`, `ospfarea` and `ospfinterface`.
 #
@@ -12,16 +26,13 @@
 # model with its own query and its own rows, so folding a parent's create into
 # the interface's verdict would count one object twice. `preview_leaf_outcome`
 # is that distinction, and the double-count test below is what pins it.
-from dcim.models import Device
-from dcim.models import DeviceRole
-from dcim.models import DeviceType
-from dcim.models import Interface
-from dcim.models import Manufacturer
-from dcim.models import Site
-from django.test import TestCase
-from ipam.models import VRF
 
-from forward_netbox.utilities.drift_comparison import compare_model_rows
+# These models only exist when the optional plugin is installed, and on
+# NetBox 4.7 it cannot be: netbox-routing declares a max_version in the 4.6
+# series, so NetBox refuses to start with it. The suite skips rather than
+# fails - but this IS lost coverage, not a clean pass, and the 4.6 lane on
+# 2.9.x is where these adapters stay exercised until that ceiling moves.
+NETBOX_ROUTING_INSTALLED = apps.is_installed("netbox_routing")
 
 INSTANCE = "netbox_routing.ospfinstance"
 AREA = "netbox_routing.ospfarea"
@@ -38,6 +49,7 @@ def _ospf_models():
     )
 
 
+@unittest.skipUnless(NETBOX_ROUTING_INSTALLED, "netbox-routing is not installed")
 class OspfPreviewTest(TestCase):
     def setUp(self):
         site = Site.objects.create(name="O Site", slug="o-site")

--- a/forward_netbox/tests/test_peering_drift_comparison.py
+++ b/forward_netbox/tests/test_peering_drift_comparison.py
@@ -1,3 +1,20 @@
+import unittest
+
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import Manufacturer
+from dcim.models import Site
+from django.apps import apps
+from django.test import TestCase
+from ipam.models import ASN
+from ipam.models import IPAddress
+from ipam.models import RIR
+
+from forward_netbox.utilities.drift_comparison import compare_model_rows
+from forward_netbox.utilities.sync_routing_impl import bgp_peer_comments
+from forward_netbox.utilities.sync_routing_impl import bgp_peer_name
+
 # Slice seven of the adapter-only drift comparison: the peering models -
 # `netbox_routing.bgppeer`, `bgpaddressfamily`, `bgppeeraddressfamily`, and
 # `netbox_peering_manager.peeringsession`.
@@ -18,19 +35,13 @@
 # so a router this run would rewrite is drift that no model would report if the
 # peer's verdict looked only at the leaf row. That is what
 # `preview_routing_outcome` is for, and what the parent tests below pin.
-from dcim.models import Device
-from dcim.models import DeviceRole
-from dcim.models import DeviceType
-from dcim.models import Manufacturer
-from dcim.models import Site
-from django.test import TestCase
-from ipam.models import ASN
-from ipam.models import IPAddress
-from ipam.models import RIR
 
-from forward_netbox.utilities.drift_comparison import compare_model_rows
-from forward_netbox.utilities.sync_routing_impl import bgp_peer_comments
-from forward_netbox.utilities.sync_routing_impl import bgp_peer_name
+# These models only exist when the optional plugin is installed, and on
+# NetBox 4.7 it cannot be: netbox-peering-manager declares a max_version in the 4.6
+# series, so NetBox refuses to start with it. The suite skips rather than
+# fails - but this IS lost coverage, not a clean pass, and the 4.6 lane on
+# 2.9.x is where these adapters stay exercised until that ceiling moves.
+NETBOX_PEERING_MANAGER_INSTALLED = apps.is_installed("netbox_peering_manager")
 
 BGP_PEER = "netbox_routing.bgppeer"
 
@@ -45,6 +56,9 @@ def _routing_models():
     )
 
 
+@unittest.skipUnless(
+    NETBOX_PEERING_MANAGER_INSTALLED, "netbox-peering-manager is not installed"
+)
 class PeeringPreviewTest(TestCase):
     def setUp(self):
         site = Site.objects.create(name="P Site", slug="p-site")

--- a/forward_netbox/tests/test_query_registry.py
+++ b/forward_netbox/tests/test_query_registry.py
@@ -1,8 +1,10 @@
 import json
 import re
+import unittest
 from pathlib import Path
 from unittest.mock import Mock
 
+from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
@@ -2539,6 +2541,9 @@ select {name: "vendor", slug: "vendor"}
         )
         self.assertFalse(dlm_maps.filter(enabled=True).exists())
 
+    @unittest.skipUnless(
+        apps.is_installed("netbox_cisco_aci"), "netbox-cisco-aci is not installed"
+    )
     def test_seed_builtin_maps_includes_installed_aci_models(self):
         seed_builtin_nqe_maps(type("Sender", (), {"label": "forward_netbox"}))
 

--- a/forward_netbox/tests/test_refused_deletes_are_not_staged.py
+++ b/forward_netbox/tests/test_refused_deletes_are_not_staged.py
@@ -1,3 +1,5 @@
+import unittest
+
 """A delete the database will refuse must never be staged.
 
 A deployment's sync reported sixteen protected-delete skips: ten `dcim.device`
@@ -38,6 +40,12 @@ from django.apps import apps
 from django.test import TestCase
 
 from forward_netbox.utilities.workload_state import _reference_protected_pks
+
+# netbox-dlm cannot be installed on NetBox 4.7: it declares a max_version in
+# the 4.6 series and NetBox refuses to start with a plugin outside its range.
+# These skip rather than fail, which IS lost coverage - the 4.6 lane on 2.9.x
+# is where the DLM paths stay exercised until that ceiling moves.
+DLM_INSTALLED = apps.is_installed("netbox_dlm")
 
 
 class TheCollectorSeesProtectionAScanCannotTest(TestCase):
@@ -94,6 +102,7 @@ class TheCollectorSeesProtectionAScanCannotTest(TestCase):
         )
 
 
+@unittest.skipUnless(DLM_INSTALLED, "netbox-dlm is not installed")
 class SoftwareVersionInventoryItemHoldTest(TestCase):
     """The six skips the hand-written list omitted."""
 

--- a/forward_netbox/tests/test_runtime_dependency_check.py
+++ b/forward_netbox/tests/test_runtime_dependency_check.py
@@ -29,17 +29,30 @@ class RuntimeDependencyCheckTest(SimpleTestCase):
         _check_runtime_dependencies()
 
     def test_rejects_version_that_is_not_exact(self):
-        with patch("forward_netbox._resolved_branching_version", return_value="1.0.4"):
-            with self.assertRaises(ImproperlyConfigured):
-                _check_runtime_dependencies()
+        # 1.2 is the supported series now, so the versions either side of it are
+        # what must be refused. 1.1.x is the branching line for NetBox 4.6 and
+        # cannot run on 4.7 at all; loading against it would be the worst kind
+        # of failure, since the plugin would start and the merge internals it
+        # reaches into would differ underneath.
+        for version in ("1.0.4", "1.1.3", "1.3.0", None):
+            with self.subTest(branching=version):
+                with patch(
+                    "forward_netbox._resolved_branching_version", return_value=version
+                ):
+                    with self.assertRaises(ImproperlyConfigured):
+                        _check_runtime_dependencies()
 
-        with patch("forward_netbox._resolved_branching_version", return_value="1.2.0"):
-            with self.assertRaises(ImproperlyConfigured):
-                _check_runtime_dependencies()
-
-        with patch("forward_netbox._resolved_branching_version", return_value=None):
-            with self.assertRaises(ImproperlyConfigured):
-                _check_runtime_dependencies()
+    def test_accepts_the_supported_series_including_a_prerelease(self):
+        # 3.0 ships against 1.2.0 final. The prerelease stays in this list on
+        # purpose: `series_matches` accepts it by prefix, and anyone who
+        # installed the beta before final shipped must not be locked out by a
+        # version check that only ever saw release strings.
+        for version in ("1.2.0b1", "1.2.0", "1.2.4"):
+            with self.subTest(branching=version):
+                with patch(
+                    "forward_netbox._resolved_branching_version", return_value=version
+                ):
+                    _check_runtime_dependencies()
 
     def test_rejects_when_not_importable(self):
         real_import = (

--- a/forward_netbox/tests/test_sync.py
+++ b/forward_netbox/tests/test_sync.py
@@ -1324,9 +1324,16 @@ select {name: site.name, slug: site.name}
             "tag_color": "9e9e9e",
         }
 
+        # The FIRST apply is measured separately from the repeat. Creating a tag
+        # assignment legitimately invalidates the device's config-context cache
+        # on NetBox 4.7 - `_config_context_data = NULL` plus a generation bump -
+        # and that write is correct work, not churn. The property this test
+        # exists to defend is that applying the SAME row again does nothing, so
+        # the repeat is what gets the empty assertion.
+        runner._apply_extras_taggeditem(row)
+
         before_count = ObjectChange.objects.count()
         with CaptureQueriesContext(connection) as queries:
-            runner._apply_extras_taggeditem(row)
             runner._apply_extras_taggeditem(row)
 
         self.assertEqual(device.tags.filter(slug="feature").count(), 1)

--- a/forward_netbox/tests/test_validated_runtime_is_declared_once.py
+++ b/forward_netbox/tests/test_validated_runtime_is_declared_once.py
@@ -114,12 +114,16 @@ class AddingAnIntegrationTakesOneEditTest(SimpleTestCase):
     def test_helpers_name_what_differs(self):
         from forward_netbox.utilities import validated_runtime
 
-        installed = (VALIDATED_PLUGIN_APPS | {"stranger"}) - {"netbox_dlm"}
+        # Removes netbox_branching rather than an optional plugin: on NetBox 4.7
+        # no optional plugin is in the validated set, so dropping one would be a
+        # no-op and the assertion would pass without testing anything. Branching
+        # is always there, and its absence is the case that matters most.
+        installed = (VALIDATED_PLUGIN_APPS | {"stranger"}) - {"netbox_branching"}
 
         self.assertFalse(validated_runtime.validated_plugin_apps_match(installed))
         self.assertEqual(
             validated_runtime.unexpected_plugin_apps(installed), ["stranger"]
         )
         self.assertEqual(
-            validated_runtime.missing_plugin_apps(installed), ["netbox_dlm"]
+            validated_runtime.missing_plugin_apps(installed), ["netbox_branching"]
         )

--- a/forward_netbox/tests/test_workload_state.py
+++ b/forward_netbox/tests/test_workload_state.py
@@ -1,7 +1,9 @@
 import hashlib
 import json
+import unittest
 from unittest.mock import patch
 
+from django.apps import apps
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
@@ -25,6 +27,12 @@ from forward_netbox.utilities.workload_state import decode_state_entries
 from forward_netbox.utilities.workload_state import encode_state_entries
 from forward_netbox.utilities.workload_state import promote_workload_states_locked
 from forward_netbox.utilities.workload_state import stage_workload_states
+
+# netbox-dlm cannot be installed on NetBox 4.7: it declares a max_version in
+# the 4.6 series and NetBox refuses to start with a plugin outside its range.
+# These skip rather than fail, which IS lost coverage - the 4.6 lane on 2.9.x
+# is where the DLM paths stay exercised until that ceiling moves.
+DLM_INSTALLED = apps.is_installed("netbox_dlm")
 
 
 def _workload(
@@ -482,6 +490,7 @@ class DurableWorkloadStateTest(TestCase):
 
         self.assertEqual(workloads[0].delete_rows, [row])
 
+    @unittest.skipUnless(DLM_INSTALLED, "netbox-dlm is not installed")
     def test_enrichment_only_software_version_state_never_derives_delete(self):
         row = {"platform_slug": "ios-xe", "version": "17.12.7"}
         _, pending, _ = apply_durable_workload_deltas(
@@ -539,6 +548,7 @@ class DurableWorkloadStateTest(TestCase):
             device=device,
         )
 
+    @unittest.skipUnless(DLM_INSTALLED, "netbox-dlm is not installed")
     def test_software_catalog_sweep_is_scoped_to_versions_this_sync_can_attribute(
         self,
     ):
@@ -568,6 +578,7 @@ class DurableWorkloadStateTest(TestCase):
         self.assertEqual(workloads[0].delete_rows, [])
         self.assertEqual(summaries[0]["protected_delete_rows"], 1)
 
+    @unittest.skipUnless(DLM_INSTALLED, "netbox-dlm is not installed")
     def test_an_operator_created_version_is_not_a_sweep_candidate(self):
         # No device of this sync references `1.0`. Before this change it was
         # deleted on every full run because it was in the table and not in
@@ -584,6 +595,7 @@ class DurableWorkloadStateTest(TestCase):
         self.assertEqual(workloads[0].delete_rows, [])
         self.assertEqual(summaries[0]["catalog_delete_rows"], 0)
 
+    @unittest.skipUnless(DLM_INSTALLED, "netbox-dlm is not installed")
     def test_a_version_referenced_only_by_another_syncs_device_is_not_swept(self):
         from django.apps import apps
 
@@ -620,6 +632,7 @@ class DurableWorkloadStateTest(TestCase):
             CATALOG_SWEEP_MODELS, frozenset({"netbox_dlm.softwareversion"})
         )
 
+    @unittest.skipUnless(DLM_INSTALLED, "netbox-dlm is not installed")
     def test_catalog_deletes_follow_authoritative_association_deletes_same_run(self):
         from django.apps import apps
         from dcim.models import Device
@@ -747,6 +760,7 @@ class DurableWorkloadStateTest(TestCase):
             0,
         )
 
+    @unittest.skipUnless(DLM_INSTALLED, "netbox-dlm is not installed")
     def test_peer_association_state_protects_catalog_transition_deletes(self):
         from django.apps import apps
         from dcim.models import Platform
@@ -1136,6 +1150,7 @@ class DurableWorkloadStateTest(TestCase):
         self.assertEqual(workloads[0].delete_rows, [])
         self.assertEqual(summaries[0]["mode"], "contract_reset")
 
+    @unittest.skipUnless(DLM_INSTALLED, "netbox-dlm is not installed")
     def test_first_dlm_baseline_deletes_legacy_rows_absent_from_target(self):
         current = [{"cve_id": "CVE-2026-0001"}]
         legacy = [

--- a/forward_netbox/urls.py
+++ b/forward_netbox/urls.py
@@ -53,6 +53,32 @@ urlpatterns = (
         include(get_model_urls("forward_netbox", "forwardnqemap")),
     ),
     path(
+        "change/",
+        include(get_model_urls("forward_netbox", "forwardchange", detail=False)),
+    ),
+    path(
+        "change/<int:pk>/",
+        include(get_model_urls("forward_netbox", "forwardchange")),
+    ),
+    path(
+        "change-policy/",
+        include(get_model_urls("forward_netbox", "forwardchangepolicy", detail=False)),
+    ),
+    path(
+        "change-policy/<int:pk>/",
+        include(get_model_urls("forward_netbox", "forwardchangepolicy")),
+    ),
+    path(
+        "change-policy-rule/",
+        include(
+            get_model_urls("forward_netbox", "forwardchangepolicyrule", detail=False)
+        ),
+    ),
+    path(
+        "change-policy-rule/<int:pk>/",
+        include(get_model_urls("forward_netbox", "forwardchangepolicyrule")),
+    ),
+    path(
         "drift-policy/",
         include(get_model_urls("forward_netbox", "forwarddriftpolicy", detail=False)),
     ),

--- a/forward_netbox/utilities/apply_engine_copy_sql.py
+++ b/forward_netbox/utilities/apply_engine_copy_sql.py
@@ -117,7 +117,8 @@ def _runtime_preflight(*, branch, content_type):
     for model_name, configured in getattr(protection_rules, "items", lambda: ())():
         if str(model_name).lower() == COPY_SQL_MODEL_STRING and configured:
             return False, "dynamic_protection_rule_present"
-    if CustomField.objects.get_for_model(content_type.model_class()).exists():
+    # NetBox 4.7 returns a list here, not a queryset: no `.exists()`.
+    if CustomField.objects.get_for_model(content_type.model_class()):
         return False, "custom_field_definition_present"
     object_change_type = ContentType.objects.get_for_model(ObjectChange)
     if EventRule.objects.filter(

--- a/forward_netbox/utilities/apply_engine_decision.py
+++ b/forward_netbox/utilities/apply_engine_decision.py
@@ -64,8 +64,8 @@ COPY_SQL_MODEL_SPEC_VERSIONS = {
 }
 COPY_SQL_ALLOWED_MODELS = frozenset(COPY_SQL_MODEL_SPEC_VERSIONS)
 
-COPY_SQL_SUPPORTED_NETBOX_SERIES = "4.6"
-COPY_SQL_SUPPORTED_BRANCHING_SERIES = "1.1"
+COPY_SQL_SUPPORTED_NETBOX_SERIES = "4.7"
+COPY_SQL_SUPPORTED_BRANCHING_SERIES = "1.2"
 # Derived from the single validated-runtime declaration; see
 # `validated_runtime` for why these are no longer written out per engine, and
 # for the netbox-validity entry - a CONSUMER integration reads configuration
@@ -373,7 +373,15 @@ def _copy_sql_runtime_supported():
             },
         )
     for distribution, actual in optional_versions:
-        expected = COPY_SQL_SUPPORTED_OPTIONAL_DISTRIBUTIONS[distribution]
+        # `.get`, not `[...]`. A distribution the runtime reports but this
+        # declaration has never heard of is an UNVALIDATED runtime, which is
+        # exactly what this loop exists to refuse - so it must fail closed and
+        # say so, not raise KeyError out of a decision function. That is not
+        # hypothetical on NetBox 4.7: the validated map is empty there, so any
+        # deployment carrying an optional plugin hit this.
+        expected = COPY_SQL_SUPPORTED_OPTIONAL_DISTRIBUTIONS.get(
+            distribution, frozenset()
+        )
         # Absence is also a different runtime tuple. Each entry lists every
         # version validated against this engine; anything else fails closed.
         if actual not in expected:

--- a/forward_netbox/utilities/bulk_merge.py
+++ b/forward_netbox/utilities/bulk_merge.py
@@ -39,7 +39,17 @@ from django.db import transaction
 from django.db.models import prefetch_related_objects
 from django.db.models import Q
 from django.db.models.deletion import ProtectedError
-from mptt.models import MPTTModel
+from netbox.models.ltree import LtreeField
+from netbox.models.ltree import LtreeModel
+
+try:  # pragma: no cover - exercised by whichever runtime is installed
+    # Legacy on NetBox 4.7: ltree replaced django-mptt, but mptt is still
+    # installed as a transitive dependency and a plugin model may still use it.
+    # Tolerated rather than required, so this module keeps importing the day
+    # nothing depends on mptt any more.
+    from mptt.models import MPTTModel
+except ImportError:  # pragma: no cover
+    MPTTModel = None
 from netbox_branching.merge_strategies.squash import ActionType
 from netbox_branching.merge_strategies.squash import CollapsedChange
 from netbox_branching.merge_strategies.squash import SquashMergeStrategy
@@ -563,7 +573,7 @@ def _split_bidirectional_create_cycles(collapsed_changes, change_logger):
             break
 
 
-# The bookkeeping columns django-mptt adds to every tree model. Checked as a
+# The bookkeeping columns django-mptt added to every tree model. Checked as a
 # SIGNATURE rather than only by base class, because the base class is the part
 # upstream can change without telling us.
 _MPTT_FIELD_SIGNATURE = frozenset({"lft", "rght", "tree_id", "level"})
@@ -572,25 +582,30 @@ _MPTT_FIELD_SIGNATURE = frozenset({"lft", "rght", "tree_id", "level"})
 def _is_tree_model(model_class) -> bool:
     """Whether this model maintains hierarchy state that a bulk insert skips.
 
-    Two independent tests, and either one is enough. `issubclass(MPTTModel)` is
-    exact while django-mptt is what NetBox uses; the field signature keeps
-    working if the base class moves but the columns stay.
+    Four independent tests, any one of which is enough, in two pairs: a base
+    class and a column signature for each of the two mechanisms NetBox has
+    used. The base class is exact; the signature keeps working if the base
+    class moves but the columns stay.
 
-    Why both: NetBox 4.7 replaces the deprecated `NestedGroupModel` with an
-    ltree implementation. If django-mptt is uninstalled with it, the import at
-    the top of this module fails loudly and someone fixes it. The dangerous
-    case is the quiet one - mptt still installed as somebody's transitive
-    dependency while NetBox models no longer inherit from it. Then
-    `issubclass` simply answers False for every former tree model, they all
-    become "bulk safe", and `bulk_create` skips the per-object save that keeps
-    the hierarchy coherent. No error, corrupted tree.
+    The prediction written here for 4.6 came true exactly as stated. NetBox 4.7
+    replaced django-mptt with ltree, and the hoped-for loud failure did not
+    happen: **django-mptt is still installed on 4.7** as a transitive
+    dependency, so the import succeeded and `issubclass(MPTTModel)` simply
+    answered False for Region, SiteGroup and Location. All three became "bulk
+    safe", and `bulk_create` skips the per-object save that keeps the hierarchy
+    coherent - no error, corrupted tree. `test_tree_model_detection.py` is what
+    caught it.
 
-    `test_tree_model_detection.py` guards the residual gap: it asserts this
-    function still recognises a real nested-group model in the installed
-    NetBox, so a detector that has stopped detecting fails the suite instead of
-    silently reporting everything flat.
+    So the ltree pair leads now and the mptt pair is retained as legacy: a
+    plugin model may still use mptt, and answering True for a real tree costs
+    only a slower path, while answering False corrupts data. This asymmetry is
+    why every test here is additive and none is an `elif`.
     """
-    if issubclass(model_class, MPTTModel):
+    if issubclass(model_class, LtreeModel):
+        return True
+    if any(isinstance(field, LtreeField) for field in model_class._meta.fields):
+        return True
+    if MPTTModel is not None and issubclass(model_class, MPTTModel):
         return True
     field_names = {field.name for field in model_class._meta.fields}
     return _MPTT_FIELD_SIGNATURE <= field_names

--- a/forward_netbox/utilities/fast_baseline.py
+++ b/forward_netbox/utilities/fast_baseline.py
@@ -86,17 +86,23 @@ FAST_BASELINE_OMITTED_EVIDENCE = (
 # `bulk_create` without our help, which is why netbox-dlm 0.5.0 adding
 # `SoftwareVersion.release_designation` is fine. A new *required* column is one
 # the loader would leave unset, so it fails closed instead.
+# The three hierarchical models lost `level`/`lft`/`rght`/`tree_id` in NetBox
+# 4.7: ltree replaced django-mptt and the columns were dropped. Their `path`
+# replacement is NOT required - database triggers maintain it - so `bulk_create`
+# no longer has to fabricate tree bookkeeping at all. Read off the live runtime
+# rather than hand-edited, because this contract exists to fail closed when a
+# column appears, and a guess would defeat it.
 FAST_BASELINE_REQUIRED_FIELD_CONTRACT = {
     "dcim.cable": (),
     "dcim.device": ("device_type", "role", "site"),
-    "dcim.devicerole": ("level", "lft", "name", "rght", "slug", "tree_id"),
+    "dcim.devicerole": ("name", "slug"),
     "dcim.devicetype": ("manufacturer", "model", "slug"),
     "dcim.interface": ("device", "name", "type"),
-    "dcim.inventoryitem": ("device", "level", "lft", "name", "rght", "tree_id"),
+    "dcim.inventoryitem": ("device", "name"),
     "dcim.macaddress": ("mac_address",),
     "dcim.manufacturer": ("name", "slug"),
     "dcim.module": ("device", "module_bay", "module_type"),
-    "dcim.platform": ("level", "lft", "name", "rght", "slug", "tree_id"),
+    "dcim.platform": ("name", "slug"),
     "dcim.site": ("name", "slug"),
     "extras.taggeditem": ("content_type", "object_id", "tag"),
     "ipam.fhrpgroup": ("group_id", "protocol"),
@@ -510,7 +516,13 @@ def _dynamic_hook_decision(models):
 
     content_types = [ContentType.objects.get_for_model(model) for model in models]
     for model, content_type in zip(models, content_types, strict=True):
-        custom_fields = list(CustomField.objects.get_for_model(model).order_by("name"))
+        # NetBox 4.7 returns a list, so `.order_by()` is gone too; sort here.
+        # 4.7 also omits fields whose stored data a background job is still
+        # updating, which is the answer this gate wants: a field mid-rewrite
+        # is not one the fast path may assume is settled.
+        custom_fields = sorted(
+            CustomField.objects.get_for_model(model), key=lambda field: field.name
+        )
         model_string = f"{model._meta.app_label}.{model._meta.model_name}"
         # The exact supported plugin migration owns this optional Device object
         # field. It is populated only by the generation-guarded post-baseline

--- a/forward_netbox/utilities/fast_baseline_models.py
+++ b/forward_netbox/utilities/fast_baseline_models.py
@@ -13,7 +13,6 @@ from itertools import chain
 
 from core.models import ObjectType
 from django.db import transaction
-from django.db.models import Max
 
 _BATCH_SIZE = 5_000
 FAST_BASELINE_SET_BASED_MODELS = frozenset(
@@ -344,10 +343,11 @@ def bulk_load_inventory_items(runner, rows):
         role_by_slug = {**existing_roles, **{role.slug: role for role in roles}}
 
         objects = []
-        first_tree_id = (
-            InventoryItem.objects.aggregate(value=Max("tree_id"))["value"] or 0
-        ) + 1
-        for tree_id, row in enumerate(rows, first_tree_id):
+        # No tree bookkeeping is assembled here any more. NetBox 4.7 dropped
+        # `lft`/`rght`/`tree_id`/`level` from InventoryItem when ltree replaced
+        # django-mptt, and the `path` column that replaced them is maintained by
+        # a database trigger, which fires for these inserts like any other.
+        for row in rows:
             device = device_by_name[str(row["device"])]
             objects.append(
                 InventoryItem(
@@ -365,10 +365,6 @@ def bulk_load_inventory_items(runner, rows):
                     _site_id=device.site_id,
                     _location_id=device.location_id,
                     _rack_id=device.rack_id,
-                    lft=1,
-                    rght=2,
-                    tree_id=tree_id,
-                    level=0,
                 )
             )
         _bulk_create(InventoryItem, objects)
@@ -728,18 +724,33 @@ def _adapter_workload_contract(rows_by_model):
             return False, {"model": model_string, "reason": "invalid_routing_identity"}
 
     af_rows = rows_by_model.get("netbox_routing.bgpaddressfamily", [])
-    from netbox_routing.models import BGPAddressFamily
-
-    allowed_address_families = {
-        str(choice[0])
-        for choice in BGPAddressFamily._meta.get_field("address_family").choices
-    }
+    peer_af_rows = rows_by_model.get("netbox_routing.bgppeeraddressfamily", [])
+    # Unconditional before, which crashed the whole fast baseline with
+    # ModuleNotFoundError on NetBox 4.7 - netbox-routing caps at a max_version
+    # in the 4.6 series and cannot be installed there, so this import always
+    # failed and it failed LOUDLY in a contract function rather than declining.
+    #
+    # Nothing to validate is not the same as failing to validate: with no
+    # routing rows there is no address family to check and the contract has
+    # nothing to say. Rows for a model whose plugin is absent is a different
+    # thing entirely, and fails closed below.
+    if af_rows or peer_af_rows:
+        try:
+            from netbox_routing.models import BGPAddressFamily
+        except ImportError:
+            return False, {
+                "model": "netbox_routing.bgpaddressfamily",
+                "reason": "routing_plugin_not_installed",
+            }
+        allowed_address_families = {
+            str(choice[0])
+            for choice in BGPAddressFamily._meta.get_field("address_family").choices
+        }
+    else:
+        allowed_address_families = set()
     if allowed_address_families and any(
         _routing_af(row.get("afi_safi")) not in allowed_address_families
-        for row in [
-            *af_rows,
-            *rows_by_model.get("netbox_routing.bgppeeraddressfamily", []),
-        ]
+        for row in [*af_rows, *peer_af_rows]
     ):
         return False, {
             "model": "netbox_routing.bgpaddressfamily",
@@ -764,7 +775,16 @@ def bulk_load_vulnerabilities(runner, rows):
         return False
 
     from dcim.models import Device, Platform
-    from netbox_dlm.models import CVE, DeviceSoftware, SoftwareVersion, Vulnerability
+
+    try:
+        from netbox_dlm.models import CVE
+        from netbox_dlm.models import DeviceSoftware
+        from netbox_dlm.models import SoftwareVersion
+        from netbox_dlm.models import Vulnerability
+    except ImportError:
+        # Reachable only with rows for a model whose plugin is absent, which is
+        # a refusal rather than a crash - the same shape as the routing guard.
+        return False
 
     device_names = {str(row["name"]).strip() for row in rows}
     platform_slugs = {str(row["platform_slug"]).strip() for row in rows}

--- a/forward_netbox/utilities/ingestion_merge.py
+++ b/forward_netbox/utilities/ingestion_merge.py
@@ -2,18 +2,13 @@ from contextlib import contextmanager
 
 from core.exceptions import SyncError
 from core.models import Job
-from core.signals import pre_sync
-from dcim.models import Site
 from dcim.models import VirtualChassis
-from dcim.signals import assign_virtualchassis_master
-from dcim.signals import sync_cached_scope_fields
 from django.db import DEFAULT_DB_ALIAS
 from django.db import transaction
 from django.db.models import signals
 from django.utils import timezone
 from django.utils.module_loading import import_string
-from django_pglocks import advisory_lock
-from extras.signals import notify_object_changed
+from django_pg_utils import advisory_lock
 from netbox.constants import ADVISORY_LOCK_KEYS
 from netbox_branching.choices import BranchStatusChoices
 from netbox_branching.models import AppliedChange
@@ -38,8 +33,6 @@ def suppress_ingest_side_effect_signals():
     - assign_virtualchassis_master (dcim): recalculates VC master on every
       VirtualChassis save; meaningless mid-ingest, so it is skipped until the
       final save.
-    - sync_cached_scope_fields (dcim): recalculates Site scope cache on every
-      Site save; batched naturally after ingest.
     - notify_object_changed (extras): creates Notification rows per save for
       subscribers; no operator subscribes to ingest-driven churn and the lookup
       fires a DB query per object even with no subscribers.
@@ -47,10 +40,28 @@ def suppress_ingest_side_effect_signals():
     Does NOT suppress core.signals.handle_changed_object (ObjectChange /
     Branching diff tracking) — that is intentional and required for Branching
     review.
+
+    NOT suppressed on NetBox 4.7, and deliberately not replaced:
+    `sync_cached_scope_fields` no longer exists. 4.7 maintains the
+    CachedScopeMixin denormalized columns - Site's among them - with database
+    triggers rather than a Python post_save handler, so the per-save cost this
+    suppression avoided is gone rather than moved. What remains in Python is
+    the Location and Rack scope cascade (`handle_location_site_change` and its
+    Rack counterpart), and this sync writes neither model: `dcim.site` is the
+    only one of the three in the query registry. Suppressing a handler for a
+    model nothing here saves would be theatre.
     """
+    # Imported here, not at module scope. `forward_netbox.models` imports this
+    # module while Django is still loading models, and on NetBox 4.7
+    # `extras.signals` runs `_connect_object_save_handlers()` at import time,
+    # which calls `apps.get_model()` and raises `AppRegistryNotReady`. The
+    # sibling signal modules are deferred with it so the next one to grow an
+    # import-time side effect does not reintroduce the same failure.
+    from dcim.signals import assign_virtualchassis_master
+    from extras.signals import notify_object_changed
+
     disconnect_pairs = [
         (assign_virtualchassis_master, VirtualChassis),
-        (sync_cached_scope_fields, Site),
         (notify_object_changed, None),
     ]
 
@@ -388,6 +399,8 @@ def sync_merge_ingestion(
         claimed_job_id is None or ingestion.merge_job_id != claimed_job_id
     ):
         raise SyncError("Cannot initiate merge; merge already in progress.")
+
+    from core.signals import pre_sync
 
     pre_sync.send(sender=ingestion.__class__, instance=ingestion)
     context = _post_merge_context(ingestion, mark_baseline_ready)

--- a/forward_netbox/utilities/job_queue.py
+++ b/forward_netbox/utilities/job_queue.py
@@ -7,7 +7,7 @@ from core.choices import JobStatusChoices
 from core.models import Job
 from core.models import ObjectType
 from django.db import transaction
-from django_pglocks import advisory_lock
+from django_pg_utils import advisory_lock
 from netbox.constants import ADVISORY_LOCK_KEYS
 from utilities.rqworker import get_queue_for_model
 

--- a/forward_netbox/utilities/merge_set_based.py
+++ b/forward_netbox/utilities/merge_set_based.py
@@ -29,8 +29,8 @@ logger = logging.getLogger("forward_netbox.bulk_merge")
 
 SET_BASED_MERGE_MODEL_SPEC_VERSIONS = {"dcim.macaddress": 1}
 SET_BASED_MERGE_ALLOWED_MODELS = frozenset(SET_BASED_MERGE_MODEL_SPEC_VERSIONS)
-SET_BASED_MERGE_SUPPORTED_NETBOX_SERIES = "4.6"
-SET_BASED_MERGE_SUPPORTED_BRANCHING_SERIES = "1.1"
+SET_BASED_MERGE_SUPPORTED_NETBOX_SERIES = "4.7"
+SET_BASED_MERGE_SUPPORTED_BRANCHING_SERIES = "1.2"
 # Derived from the single validated-runtime declaration; see
 # `validated_runtime` for why these are no longer written out per engine.
 SET_BASED_MERGE_SUPPORTED_OPTIONAL_DISTRIBUTIONS = VALIDATED_OPTIONAL_DISTRIBUTIONS
@@ -49,14 +49,26 @@ _MAC_PAYLOAD_FIELDS = frozenset(
     }
 )
 _MAC_FAST_UPDATE_FIELDS = frozenset({"assigned_object_type", "assigned_object_id"})
+# Read off the live NetBox 4.7 runtime, not carried forward from 4.6. Two
+# entries changed and both are load-bearing:
+#
+# - `netbox.denormalized.update_denormalized_fields` is GONE from post_save.
+#   4.7 maintains denormalized columns with database triggers, and the
+#   `netbox.denormalized` module does not exist at all. That is a reason this
+#   engine can do MORE on 4.7, not less: the per-row Python work it used to
+#   have to reason about is now the database's job.
+# - The search cache handlers moved from `netbox.search.backends.SearchBackend`
+#   to `netbox.search.signals`, and 4.7 defers the write to a background job.
+#
+# This set is exact equality: a receiver appearing or disappearing disables the
+# engine rather than letting it run against a runtime it was not validated on.
 _EXPECTED_MAC_SIGNAL_RECEIVERS = {
     "pre_save": frozenset(),
     "post_save": frozenset(
         {
             "core.signals.handle_changed_object",
             "extras.signals.notify_object_changed",
-            "netbox.denormalized.update_denormalized_fields",
-            "netbox.search.backends.SearchBackend.caching_handler",
+            "netbox.search.signals.caching_handler",
         }
     ),
     "pre_delete": frozenset(
@@ -65,7 +77,7 @@ _EXPECTED_MAC_SIGNAL_RECEIVERS = {
             "extras.signals.notify_object_changed",
         }
     ),
-    "post_delete": frozenset({"netbox.search.backends.SearchBackend.removal_handler"}),
+    "post_delete": frozenset({"netbox.search.signals.removal_handler"}),
 }
 
 
@@ -180,7 +192,15 @@ def _runtime_tuple_decision():
             },
         )
     for distribution, actual in optional_versions:
-        expected = SET_BASED_MERGE_SUPPORTED_OPTIONAL_DISTRIBUTIONS[distribution]
+        # `.get`, not `[...]`. A distribution the runtime reports but this
+        # declaration has never heard of is an UNVALIDATED runtime, which is
+        # exactly what this loop exists to refuse - so it must fail closed and
+        # say so, not raise KeyError out of a decision function. That is not
+        # hypothetical on NetBox 4.7: the validated map is empty there, so any
+        # deployment carrying an optional plugin hit this.
+        expected = SET_BASED_MERGE_SUPPORTED_OPTIONAL_DISTRIBUTIONS.get(
+            distribution, frozenset()
+        )
         if actual not in expected:
             return SetBasedMergeDecision(
                 False,
@@ -245,7 +265,6 @@ def set_based_merge_decision(*, sync, branch, model_string=SET_BASED_MAC_MODEL):
     from extras.models import CustomField
     from extras.models import EventRule
     from netbox.config import get_config
-    from netbox.denormalized import registry as denormalized_registry
     from netbox.search import get_indexer
 
     expected_columns = {
@@ -270,7 +289,8 @@ def set_based_merge_decision(*, sync, branch, model_string=SET_BASED_MAC_MODEL):
             {"expected": sorted(expected_columns), "actual": sorted(actual_columns)},
         )
     content_type = ContentType.objects.get_for_model(MACAddress)
-    if CustomField.objects.get_for_model(MACAddress).exists():
+    # NetBox 4.7 returns a list here, not a queryset: no `.exists()`.
+    if CustomField.objects.get_for_model(MACAddress):
         return SetBasedMergeDecision(False, "custom_field_definition_present", {})
     config = get_config()
     validators = getattr(config, "CUSTOM_VALIDATORS", {}) or getattr(
@@ -316,8 +336,16 @@ def set_based_merge_decision(*, sync, branch, model_string=SET_BASED_MAC_MODEL):
                 },
             },
         )
-    if denormalized_registry["denormalized_fields"].get(MACAddress):
-        return SetBasedMergeDecision(False, "denormalized_fields_present", {})
+    # NetBox 4.7 removed `registry["denormalized_fields"]` along with the whole
+    # `netbox.denormalized` module: denormalized columns are maintained by
+    # database triggers now. The gate existed because a Python post_save
+    # handler would have written columns this engine's set-based UPDATE does
+    # not go through. A trigger fires inside the same statement, so that class
+    # of divergence cannot arise, and there is nothing left to ask.
+    #
+    # This is a real widening: on 4.6 an installed denormalization disabled the
+    # engine outright. It is recorded here rather than silently dropped so the
+    # next reader knows the check was retired on purpose.
     try:
         indexer = get_indexer(MACAddress)
     except KeyError:

--- a/forward_netbox/utilities/model_validation.py
+++ b/forward_netbox/utilities/model_validation.py
@@ -67,6 +67,7 @@ def clean_forward_source(source):
             "scope_endpoints_by_include_tags",
             "config_backup_data_source",
             "config_backup_include_unmanaged",
+            "enable_predict",
         }
     )
     if invalid:
@@ -92,6 +93,8 @@ def clean_forward_source(source):
         )
     if not isinstance(parameters.get("config_backup_include_unmanaged", False), bool):
         raise ValidationError(_("`config_backup_include_unmanaged` must be a boolean."))
+    if not isinstance(parameters.get("enable_predict", False), bool):
+        raise ValidationError(_("`enable_predict` must be a boolean."))
     if not isinstance(parameters.get("sync_generic_endpoints", False), bool):
         raise ValidationError(_("`sync_generic_endpoints` must be a boolean."))
     parameters.setdefault("scope_endpoints_by_include_tags", True)

--- a/forward_netbox/utilities/stuck_recovery.py
+++ b/forward_netbox/utilities/stuck_recovery.py
@@ -15,7 +15,7 @@ from core.choices import JobStatusChoices
 from core.models import Job
 from core.models import ObjectType
 from django.utils import timezone
-from django_pglocks import advisory_lock
+from django_pg_utils import advisory_lock
 from netbox.constants import ADVISORY_LOCK_KEYS
 from netbox_branching.choices import BranchStatusChoices
 

--- a/forward_netbox/utilities/sync_facade.py
+++ b/forward_netbox/utilities/sync_facade.py
@@ -3,7 +3,7 @@ from core.exceptions import SyncError
 from django.db import transaction as db_transaction
 from django.db.models import Q
 from django.utils.module_loading import import_string
-from django_pglocks import advisory_lock
+from django_pg_utils import advisory_lock
 from netbox.constants import ADVISORY_LOCK_KEYS
 
 from ..choices import forward_configured_models

--- a/forward_netbox/utilities/validated_runtime.py
+++ b/forward_netbox/utilities/validated_runtime.py
@@ -26,39 +26,41 @@ codes. This module carries facts about the runtime, not policy about it.
 
 # NetBox and Branching are matched by series; a patch release inside a
 # validated series is not a different runtime.
-VALIDATED_NETBOX_SERIES = "4.6"
-VALIDATED_BRANCHING_SERIES = "1.1"
+VALIDATED_NETBOX_SERIES = "4.7"
+VALIDATED_BRANCHING_SERIES = "1.2"
 
 # Plugin apps as they appear in `settings.PLUGINS`.
+#
+# On NetBox 4.7 this is forward_netbox and Branching, and nothing else. Every
+# optional integration - netbox-dlm 0.9.1, netbox-cisco-aci 0.4.0,
+# netbox-peering-manager 0.3.0, netbox-routing, netbox-validity 3.5.2 -
+# declares `max_version = "4.6.99"`, and NetBox refuses to start with a plugin
+# outside its declared range. They cannot be installed here, so listing them
+# would be a claim about a runtime nobody can assemble.
+#
+# This set is an EXACT match that fails closed and silently: an app present in
+# PLUGINS but absent here disables COPY/SQL, the set-based merge and the fast
+# baseline with no error, turning a first sync from minutes into hours. So when
+# an optional plugin raises its ceiling past 4.6.99, its app label goes back in
+# here and its versions into VALIDATED_OPTIONAL_DISTRIBUTIONS below - a data
+# edit in one file, which is the whole point of this module.
 VALIDATED_PLUGIN_APPS = frozenset(
     {
         "forward_netbox",
         "netbox_branching",
-        "netbox_cisco_aci",
-        "netbox_dlm",
-        "netbox_peering_manager",
-        "netbox_routing",
-        # netbox-validity is a CONSUMER integration: it reads configuration
-        # files from a git data source and writes nothing the apply engines
-        # touch. It is listed here anyway, because this set is an exact match
-        # that fails closed - its mere presence in PLUGINS would otherwise
-        # disable the fast paths entirely. This entry is a claim that they
-        # were validated with it installed; the COPY/SQL paired-branch
-        # equivalence tests are that validation.
-        "validity",
     }
 )
 
 # Distribution name -> every version validated against these subsystems, not a
 # single pin. An exact pin meant a customer upgrading one optional plugin
 # silently lost the fast paths, because the whole tuple stopped matching.
-VALIDATED_OPTIONAL_DISTRIBUTIONS = {
-    "netbox-cisco-aci": frozenset({"0.4.0"}),
-    "netbox-dlm": frozenset({"0.4.1", "0.5.0", "0.6.0", "0.7.0", "0.8.0", "0.9.1"}),
-    "netbox-peering-manager": frozenset({"0.3.0"}),
-    "netbox-routing": frozenset({"0.4.3"}),
-    "netbox-validity": frozenset({"3.5.2"}),
-}
+# Empty on 4.7 for the reason above, not because the integrations were
+# removed: their registry, models and sync paths are all still here and still
+# report an absent plugin honestly. The 4.6 versions this set held are kept in
+# the 2.9.x line, and the values to restore are recorded in
+# `docs/03_Plans/active/2026-09-02-netbox-4.7-runtime.md` so regaining one is a
+# lookup rather than an archaeology exercise.
+VALIDATED_OPTIONAL_DISTRIBUTIONS: dict[str, frozenset[str]] = {}
 
 # The distributions whose versions a runtime probe reports. Derived rather than
 # repeated: a name expected but never probed reads as ABSENT and fails the

--- a/forward_netbox/views.py
+++ b/forward_netbox/views.py
@@ -43,6 +43,9 @@ from .filtersets import ForwardNQEMapFilterSet
 from .filtersets import ForwardSourceFilterSet
 from .filtersets import ForwardSyncFilterSet
 from .filtersets import ForwardValidationRunFilterSet
+from .forms import ForwardChangeForm
+from .forms import ForwardChangePolicyForm
+from .forms import ForwardChangePolicyRuleForm
 from .forms import ForwardDriftPolicyBulkEditForm
 from .forms import ForwardDriftPolicyForm
 from .forms import ForwardIngestionMergeForm
@@ -53,6 +56,10 @@ from .forms import ForwardSourceForm
 from .forms import ForwardSyncBulkEditForm
 from .forms import ForwardSyncForm
 from .forms import ForwardValidationRunForceAllowForm
+from .models import ForwardChange
+from .models import ForwardChangePolicy
+from .models import ForwardChangePolicyRule
+from .models import ForwardChangeReview
 from .models import ForwardDeviceAnalysis
 from .models import ForwardDriftPolicy
 from .models import ForwardIngestion
@@ -61,6 +68,8 @@ from .models import ForwardNQEMap
 from .models import ForwardSource
 from .models import ForwardSync
 from .models import ForwardValidationRun
+from .tables import ForwardChangePolicyTable
+from .tables import ForwardChangeTable
 from .tables import ForwardDeviceAnalysisTable
 from .tables import ForwardDriftPolicyTable
 from .tables import ForwardIngestionChangesTable
@@ -2950,3 +2959,191 @@ if django_apps.is_installed("netbox_dlm"):
                     for label in ("critical", "high", "medium", "low")
                 },
             }
+
+
+@register_model_view(ForwardChange, "list", path="", detail=False)
+class ForwardChangeListView(generic.ObjectListView):
+    queryset = ForwardChange.objects.all()
+    table = ForwardChangeTable
+    actions = (AddObject, BulkExport, BulkDelete)
+
+
+@register_model_view(ForwardChange, "add", detail=False)
+@register_model_view(ForwardChange, "edit")
+class ForwardChangeEditView(generic.ObjectEditView):
+    queryset = ForwardChange.objects.all()
+    form = ForwardChangeForm
+
+
+@register_model_view(ForwardChange)
+class ForwardChangeView(generic.ObjectView):
+    queryset = ForwardChange.objects.all()
+    template_name = "forward_netbox/forwardchange.html"
+
+    def get_extra_context(self, request, instance):
+        """Everything the approver needs on one page, and nothing implied.
+
+        The two panels are kept apart deliberately. `criterion_outcomes` is
+        evidence and feeds the verdict; the predict panel is advisory and does
+        not. A reader must be able to tell which is which, because an advisory
+        panel that looks like evidence is how a prediction becomes a decision.
+        """
+        from .change_control.evidence import criterion_outcomes
+        from .change_control.predict import PredictOutcome
+        from .change_control.predict import render_predict_panel
+        from .change_control.state_machine import available_transitions
+        from .change_control.state_machine import check_transition
+
+        outcomes = criterion_outcomes(instance)
+        transitions = []
+        for target in available_transitions(instance.state):
+            result = check_transition(instance, target)
+            transitions.append(
+                {
+                    "target": target,
+                    "allowed": result.allowed,
+                    "blockers": result.blockers,
+                }
+            )
+
+        return {
+            "criterion_outcomes": outcomes,
+            "transitions": transitions,
+            "predict_panel": render_predict_panel(
+                PredictOutcome(
+                    status=instance.predict_status or PredictOutcome.UNAVAILABLE,
+                    reason=instance.predict_reason,
+                    pre_verdict=instance.predict_pre_verdict,
+                )
+            ),
+            "scoped_devices": instance.devices.select_related("device"),
+            "reviews": instance.reviews.select_related("reviewer"),
+        }
+
+
+@register_model_view(ForwardChange, "delete")
+class ForwardChangeDeleteView(generic.ObjectDeleteView):
+    queryset = ForwardChange.objects.all()
+
+
+@register_model_view(ForwardChange, "bulk_delete", path="delete", detail=False)
+class ForwardChangeBulkDeleteView(generic.BulkDeleteView):
+    queryset = ForwardChange.objects.all()
+    table = ForwardChangeTable
+
+
+@register_model_view(ForwardChangePolicy, "list", path="", detail=False)
+class ForwardChangePolicyListView(generic.ObjectListView):
+    queryset = ForwardChangePolicy.objects.all()
+    table = ForwardChangePolicyTable
+    actions = (AddObject, BulkExport, BulkEdit, BulkDelete)
+
+
+@register_model_view(ForwardChangePolicy, "add", detail=False)
+@register_model_view(ForwardChangePolicy, "edit")
+class ForwardChangePolicyEditView(generic.ObjectEditView):
+    queryset = ForwardChangePolicy.objects.all()
+    form = ForwardChangePolicyForm
+
+
+@register_model_view(ForwardChangePolicy)
+class ForwardChangePolicyView(generic.ObjectView):
+    queryset = ForwardChangePolicy.objects.all()
+    template_name = "forward_netbox/forwardchangepolicy.html"
+
+    def get_extra_context(self, request, instance):
+        return {"rules": instance.rules.select_related("device_role", "site")}
+
+
+@register_model_view(ForwardChangePolicy, "delete")
+class ForwardChangePolicyDeleteView(generic.ObjectDeleteView):
+    queryset = ForwardChangePolicy.objects.all()
+
+
+@register_model_view(ForwardChangePolicy, "bulk_delete", path="delete", detail=False)
+class ForwardChangePolicyBulkDeleteView(generic.BulkDeleteView):
+    queryset = ForwardChangePolicy.objects.all()
+    table = ForwardChangePolicyTable
+
+
+@register_model_view(ForwardChange, "review", path="review")
+class ForwardChangeReviewView(BaseObjectView):
+    """Record an approval or a rejection at whichever gate is open.
+
+    The first and only writer of `ForwardChangeReview`. Until this existed the
+    approval gate was unreachable: reviews had no form, view or API, so no
+    change could leave STAGED at all.
+
+    The anchors are captured HERE, from the change as it is at this moment,
+    rather than accepted from the request. That is what makes staleness mean
+    anything - a reviewer approves the evidence they were shown, and a review
+    that carried its own anchors could claim to have seen anything.
+    """
+
+    queryset = ForwardChange.objects.all()
+
+    def get_required_permission(self):
+        # A distinct right from editing, following `run_forwardsync`. Anyone
+        # who can edit a change should not thereby be able to sign it off.
+        return "forward_netbox.approve_forwardchange"
+
+    def get(self, request, pk):
+        change = get_object_or_404(self.queryset, pk=pk)
+        return redirect(change.get_absolute_url())
+
+    def post(self, request, pk):
+        from .change_control.choices import ForwardChangeStateChoices
+        from .change_control.choices import ForwardReviewPhaseChoices
+
+        change = get_object_or_404(self.queryset, pk=pk)
+        approved = request.POST.get("decision") == "approve"
+
+        # The gate is derived from the change's state, not chosen by the
+        # reviewer: a POST approval recorded while the change is still STAGED
+        # would sign off on evidence that does not exist yet.
+        phase = (
+            ForwardReviewPhaseChoices.POST
+            if change.state == ForwardChangeStateChoices.VERIFIED_PROCEED
+            else ForwardReviewPhaseChoices.PRE
+        )
+
+        if change.requester_id and change.requester_id == request.user.pk:
+            messages.error(
+                request,
+                _(
+                    "You raised this change, so your own approval does not "
+                    "count towards it."
+                ),
+            )
+            return redirect(change.get_absolute_url())
+
+        ForwardChangeReview.objects.update_or_create(
+            change=change,
+            reviewer=request.user,
+            phase=phase,
+            defaults={
+                "approved": approved,
+                "comment": (request.POST.get("comment") or "").strip(),
+                "branch_change_time": change.branch_last_change_time,
+                "baseline_snapshot_id": change.before_snapshot_id,
+                "after_snapshot_id": change.after_snapshot_id,
+                "verdict": change.verdict,
+            },
+        )
+        messages.success(
+            request,
+            _("Recorded your %(phase)s-change decision.") % {"phase": phase},
+        )
+        return redirect(change.get_absolute_url())
+
+
+@register_model_view(ForwardChangePolicyRule, "add", detail=False)
+@register_model_view(ForwardChangePolicyRule, "edit")
+class ForwardChangePolicyRuleEditView(generic.ObjectEditView):
+    queryset = ForwardChangePolicyRule.objects.all()
+    form = ForwardChangePolicyRuleForm
+
+
+@register_model_view(ForwardChangePolicyRule, "delete")
+class ForwardChangePolicyRuleDeleteView(generic.ObjectDeleteView):
+    queryset = ForwardChangePolicyRule.objects.all()

--- a/poetry.lock
+++ b/poetry.lock
@@ -1659,14 +1659,15 @@ docs = ["mkdocs (==1.6.1)", "mkdocs-include-markdown-plugin (==7.1.8)", "mkdocs-
 
 [[package]]
 name = "netboxlabs-netbox-branching"
-version = "1.1.3"
+version = "1.2.0"
 description = "A git-like branching implementation for NetBox"
 optional = false
-python-versions = ">=3.10"
+python-versions = ">=3.12"
 groups = ["main"]
+markers = "python_version >= \"3.12\""
 files = [
-    {file = "netboxlabs_netbox_branching-1.1.3-py3-none-any.whl", hash = "sha256:38d8e22f98f5ad3b7401469a92f6536721cc21487b377eaa5f73e76dc3c3820b"},
-    {file = "netboxlabs_netbox_branching-1.1.3.tar.gz", hash = "sha256:b10836563c00ccb2f796651a35b3270854c62a33eef7e19808e8392ae1b9f15d"},
+    {file = "netboxlabs_netbox_branching-1.2.0-py3-none-any.whl", hash = "sha256:222b88291a1e0e5e9762d8586a764bc5caf462929706179aae2db749d606ee52"},
+    {file = "netboxlabs_netbox_branching-1.2.0.tar.gz", hash = "sha256:97102bdb2d1d25f94851e0468f8643e9ef80cf9cba77e402918f1522c0211461"},
 ]
 
 [package.extras]
@@ -2828,4 +2829,4 @@ validity = ["netbox-validity"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "85ce462fb1513abcd88578cbf0b8b87ecd62e3c60752f4fed475c44d39c228bc"
+content-hash = "c497a528f378ce8c2240023ebcf0c46607ccc26421fefdde687188a6e86862d3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,11 @@ Changelog = "https://github.com/forwardnetworks/forward-netbox/blob/main/CHANGEL
 
 [tool.poetry.dependencies]
 httpx = ">0.26,<0.29"
-netboxlabs-netbox-branching = ">=1.1.1,<1.2.0"
+# 1.2.0 final declares requires-python >=3.12, which the beta did not.
+# Scoped the same way as the optional plugins rather than raising the
+# project floor: NetBox 4.7 needs 3.12+ anyway, so this states a fact
+# about the dependency rather than working around one.
+netboxlabs-netbox-branching = {version = ">=1.2.0,<1.3.0", python = ">=3.12,<3.15"}
 pyzipper = ">=0.4.0,<0.5.0"
 python = ">=3.10,<3.15"
 # Optional NetBox-plugin integrations. The core install pulls none of these;

--- a/scripts/check_release_authorization.py
+++ b/scripts/check_release_authorization.py
@@ -66,8 +66,8 @@ EVIDENCE_BASE_RE = re.compile(
 )
 EVIDENCE_REQUIRED_TEXT_PATTERNS = {
     "exact-runtime-artifact": (
-        re.compile(r"\bNetBox\s+4\.6\.8\b", re.IGNORECASE),
-        re.compile(r"\bBranching\s+1\.1\.3\b", re.IGNORECASE),
+        re.compile(r"\bNetBox\s+4\.7\.0\b", re.IGNORECASE),
+        re.compile(r"\bBranching\s+1\.2\.0\b", re.IGNORECASE),
         re.compile(r"\bPython\s+3\.14\b", re.IGNORECASE),
         re.compile(r"\bSBOM\b", re.IGNORECASE),
     ),
@@ -87,13 +87,13 @@ RELEASE_RUNTIME_ENVIRONMENT = {
     "FORWARD_NETBOX_DOCKER_PROJECT": "forward-netbox-release-gate",
     "FORWARD_NETBOX_POSTGRES_DATA_PATH": "netbox-postgres-data",
     "FORWARD_NETBOX_WORKER_AUTORELOAD": "0",
-    "NETBOX_VER": "v4.6.8",
+    "NETBOX_VER": "v4.7.0",
 }
 ACCEPTANCE_RUNTIME_ENVIRONMENT = {
     "FORWARD_NETBOX_DOCKER_PROJECT": "forward-netbox-upgrade26",
     "FORWARD_NETBOX_POSTGRES_DATA_PATH": "netbox-postgres-data",
     "FORWARD_NETBOX_WORKER_AUTORELOAD": "0",
-    "NETBOX_VER": "v4.6.8",
+    "NETBOX_VER": "v4.7.0",
 }
 
 
@@ -138,7 +138,7 @@ def _safe_environment_assignment(assignment: str) -> bool:
         # cannot be used to smuggle a value into the recorded command.
         return value == "1"
     return (name, value) in {
-        ("NETBOX_VER", "v4.6.8"),
+        ("NETBOX_VER", "v4.7.0"),
         ("FORWARD_NETBOX_WORKER_AUTORELOAD", "0"),
         ("FORWARD_NETBOX_POSTGRES_DATA_PATH", "netbox-postgres-data"),
     }

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -100,18 +100,27 @@ def bump_version_text(text: str, old: str, new: str, *, key: str) -> str:
     return new_text
 
 
-def insert_release_row(table_text: str, version: str, summary: str) -> str:
+def insert_release_row(
+    table_text: str, version: str, summary: str, *, support: str = ""
+) -> str:
     """Insert a release candidate while retaining the published current row.
 
     Finalization promotes the candidate and demotes the prior release only after
     the release branch is green, so unreleased docs never claim publication.
+
+    `support` overrides the compatibility cell. It defaults to reusing the
+    current row's text verbatim, which is right for every release that does not
+    move the runtime - and wrong for the one that does. 3.0 changes NetBox 4.6
+    to 4.7 and Branching 1.1 to 1.2, and inheriting the previous cell would
+    have published a row claiming 3.0 runs on the version it explicitly
+    refuses to load on.
     """
     if "| Release candidate;" in table_text:
         raise ReleaseError("a release candidate already exists")
     match = CURRENT_RELEASE_RE.search(table_text)
     if not match:
         raise ReleaseError("could not find the current-release row to supersede")
-    support = match.group("support")
+    support = support or match.group("support")
     new_row = f"| `v{version}` | {support} | Release candidate; {summary} |"
     old_line_start = match.start()
     return table_text[:old_line_start] + new_row + "\n" + table_text[old_line_start:]
@@ -150,8 +159,15 @@ def promote_release_candidate_text(table_text: str, version: str) -> str:
     return "".join(lines)
 
 
-def set_release_intro_text(text: str, version: str, *, candidate: bool) -> str:
-    """Keep the compatibility introduction aligned with the release table."""
+def set_release_intro_text(
+    text: str, version: str, *, candidate: bool, requirements: str = ""
+) -> str:
+    """Keep the compatibility introduction aligned with the release table.
+
+    `requirements` overrides the sentence's runtime clause for the same reason
+    `insert_release_row` takes `support`: a release that moves the runtime must
+    not inherit the previous one's wording.
+    """
     matches = list(RELEASE_INTRO_RE.finditer(text))
     if len(matches) != 1:
         raise ReleaseError(
@@ -160,8 +176,9 @@ def set_release_intro_text(text: str, version: str, *, candidate: bool) -> str:
     match = matches[0]
     release_label = "release candidate" if candidate else "release"
     notes_label = "candidate notes" if candidate else "release notes"
+    requirements = requirements or match.group("requirements")
     replacement = (
-        f"The `{version}` {release_label} requires {match.group('requirements')}. "
+        f"The `{version}` {release_label} requires {requirements}. "
         f"Expand for the published release history and {notes_label}."
     )
     return text[: match.start()] + replacement + text[match.end() :]
@@ -221,15 +238,25 @@ def version_surface_edits(old: str, new: str) -> dict[Path, str]:
     return edits
 
 
-def stage_prepare(version: str, summary: str, *, write: bool) -> None:
+def stage_prepare(
+    version: str,
+    summary: str,
+    *,
+    write: bool,
+    support: str = "",
+    requirements: str = "",
+) -> None:
     old = read_current_version()
     print(f"[prepare] bump {old} -> {version}")
     edits = version_surface_edits(old, version)
     for path in README_TABLES:
         edits[path] = set_release_intro_text(
-            insert_release_row(path.read_text(encoding="utf-8"), version, summary),
+            insert_release_row(
+                path.read_text(encoding="utf-8"), version, summary, support=support
+            ),
             version,
             candidate=True,
+            requirements=requirements,
         )
     # Install-doc wheel/sdist/pin references.
     install_text = edits.get(INSTALL_DOC, INSTALL_DOC.read_text(encoding="utf-8"))
@@ -1524,6 +1551,22 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--write", action="store_true", help="write prepare edits")
     parser.add_argument(
+        "--support",
+        default="",
+        help=(
+            "compatibility cell for the new table row. Defaults to reusing the "
+            "current row, which is only right when the runtime has not moved."
+        ),
+    )
+    parser.add_argument(
+        "--requirements",
+        default="",
+        help=(
+            "runtime clause for the compatibility sentence, e.g. "
+            "'NetBox `4.7.x` (tested on `4.7.0`) and `netbox-branching` `1.2.x`'"
+        ),
+    )
+    parser.add_argument(
         "--publish",
         action="store_true",
         help="branch + push (rollout), then wait for GitHub CI. Off by default.",
@@ -1574,7 +1617,13 @@ def main(argv: list[str] | None = None) -> int:
             else:
                 stage_finish(args.version)
             return 0
-        stage_prepare(args.version, args.summary, write=args.write)
+        stage_prepare(
+            args.version,
+            args.summary,
+            write=args.write,
+            support=args.support,
+            requirements=args.requirements,
+        )
         if args.write:
             stage_verify(args.version)
         if args.publish:

--- a/scripts/tested_runtime.py
+++ b/scripts/tested_runtime.py
@@ -25,5 +25,5 @@ the harness rule rather than by being invisible to it.
 
 # The runtime every release gate runs on, and the version the compatibility
 # tables claim. Bump here first; the harness names every other site.
-TESTED_NETBOX_VERSION = "4.6.8"
+TESTED_NETBOX_VERSION = "4.7.0"
 TESTED_NETBOX_TAG = f"v{TESTED_NETBOX_VERSION}"

--- a/scripts/tests/test_release.py
+++ b/scripts/tests/test_release.py
@@ -578,7 +578,7 @@ class EvidenceCommandTest(unittest.TestCase):
         "FORWARD_NETBOX_DOCKER_PROJECT": "forward-netbox-release-gate",
         "FORWARD_NETBOX_POSTGRES_DATA_PATH": "netbox-postgres-data",
         "FORWARD_NETBOX_WORKER_AUTORELOAD": "0",
-        "NETBOX_VER": "v4.6.8",
+        "NETBOX_VER": "v4.7.0",
         "FORWARD_NETBOX_HOST_PORT": "18080",
         "NETBOX_URL": "http://127.0.0.1:18080",
         "HOME": "/nowhere",
@@ -590,7 +590,7 @@ class EvidenceCommandTest(unittest.TestCase):
             command,
             "rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate "
             "FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data "
-            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 invoke ci",
+            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.7.0 invoke ci",
         )
 
     def test_the_artifact_command_carries_the_pair_and_nothing_foreign(self):
@@ -615,8 +615,8 @@ class RenderReleaseAuthorizationTest(unittest.TestCase):
         environment = EvidenceCommandTest.ENVIRONMENT
         record = {
             "version": "2.9.2",
-            "netbox_version": "4.6.8",
-            "branching_version": "1.1.3",
+            "netbox_version": "4.7.0",
+            "branching_version": "1.2.0",
             "python_version": "3.14",
             "wheel": "forward_netbox-2.9.2-py3-none-any.whl",
             "gate": {

--- a/scripts/tests/test_release_authorization.py
+++ b/scripts/tests/test_release_authorization.py
@@ -19,35 +19,35 @@ class ReleaseAuthorizationTest(unittest.TestCase):
         "final-tree-full-gate": (
             "`rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate "
             "FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data "
-            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 "
+            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.7.0 "
             "invoke ci` passed: 1343 tests, 0 failures."
         ),
         "exact-runtime-artifact": (
             "`rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate "
             "FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data "
-            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 "
-            "invoke artifact-test` passed: NetBox 4.6.8, Branching 1.1.3, "
+            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.7.0 "
+            "invoke artifact-test` passed: NetBox 4.7.0, Branching 1.2.0, "
             "Python 3.14, and SBOM validation; 0 errors."
         ),
         "scale-and-failure": (
             "`rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-upgrade26 "
             "FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data "
-            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 "
+            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.7.0 "
             "invoke scale-soak --runs 3` passed 3 runs and "
             "`rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate "
             "FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data "
-            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 "
+            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.7.0 "
             "invoke scenario-test` passed 28 failure scenarios, 0 failures and "
             "`rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate "
             "FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data "
-            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 "
+            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.7.0 "
             "invoke bulk-merge-retry-scale-test` passed 20,005-row replay with "
             "a 1,512-second 1M-row projection under the 2,400-second limit."
         ),
         "ui-validation": (
             "`rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate "
             "FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data "
-            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 "
+            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.7.0 "
             "FORWARD_NETBOX_HOST_PORT=18081 NETBOX_URL=http://127.0.0.1:18081 "
             "invoke playwright-test` passed 14 desktop and mobile checks, 0 failures."
         ),
@@ -59,7 +59,7 @@ class ReleaseAuthorizationTest(unittest.TestCase):
         "customer-equivalent-acceptance": (
             "`rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-upgrade26 "
             "FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data "
-            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.6.8 "
+            "FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.7.0 "
             "invoke sync-release-gate --sync-ids 51` passed sync id 51: 0 blockers, "
             "0 warnings, 0 errors."
         ),
@@ -260,7 +260,7 @@ class ReleaseAuthorizationTest(unittest.TestCase):
         # The loosening must not leak: everything except the port pair is still
         # compared for exact equality with the canonical release environment.
         evidence = self._on_host_port("final-tree-full-gate", 18080).replace(
-            "NETBOX_VER=v4.6.8", "NETBOX_VER=v4.6.4"
+            "NETBOX_VER=v4.7.0", "NETBOX_VER=v4.6.8"
         )
         with self.assertRaisesRegex(ValueError, "placeholder_evidence"):
             release_authorization.check_release_authorization(

--- a/scripts/tests/test_tasks.py
+++ b/scripts/tests/test_tasks.py
@@ -51,7 +51,7 @@ class DockerComposeIsolationTest(unittest.TestCase):
         context = SimpleNamespace(
             run=Mock(),
             forward_netbox=SimpleNamespace(
-                netbox_ver="v4.6.8",
+                netbox_ver="v4.7.0",
                 project_name="forward-netbox",
                 compose_dir="/tmp/forward-netbox",
             ),
@@ -77,7 +77,7 @@ class DockerComposeIsolationTest(unittest.TestCase):
         context = SimpleNamespace(
             run=Mock(),
             forward_netbox=SimpleNamespace(
-                netbox_ver="v4.6.8",
+                netbox_ver="v4.7.0",
                 project_name="forward-netbox",
                 compose_dir="/tmp/forward-netbox",
             ),
@@ -91,7 +91,7 @@ class DockerComposeIsolationTest(unittest.TestCase):
 
 
 class ReleaseArtifactTaskTest(unittest.TestCase):
-    def _context(self, netbox_version="v4.6.8"):
+    def _context(self, netbox_version="v4.7.0"):
         return SimpleNamespace(
             run=Mock(),
             forward_netbox=SimpleNamespace(
@@ -121,7 +121,7 @@ class ReleaseArtifactTaskTest(unittest.TestCase):
             tasks.artifact_test.body(context)
 
         commands = [call.args[0] for call in context.run.call_args_list]
-        self.assertIn("--build-arg NETBOX_VER=v4.6.8", commands[0])
+        self.assertIn("--build-arg NETBOX_VER=v4.7.0", commands[0])
         self.assertIn(
             "--build-arg PACKAGE=/source/dist/forward_netbox-2.6.0-py3-none-any.whl",
             commands[0],
@@ -142,7 +142,7 @@ class ReleaseArtifactTaskTest(unittest.TestCase):
         self.assertIn("uv tool run --isolated", commands[2])
         self.assertIn("cyclonedx-py environment", commands[2])
         self.assertIn("--pyproject /tmp/netbox-runtime-pyproject.toml", commands[2])
-        self.assertIn('version = "4.6.8"', commands[2])
+        self.assertIn('version = "4.7.0"', commands[2])
         self.assertIn("forward-netbox==2.6.0", commands[2])
         self.assertIn("/opt/netbox/venv/bin/python", commands[2])
         self.assertIn("--output-reproducible", commands[2])
@@ -156,7 +156,7 @@ class ReleaseArtifactTaskTest(unittest.TestCase):
         )
 
     def test_artifact_test_rejects_any_other_netbox_version(self):
-        context = self._context(netbox_version="v4.6.4")
+        context = self._context(netbox_version="v4.6.8")
         wheel = tasks.REPO_ROOT / "dist/forward_netbox-2.6.0-py3-none-any.whl"
 
         with patch.object(
@@ -317,7 +317,7 @@ class ArtifactUpgradeTaskTest(unittest.TestCase):
 
     WHEEL = "dist/forward_netbox-2.6.7-py3-none-any.whl"
 
-    def _context(self, netbox_version="v4.6.8", tags="v2.6.5\nv2.6.6\n"):
+    def _context(self, netbox_version="v4.7.0", tags="v2.6.5\nv2.6.6\n"):
         run = Mock(return_value=SimpleNamespace(stdout=tags))
         return SimpleNamespace(
             run=run,
@@ -433,7 +433,7 @@ class ArtifactUpgradeTaskTest(unittest.TestCase):
         self.assertEqual(raised.exception.code, 2)
 
     def test_rejects_any_other_netbox_version(self):
-        context = self._context(netbox_version="v4.6.4")
+        context = self._context(netbox_version="v4.6.8")
         with patch.object(
             tasks,
             "_release_artifact_inputs",

--- a/scripts/tests/test_validate_sbom.py
+++ b/scripts/tests/test_validate_sbom.py
@@ -42,7 +42,7 @@ class ValidateSbomTest(unittest.TestCase):
         )
 
         self.assertGreaterEqual(result["component_count"], 20)
-        self.assertEqual(result["netbox_version"], "4.6.8")
+        self.assertEqual(result["netbox_version"], "4.7.0")
 
     def test_rejects_runtime_version_mismatch(self):
         components = self._components()

--- a/scripts/validate_installed_artifact.py
+++ b/scripts/validate_installed_artifact.py
@@ -33,10 +33,10 @@ def main():
         raise SystemExit(
             f"forward-netbox {package_version} != expected {args.expected_version}"
         )
-    if netbox_version != "4.6.8":
-        raise SystemExit(f"NetBox {netbox_version} != required 4.6.8")
-    if branching_version != "1.1.3":
-        raise SystemExit(f"netbox-branching {branching_version} != required 1.1.3")
+    if netbox_version != "4.7.0":
+        raise SystemExit(f"NetBox {netbox_version} != required 4.7.0")
+    if branching_version != "1.2.0":
+        raise SystemExit(f"netbox-branching {branching_version} != required 1.2.0")
 
     print(
         json.dumps(

--- a/scripts/validate_sbom.py
+++ b/scripts/validate_sbom.py
@@ -10,13 +10,10 @@ from pathlib import Path
 REQUIRED_COMPONENTS = {
     "forward-netbox": None,
     "httpx": "0.28.1",
-    "netbox": "4.6.8",
-    "netbox-cisco-aci": "0.4.0",
-    "netbox-dlm": "0.9.1",
-    "netbox-peering-manager": "0.3.0",
-    "netbox-routing": "0.4.3",
-    "netbox-validity": "3.5.2",
-    "netboxlabs-netbox-branching": "1.1.3",
+    "netbox": "4.7.0",
+    # The five optional plugins are absent on 4.7: each declares
+    # a max_version in the 4.6 series, so the artifact cannot contain them.
+    "netboxlabs-netbox-branching": "1.2.0",
     "pyzipper": "0.4.0",
 }
 

--- a/tasks.py
+++ b/tasks.py
@@ -91,7 +91,7 @@ namespace = Collection("forward_netbox")
 namespace.configure(
     {
         "forward_netbox": {
-            "netbox_ver": os.environ.get("NETBOX_VER", "v4.6.8"),
+            "netbox_ver": os.environ.get("NETBOX_VER", "v4.7.0"),
             "project_name": os.environ.get(
                 "FORWARD_NETBOX_DOCKER_PROJECT",
                 "forward-netbox",
@@ -1199,9 +1199,9 @@ def artifact_test(context):
     version, wheel = _release_artifact_inputs()
     sbom_path = _prepare_sbom_output(version)
     netbox_version = str(context.forward_netbox.netbox_ver or "").strip()
-    if netbox_version != "v4.6.8":
+    if netbox_version != "v4.7.0":
         raise Exit(
-            "Release artifact validation requires NETBOX_VER=v4.6.8.",
+            "Release artifact validation requires NETBOX_VER=v4.7.0.",
             code=2,
         )
 
@@ -1246,13 +1246,11 @@ def artifact_test(context):
             "'requires-python = \">=3.14,<3.15\"' "
             "'dependencies = [' "
             f"'  \"forward-netbox=={version}\",' "
-            "'  \"netbox-cisco-aci==0.4.0\",' "
-            "'  \"netbox-dlm==0.9.1\",' "
-            "'  \"netbox-peering-manager==0.3.0\",' "
-            "'  \"netbox-routing==0.4.3\",' "
-            "'  \"netbox-validity==3.5.2\",' "
-            "']' "
-            "> /tmp/netbox-runtime-pyproject.toml",
+            # The five optional plugins are NOT listed on NetBox 4.7: each caps
+            # at a max_version in the 4.6 series, so none of them is installed
+            # in the artifact and naming them would put components in the SBOM
+            # that the image does not contain.
+            "']' " "> /tmp/netbox-runtime-pyproject.toml",
             "UV_CACHE_DIR=/tmp/uv-cache uv tool run --isolated "
             f"--from cyclonedx-bom=={CYCLONEDX_BOM_VERSION} "
             "cyclonedx-py environment "
@@ -1313,9 +1311,9 @@ def artifact_upgrade_test(context, from_version=None, from_netbox_ver=None):
     """
     version, wheel = _release_artifact_inputs()
     netbox_version = str(context.forward_netbox.netbox_ver or "").strip()
-    if netbox_version != "v4.6.8":
+    if netbox_version != "v4.7.0":
         raise Exit(
-            "Release artifact validation requires NETBOX_VER=v4.6.8.",
+            "Release artifact validation requires NETBOX_VER=v4.7.0.",
             code=2,
         )
     # `invoke ci` runs this through its pre-list, which cannot pass arguments, so


### PR DESCRIPTION
## Summary

Re-lands the 3.0 content as **one reviewed commit**, so it carries a pull request association again.

## Why it had to be re-landed

The earlier history rewrite — which removed two live Forward identifiers from public history, correctly — gave every rewritten commit a new SHA. A SHA is how GitHub associates a commit with its pull request, so the association was lost. The provenance verifier then refused the `v3.0.0` tag:

```
ProvenanceError: direct release-control commit e6395c7 changes production code
```

I had read that rule as "control commits may be direct". That is only half of it: a direct control commit is permitted **only if it touches nothing under `forward_netbox/` outside tests**. Two of the rewritten commits changed production code, so the tag could never have passed. Purging the identifiers was still the right call; the cost was this rebuild.

## What is in it

The content is unchanged and already measured — the tree of `e1b6a65`, plus the release plan's corrections for branching 1.2.0 shipping before the tag.

- **NetBox 4.7 + netbox-branching 1.2.0** as the only supported runtime, with seven production defects fixed along the way — two of which failed *silently*: tree detection (mptt still installed but no longer inherited, so `bulk_create` would corrupt hierarchies) and the fast-baseline field contract (hours instead of minutes, no error).
- **Change control**: two human gates, an enforced approval policy, the first write path for reviews, predict flagged off by default.
- **The optional plugins** leave the image and the validated set together, because that set fails closed and silently.

## Validation

On 4.7.0 + branching 1.2.0: full suite **2648 OK** (158 skipped), harness **382 OK**, whole-repo lint clean, all three fast paths ENABLED on the exact runtime tuple, and the real upgrade leg green — **2.9.2 on NetBox 4.6.5 → 3.0.0 on 4.7.0**, with the rows seeded under the previous release surviving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa
