### PR TITLE
fix: a pull request merged into dead history is not this release

### DIFF
--- a/docs/03_Plans/active/2026-09-02-release-3.0.0.md
+++ b/docs/03_Plans/active/2026-09-02-release-3.0.0.md
@@ -87,6 +87,19 @@ belongs in the release notes.
   adapters are exercised on the 2.9.x lane until an upstream raises its
   ceiling.
 
+- **The release flow could not tell a live merge from a dead one.**
+  `_pull_request_for_branch` accepted any MERGED pull request on the release
+  branch name. After the history rewrite, v3.0.0's first release PRs were
+  merged into commits that no longer exist, so every subsequent run concluded
+  "release PR already merged" and stopped with nothing to fix. Deleting the
+  orphaned branches did not help: the lookup matches by head-ref NAME, which
+  outlives the branch.
+
+  The lookup now asks whether the merge commit is still reachable from
+  `origin/main`. A PR with no recorded merge commit is assumed live, because
+  a false "already merged" stops the flow loudly while a false "not merged"
+  would re-cut a shipped release.
+
 ## Open
 
 - The upgrade leg has not run yet; it needs the bumped version and so runs

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -752,6 +752,19 @@ def _checkout_merged_main() -> str:
 
 
 def _pull_request_for_branch(branch: str) -> dict | None:
+    """The pull request for `branch`, ignoring ones merged into dead history.
+
+    A merged PR whose merge commit is no longer reachable from `origin/main`
+    belongs to a history that was rewritten away. It looks identical to a real
+    one here - same head branch, state MERGED - and treating it as this
+    release's PR makes `stage_finish` conclude the release is already cut and
+    stop, every time, with nothing to fix.
+
+    That is not hypothetical: purging two live Forward identifiers from public
+    history orphaned the v3.0.0 release PRs exactly this way, and the flow
+    refused to move until the check learned to ask whether the merge is still
+    part of the branch being released.
+    """
     raw = _capture(
         [
             "gh",
@@ -766,16 +779,43 @@ def _pull_request_for_branch(branch: str) -> dict | None:
             "--state",
             "all",
             "--limit",
-            "1",
+            "5",
             "--json",
-            "number,state,mergedAt,url,headRefName,baseRefName",
+            "number,state,mergedAt,url,headRefName,baseRefName,mergeCommit",
         ]
     )
     try:
         pulls = json.loads(raw) if raw else []
     except json.JSONDecodeError:
         pulls = []
-    return pulls[0] if pulls else None
+    for pull in pulls:
+        if pull.get("state") != "MERGED":
+            return pull
+        if _merge_is_live(pull):
+            return pull
+    return None
+
+
+def _merge_is_live(pull: dict) -> bool:
+    """Whether a merged PR's merge commit is still reachable from origin/main."""
+    commit = (pull.get("mergeCommit") or {}).get("oid") or ""
+    if not commit:
+        # No merge commit recorded: assume live rather than silently reopening
+        # a release that really did complete.
+        return True
+    exists = subprocess.run(
+        ["git", "cat-file", "-e", f"{commit}^{{commit}}"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+    )
+    if exists.returncode != 0:
+        return False
+    reachable = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", commit, "origin/main"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+    )
+    return reachable.returncode == 0
 
 
 def _open_release_pull_request(version: str, branch: str, *, evidence: bool) -> None:

--- a/scripts/tests/test_release.py
+++ b/scripts/tests/test_release.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import importlib.util
 import tempfile
-import unittest
+import unittest.mock
 from contextlib import redirect_stdout
 from io import StringIO
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 _SPEC = importlib.util.spec_from_file_location(
@@ -954,3 +955,41 @@ class StageAuthorizeTest(unittest.TestCase):
     def test_it_refuses_to_authorize_twice(self):
         with self.assertRaisesRegex(release.ReleaseError, "already carries"):
             self._run(existing_section=True)
+
+
+class PullRequestLookupIgnoresDeadHistoryTest(unittest.TestCase):
+    """A PR merged into rewritten-away history is not this release's PR.
+
+    It looks identical to a real one - same head branch, state MERGED - so
+    `stage_finish` concluded the release was already cut and stopped, with
+    nothing to fix. Purging two live Forward identifiers from public history
+    orphaned the v3.0.0 release PRs exactly this way.
+    """
+
+    def _pull(self, oid, state="MERGED"):
+        return {
+            "number": 348,
+            "state": state,
+            "url": "https://example.invalid/pr/348",
+            "mergeCommit": {"oid": oid} if oid else None,
+        }
+
+    def test_an_unreachable_merge_commit_is_not_live(self):
+        completed = SimpleNamespace(returncode=1)
+        with unittest.mock.patch.object(
+            release.subprocess, "run", return_value=completed
+        ):
+            self.assertFalse(release._merge_is_live(self._pull("deadbeef" * 5)))
+
+    def test_a_reachable_merge_commit_is_live(self):
+        completed = SimpleNamespace(returncode=0)
+        with unittest.mock.patch.object(
+            release.subprocess, "run", return_value=completed
+        ):
+            self.assertTrue(release._merge_is_live(self._pull("cafebabe" * 5)))
+
+    def test_a_pull_without_a_merge_commit_is_assumed_live(self):
+        # Assume live rather than silently reopening a release that really did
+        # complete: a false "already merged" stops the flow loudly, a false
+        # "not merged" would re-cut a shipped release.
+        self.assertTrue(release._merge_is_live(self._pull(None)))


### PR DESCRIPTION
`stage_finish` stopped with "release PR already merged" on every run, with nothing to fix.

`_pull_request_for_branch` accepted any MERGED pull request on the release branch name. After the history rewrite, the first v3.0.0 release PRs were merged into commits that no longer exist — they look identical to real ones: same head branch, state MERGED.

Deleting the orphaned branches did not help, because the lookup matches by head-ref **name**, which outlives the branch. It now asks whether the merge commit is still reachable from `origin/main`.

**One deliberate asymmetry:** a PR with no recorded merge commit is assumed live. A false "already merged" stops the flow loudly and somebody investigates; a false "not merged" would re-cut a release that had already shipped.

This is the durable half of the rewrite cost — the content rebuild (#350) restored provenance, and this stops the next history rewrite from wedging the release flow the same way.

52 tests in `scripts/tests/test_release.py`, OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa