### PR TITLE
release: authorize v3.0.0

### DIFF
--- a/docs/03_Plans/active/2026-09-02-release-3.0.0.md
+++ b/docs/03_Plans/active/2026-09-02-release-3.0.0.md
@@ -129,3 +129,19 @@ its diff - which is how this list grew its third entry twice.
 - NetBox 4.7's upgrade script also runs `rebuild_config_context_cache`, which
   the harness does not. The cache falls back to on-demand rendering, so this
   should be benign, and it is unverified.
+
+## Release Authorization
+
+- Evidence base commit: `6e6c1fb2385f59e45626fb53ac00a81fee67addf`
+
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.7.0 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.9.2 FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 invoke ci` passed on the final 3.0.0 tree with exit status 0: 385 tests OK, 70 tests OK, 2648 tests OK, 1 tests OK across 3104 tests in total, and the upgrade leg seeded under the previous release and upgraded onto the tested runtime with its rows surviving.
+
+  The gated tree is the release tree apart from this authorization record,
+  which is Markdown in a single plan file and is appended after the gate by
+  construction.
+
+- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.7.0 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.9.2 FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_HOST_PORT=43141 NETBOX_URL=http://127.0.0.1:43141 invoke artifact-test` passed with exit status 0 against the installed `forward_netbox-3.0.0-py3-none-any.whl` on NetBox 4.7.0, Branching 1.2.0, Python 3.14, with every installed route returning 200, all plugin migrations applying cleanly with no drift, and a validated SBOM.
+
+The optional evidence ids are not recorded. The release owner's 2026-07-27
+proportionality decision applies; see
+`docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md`.


### PR DESCRIPTION
Release Evidence PR for v3.0.0. Required CI, CodeQL, and the trusted sensitive-content status must pass before squash merge.