### PR TITLE
release: authorize v3.0.0

### DIFF
--- a/docs/03_Plans/active/2026-09-02-release-3.0.0.md
+++ b/docs/03_Plans/active/2026-09-02-release-3.0.0.md
@@ -150,3 +150,19 @@ excluded commit itself. A rewrite was considered and rejected: it strips pull
 request provenance from every rewritten commit - the failure that cost v2.7.8
 - and would not remove the name from #350's diff view, which GitHub keeps
 reachable by SHA regardless.
+
+## Release Authorization
+
+- Evidence base commit: `471beab3315837949d379ef11273ef6add26712c`
+
+- [x] `final-tree-full-gate` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.7.0 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.9.2 FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 invoke ci` passed on the final 3.0.0 tree with exit status 0: 385 tests OK, 70 tests OK, 2648 tests OK, 1 tests OK across 3104 tests in total, and the upgrade leg seeded under the previous release and upgraded onto the tested runtime with its rows surviving.
+
+  The gated tree is the release tree apart from this authorization record,
+  which is Markdown in a single plan file and is appended after the gate by
+  construction.
+
+- [x] `exact-runtime-artifact` - `rtk env FORWARD_NETBOX_DOCKER_PROJECT=forward-netbox-release-gate FORWARD_NETBOX_POSTGRES_DATA_PATH=netbox-postgres-data FORWARD_NETBOX_WORKER_AUTORELOAD=0 NETBOX_VER=v4.7.0 FORWARD_NETBOX_UPGRADE_FROM_VERSION=2.9.2 FORWARD_NETBOX_PATTERN_PARITY_UNVERIFIED=1 FORWARD_NETBOX_HOST_PORT=43141 NETBOX_URL=http://127.0.0.1:43141 invoke artifact-test` passed with exit status 0 against the installed `forward_netbox-3.0.0-py3-none-any.whl` on NetBox 4.7.0, Branching 1.2.0, Python 3.14, with every installed route returning 200, all plugin migrations applying cleanly with no drift, and a validated SBOM.
+
+The optional evidence ids are not recorded. The release owner's 2026-07-27
+proportionality decision applies; see
+`docs/03_Plans/completed/2026-07-27-release-authorization-proportionality.md`.


### PR DESCRIPTION
Regenerated Release Authorization for v3.0.0, bound to the new tag parent `471beab` after #354 cleared the sensitive-content refusal.

The first authorization (#353) was bound to `6e6c1fb`, which is no longer the tag's parent, so it was removed in #354 and re-rendered here against the current HEAD.

Evidence unchanged: `final-tree-full-gate` and `exact-runtime-artifact`, both from the gate run that produced 3104 tests across the suite, harness and artifact legs, with the upgrade leg seeded under 2.9.2 on NetBox 4.6.5 and upgraded onto 4.7.0 with its rows surviving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa