### PR TITLE
fix: ask two liveness questions about a release pull request, not one

### DIFF
--- a/docs/03_Plans/active/2026-09-03-release-pr-lookup-liveness.md
+++ b/docs/03_Plans/active/2026-09-03-release-pr-lookup-liveness.md
@@ -1,0 +1,112 @@
+# Release PR lookup: two liveness questions, not one
+
+## Goal
+
+Make the release flow ask two distinct questions about a pull request instead
+of one, so neither half of a release stops on a false answer: a merge that just
+landed must not read as missing, and a same-named merge from an earlier attempt
+must not read as this branch having shipped.
+
+## Constraints
+
+- `_merge_is_live`'s dead-history verdict from #351 must survive unchanged; it
+  guards a different failure (a pull request merged into rewritten-away
+  history) and is pinned by its own test.
+- No extra network round trip on the common path.
+- Read-only git queries only. The release flow already decides what to push;
+  these helpers only answer questions.
+
+## Touched Surfaces
+
+- `scripts/release.py` - `_merge_is_live` (fetch retry), new `_head_is_merged`,
+  `_open_release_pull_request` (short-circuit condition).
+- `scripts/tests/test_release.py` - four cases in
+  `PullRequestLookupIgnoresDeadHistoryTest`.
+
+No plugin code, no migrations, no runtime behaviour.
+
+## Context
+
+Both halves of the v3.0.0 release stopped on the same helper asking the wrong
+question about a pull request. Neither was a product defect; both reported
+success or refusal on bookkeeping and cost a release stage.
+
+**Stale remote refs read as a missing pull request.** `_merge_is_live`
+(added in #351) decides whether a merged pull request is still reachable from
+`origin/main`, and it reads local refs. The production merge this very script
+queues lands seconds before the check runs, so the remote-tracking ref has not
+caught up and the merge looks absent. `stage_finish` then reported
+
+    stopped at merge (production): no pull request exists for release/3.0.0
+
+with the merge already on `main` as `6e6c1fb`. The check that exists to catch a
+pull request merged into rewritten-away history was rejecting a live one.
+
+**A same-named pull request from an earlier attempt read as completion.**
+`_open_release_pull_request` treated any `MERGED` pull request on the branch
+name as proof the work had shipped. After the first v3.0.0 tag was refused and
+the authorization regenerated, the evidence branch kept its name, so the lookup
+found the *first* attempt's pull request - merged, live, and irrelevant -
+printed `release PR already merged` and returned success with the new
+authorization commit still unpushed. `main` was left carrying no authorization
+section at all, and the next tag attempt would have failed on it.
+
+## Approach
+
+The two are the same conflation: *is this pull request's merge still real* is
+not *has the work in hand shipped*.
+
+- `_merge_is_live` keeps its meaning and gains a retry: a negative is only
+  trusted after `git fetch origin main`. A dead-history merge stays dead across
+  that fetch, which is pinned separately so the retry cannot quietly turn the
+  #351 verdict back into a pass.
+- `_head_is_merged` is the second question, asked directly: is *this branch's
+  current head* an ancestor of `origin/main`. `_open_release_pull_request`
+  short-circuits only when it is; otherwise it says which earlier attempt it
+  found and opens the pull request this branch needs.
+
+## Validation
+
+`scripts/tests/test_release.py::PullRequestLookupIgnoresDeadHistoryTest`:
+
+- a merge that just landed is live after the retry, and exactly one fetch is
+  issued;
+- a genuinely dead merge stays dead across that fetch;
+- a merged pull request from an earlier attempt opens a new one rather than
+  returning early;
+- a merged pull request for *this* head still returns early, so a shipped
+  release is never re-opened.
+
+Each of the two new failing cases fails against the code as it shipped in
+v3.0.0.
+
+## Not here
+
+The release flow's other v3.0.0 costs - the plan file that must ride in
+prepare's diff, and stale local and remote release branches - are handled in
+the launcher rather than the script, and are not touched by this change.
+
+## Rollback
+
+Revert the commit. Both helpers are read-only git queries used only by the
+release flow, so reverting restores the v3.0.0 behaviour exactly: the
+production-merge race returns, and a same-named merged pull request again
+short-circuits the push. Nothing in the plugin imports either function, and no
+data or schema is touched.
+
+## Decision Log
+
+- **Retry rather than always fetch.** `_merge_is_live` runs per candidate pull
+  request; fetching unconditionally would add a network round trip to every
+  call to fix a race that only shows on a negative. Only a negative is retried.
+- **Keep the two questions separate rather than widening `_merge_is_live`.**
+  Making it answer "has this branch shipped" would have silently changed the
+  #351 dead-history verdict, which exists for a different failure and is
+  pinned by its own test.
+- **Report the earlier attempt instead of failing.** `_open_release_pull_request`
+  names the pull request it found and continues, because an operator resuming a
+  refused release needs to know a same-named one exists; refusing there would
+  have stopped the v3.0.0 recovery outright.
+- **A history rewrite was rejected for the customer-name finding** that refused
+  the first tag; see `2026-09-02-release-3.0.0.md`. Not this change's subject,
+  recorded because the two failures were interleaved in one session.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -797,32 +797,94 @@ def _pull_request_for_branch(branch: str) -> dict | None:
 
 
 def _merge_is_live(pull: dict) -> bool:
-    """Whether a merged PR's merge commit is still reachable from origin/main."""
+    """Whether a merged PR's merge commit is still reachable from origin/main.
+
+    The answer is read from local refs, so a merge that landed seconds ago -
+    which is exactly the case while a release is running - looks absent until
+    the remote-tracking ref catches up. A negative is therefore only trusted
+    after a fetch: without that retry the production merge this very script
+    just queued reports "no pull request exists" and the release stops one
+    step short of the tag.
+    """
     commit = (pull.get("mergeCommit") or {}).get("oid") or ""
     if not commit:
         # No merge commit recorded: assume live rather than silently reopening
         # a release that really did complete.
         return True
-    exists = subprocess.run(
-        ["git", "cat-file", "-e", f"{commit}^{{commit}}"],
+
+    def _reachable() -> bool:
+        exists = subprocess.run(
+            ["git", "cat-file", "-e", f"{commit}^{{commit}}"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+        )
+        if exists.returncode != 0:
+            return False
+        return (
+            subprocess.run(
+                ["git", "merge-base", "--is-ancestor", commit, "origin/main"],
+                cwd=REPO_ROOT,
+                capture_output=True,
+            ).returncode
+            == 0
+        )
+
+    if _reachable():
+        return True
+    subprocess.run(
+        ["git", "fetch", "--quiet", "origin", "main"],
         cwd=REPO_ROOT,
         capture_output=True,
     )
-    if exists.returncode != 0:
-        return False
-    reachable = subprocess.run(
-        ["git", "merge-base", "--is-ancestor", commit, "origin/main"],
+    return _reachable()
+
+
+def _head_is_merged() -> bool:
+    """Whether THIS branch's current head is already on origin/main.
+
+    `_merge_is_live` asks whether a merged pull request is still reachable.
+    That is a different question from whether the work in hand has shipped,
+    and conflating the two skips a push: v3.0.0's second authorization was
+    written, then dropped, because a pull request from the FIRST attempt
+    carried the same head-ref name and was merged and live.
+    """
+    head = _capture(["git", "rev-parse", "HEAD"])
+
+    def _merged() -> bool:
+        return (
+            subprocess.run(
+                ["git", "merge-base", "--is-ancestor", head, "origin/main"],
+                cwd=REPO_ROOT,
+                capture_output=True,
+            ).returncode
+            == 0
+        )
+
+    if _merged():
+        return True
+    subprocess.run(
+        ["git", "fetch", "--quiet", "origin", "main"],
         cwd=REPO_ROOT,
         capture_output=True,
     )
-    return reachable.returncode == 0
+    return _merged()
 
 
 def _open_release_pull_request(version: str, branch: str, *, evidence: bool) -> None:
     pull = _pull_request_for_branch(branch)
     if pull and pull.get("state") == "MERGED":
-        print(f"[finish] release PR already merged: {pull['url']}")
-        return
+        if _head_is_merged():
+            print(f"[finish] release PR already merged: {pull['url']}")
+            return
+        # Same head-ref name, earlier attempt. Reporting "already merged" here
+        # returns success while THIS branch's commit is still unpushed, which
+        # is how a regenerated release authorization went missing.
+        print(
+            f"[finish] {pull['url']} merged an earlier attempt on {branch}; "
+            "this branch's head is not on origin/main, so it needs its own "
+            "pull request."
+        )
+        pull = None
     _verify_live_release_controls()
     if not pull:
         kind = "release evidence" if evidence else "production release"

--- a/scripts/tests/test_release.py
+++ b/scripts/tests/test_release.py
@@ -993,3 +993,108 @@ class PullRequestLookupIgnoresDeadHistoryTest(unittest.TestCase):
         # complete: a false "already merged" stops the flow loudly, a false
         # "not merged" would re-cut a shipped release.
         self.assertTrue(release._merge_is_live(self._pull(None)))
+
+    def test_a_merge_that_just_landed_is_live_after_a_fetch(self):
+        """The race this check creates on the release it is meant to protect.
+
+        Reachability is read from local refs, so the production merge the
+        script itself queued moments earlier is invisible until the
+        remote-tracking ref catches up. Unretried, that reads as "no pull
+        request exists for release/3.0.0" and the release stops one step short
+        of the tag - which is exactly how v3.0.0's first cut ended.
+        """
+        fetched = []
+
+        def fake_run(argv, **kwargs):
+            if argv[:2] == ["git", "fetch"]:
+                fetched.append(argv)
+                return SimpleNamespace(returncode=0)
+            if argv[:2] == ["git", "cat-file"]:
+                return SimpleNamespace(returncode=0)
+            # merge-base: unreachable until the fetch has happened
+            return SimpleNamespace(returncode=1 if not fetched else 0)
+
+        with unittest.mock.patch.object(release.subprocess, "run", fake_run):
+            self.assertTrue(release._merge_is_live(self._pull("abadcafe" * 5)))
+        self.assertEqual(len(fetched), 1, "expected exactly one fetch retry")
+
+    def test_a_merged_pull_from_an_earlier_attempt_does_not_skip_the_push(self):
+        """ "Already merged" must mean THIS head shipped, not a same-named PR.
+
+        v3.0.0's authorization was regenerated after the first tag was refused.
+        The evidence branch kept its name, so the lookup found the FIRST
+        attempt's pull request - merged, live, and irrelevant - and reported
+        the release finished while the new commit sat unpushed. main then had
+        no authorization section at all.
+        """
+        opened = []
+
+        # The stale merged PR first, then the freshly opened one.
+        lookups = [
+            {"state": "MERGED", "url": "https://example.invalid/pr/353"},
+            {
+                "state": "OPEN",
+                "url": "https://example.invalid/pr/355",
+                "number": 355,
+            },
+        ]
+
+        with (
+            unittest.mock.patch.object(
+                release, "_pull_request_for_branch", side_effect=lookups
+            ),
+            unittest.mock.patch.object(release, "_head_is_merged", return_value=False),
+            unittest.mock.patch.object(
+                release, "_verify_live_release_controls", lambda: None
+            ),
+            unittest.mock.patch.object(
+                release, "run", lambda *a, **k: opened.append(a)
+            ),
+        ):
+            release._open_release_pull_request(
+                "3.0.0", "release/3.0.0-evidence", evidence=True
+            )
+
+        commands = [a[0] for a in opened]
+        self.assertTrue(
+            any(c[:3] == ["gh", "pr", "create"] for c in commands),
+            "expected a new pull request to be opened",
+        )
+
+    def test_a_merged_pull_for_this_head_does_return_early(self):
+        """The opposite branch: a real completion must still short-circuit."""
+        opened = []
+
+        with (
+            unittest.mock.patch.object(
+                release,
+                "_pull_request_for_branch",
+                return_value={
+                    "state": "MERGED",
+                    "url": "https://example.invalid/pr/353",
+                },
+            ),
+            unittest.mock.patch.object(release, "_head_is_merged", return_value=True),
+            unittest.mock.patch.object(
+                release, "run", lambda *a, **k: opened.append(a)
+            ),
+        ):
+            release._open_release_pull_request(
+                "3.0.0", "release/3.0.0-evidence", evidence=True
+            )
+
+        self.assertEqual(opened, [], "a shipped release must not be re-opened")
+
+    def test_a_genuinely_dead_merge_stays_dead_across_the_fetch(self):
+        """The retry must not turn the dead-history verdict back into a pass."""
+        calls = []
+
+        def fake_run(argv, **kwargs):
+            calls.append(argv[:2])
+            if argv[:2] == ["git", "fetch"]:
+                return SimpleNamespace(returncode=0)
+            return SimpleNamespace(returncode=1)
+
+        with unittest.mock.patch.object(release.subprocess, "run", fake_run):
+            self.assertFalse(release._merge_is_live(self._pull("deadbeef" * 5)))
+        self.assertIn(["git", "fetch"], calls)


### PR DESCRIPTION
## Summary

Both halves of the v3.0.0 release stopped on the same helper asking the wrong question about a pull request. Neither was a product defect — both reported a false answer on bookkeeping and cost a release stage.

**A merge that just landed read as missing.** `_merge_is_live` (#351) decides whether a merged PR is still reachable from `origin/main`, reading local refs. The production merge this script itself queues lands seconds before the check runs, so the remote-tracking ref hasn't caught up:

```
stopped at merge (production): no pull request exists for release/3.0.0
```

…with the merge already on `main` as `6e6c1fb`. The check that exists to catch a PR merged into rewritten-away history was rejecting a live one.

**A same-named PR from an earlier attempt read as completion.** `_open_release_pull_request` treated any `MERGED` PR on the branch name as proof the work had shipped. After the first v3.0.0 tag was refused and the authorization regenerated, the evidence branch kept its name — so the lookup found the *first* attempt's PR, printed `release PR already merged`, and returned success with the new authorization commit still unpushed. `main` was left carrying no authorization section, which the next tag attempt would have failed on.

## The fix

The two are one conflation: *is this PR's merge still real* is not *has the work in hand shipped*.

- `_merge_is_live` keeps its meaning and gains a retry — a negative is trusted only after `git fetch origin main`. Only negatives retry, so the common path adds no round trip.
- `_head_is_merged` asks the second question directly: is **this branch's head** an ancestor of `origin/main`. The short-circuit now requires it, and otherwise names the earlier attempt and opens the PR the branch needs.

## Validation

Four cases in `PullRequestLookupIgnoresDeadHistoryTest`:

- a just-landed merge is live after the retry, with **exactly one** fetch issued;
- a genuinely dead merge **stays dead** across that fetch — the #351 verdict must not soften;
- a merged PR from an earlier attempt opens a new one;
- a merged PR for *this* head still returns early, so a shipped release is never re-opened.

Both new failing cases fail against the code as it shipped in v3.0.0. `pre-commit --all-files` ✓ · `scripts/tests` 389 passed ✓ · `check_harness` ✓

Plan: `docs/03_Plans/active/2026-09-03-release-pr-lookup-liveness.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa
