### PR TITLE
fix: a release stage can be run twice

### DIFF
--- a/docs/03_Plans/active/2026-08-22-release-2.9.0.md
+++ b/docs/03_Plans/active/2026-08-22-release-2.9.0.md
@@ -147,11 +147,11 @@ effect.
 
 ## Open
 
-- The `netbox_dlm.softwareversion` catalogue sweep (pre-existing, unrelated to
-  this release) still enumerates its entire table; carried forward from the
-  2.8.9 plan's Open section.
-- Whether unmanaged-but-collected devices should be archived under a separate
-  config-backup prefix remains an unanswered product question.
+- ~~The `netbox_dlm.softwareversion` catalogue sweep still enumerates its
+  entire table~~ - **closed in `7e07c16` (#318)**, before 3.0.0. See `2026-09-03-stale-open-sections-2.9.x.md`.
+- ~~Whether unmanaged-but-collected devices should be archived under a separate
+  config-backup prefix~~ - **answered as an opt-in in `0fbbc93` (#322)**;
+  `UNMANAGED_BACKUP_REPO_PREFIX`. See `2026-09-03-stale-open-sections-2.9.x.md`.
 - This host's close-mode HTTP fault, worked around for the release verifier
   since 2.8.7, still affects every other caller and needs attention outside a
   release window.

--- a/docs/03_Plans/active/2026-08-27-release-2.9.1.md
+++ b/docs/03_Plans/active/2026-08-27-release-2.9.1.md
@@ -101,11 +101,10 @@ pin is the whole change. A downgrade is an install of the prior wheel.
 
 ## Open
 
-- **Nothing consumes `poetry.lock`** - no Dockerfile, workflow or script. That
-  is why it drifted three releases unnoticed. Either the harness should enforce
-  it (`poetry check --lock`) or the file should go; accurate-today and
-  unenforced only resets the clock.
-- NetBox 4.7 remains blocked on netbox-branching upstream.
+- ~~**Nothing consumes `poetry.lock`**~~ - **enforced since `a26bc58` (#313)**:
+  `poetry check --lock` runs at `check_release_preflight.py:243`. See `2026-09-03-stale-open-sections-2.9.x.md`.
+- ~~NetBox 4.7 remains blocked on netbox-branching upstream.~~ - **shipped as
+  3.0.0 on 2026-09-03** with branching 1.2.0. Carried correctly until then.
 - Whether the `ChangeDiff.save()` saving is measurable on a real merge is
   unmeasured; this month's scale harness measures the comparison, not the merge.
 

--- a/docs/03_Plans/active/2026-09-03-release-stage-idempotency.md
+++ b/docs/03_Plans/active/2026-09-03-release-stage-idempotency.md
@@ -1,0 +1,134 @@
+# A release stage can be run twice
+
+## Goal
+
+Make the four release stages that cannot be re-entered idempotent, so the
+resume advice the driver already prints actually works, and port the last
+caller using the HTTP pattern this host stalls on.
+
+## Context
+
+v3.0.0 took fourteen attempts. Exactly one was a product defect; the rest
+failed in fast bookkeeping steps *after* the ~45-minute gate. A resume
+mechanism already exists - `--finish`, `--authorize`, `--post-release` and
+`--anchor` are each independently invocable and `stage_finish_unattended`
+prints which one to use - but the stages it names raised on a second run, so
+the printed advice did not work and every retry re-paid the whole gate.
+
+## Constraints
+
+- **`stage_post_release`'s clean-slate delete stays.** It deletes its branch on
+  failure because inheriting a half-made bridge is how v2.8.3's slot was lost.
+  The fix is a pre-check, never resuming a partial branch.
+- A candidate row for a **different** version is still a hard error: that is
+  what the guard is for.
+- No new CLI surface. Once the stages self-detect, the existing per-stage flags
+  are the resume mechanism.
+
+## Touched Surfaces
+
+`scripts/release.py` (`insert_release_row`, `version_surface_edits`,
+`stage_prepare`, `stage_publish`, `stage_post_release`, `stage_anchor`),
+`scripts/tests/test_release.py`, `tasks.py` (`_previous_released_version`),
+`scripts/tests/test_tasks.py`,
+`forward_netbox/management/commands/forward_profile_merge.py`.
+
+No plugin runtime code, no migrations.
+
+## Approach
+
+**The candidate guard is version-scoped.** It matched the bare
+`"| Release candidate;"` marker, so it could not tell this version's row from
+another version's - and because the edits are computed before `stage_prepare`'s
+`write` check, even a dry run tripped it. A candidate for *this* version now
+returns the table unchanged; a different version still raises.
+
+**Version surfaces are matched by shape, not by the outgoing literal.**
+`version_surface_edits` required the *old* string exactly once, so a prepare
+that died mid-write left the rest unreachable: the retry read the new version
+from `pyproject.toml`, looked for it in a file still holding the old one, and
+reported "expected exactly one". Patterns mirroring
+`check_release_preflight.py::version_surfaces` rewrite whatever is there.
+Ambiguity (zero or several literals) is still refused. `stage_prepare` prints
+which surfaces it had to move, so the repair is visible.
+
+**`stage_publish` commits only when something is staged.** An unconditional
+`git commit` turned "the previous attempt already committed" into a hard
+failure, because `git commit` exits non-zero with nothing staged.
+
+**`stage_post_release` and `stage_anchor` ask origin/main first.** Both rebuild
+their branch from `origin/main` every run, so re-pushing after a partial
+attempt is a non-fast-forward. Each now returns early if its work is already on
+`origin/main` (the bridge plan file; `PRIOR_RELEASE_TAG` already naming the
+tag) or if its pull request is already open.
+
+**The PyPI fetch speaks `http.client`.** `urllib.request` appends
+`Connection: close` inside `do_open` where it cannot be suppressed, and this
+host stalls close-mode responses - measured at 1/10 completions against 6/6
+with keep-alive. `tasks.py` was the last caller using it.
+`scripts/verify_release_provenance.py` already speaks `http.client` for this
+reason. PyPI has not been seen stalling; this removes the pattern from the last
+place it appears rather than fixing an observed failure. The Forward API client
+is unaffected - it uses `httpx`, which does not force `close`.
+
+**The merge profile can see `ChangeDiff.save()`.** Its fixture was CREATE-only
+and bulk-safe, so it never entered the per-row upstream fallback - the only
+path that reaches `ChangeDiff.save()`. `dcim.region` (a tree model, which
+`_is_bulk_safe` always refuses) joins the fixture, and the profiling command
+wraps `ChangeDiff.save` in its own `profile_scope` so the cost stops being
+hidden inside the opaque `objectchange_apply` bucket. Production is untouched:
+the instrumentation lives in the profiling command.
+
+## Validation
+
+- `scripts/tests/test_release.py`: re-inserting the same version is a no-op and
+  a different version still raises; a partially bumped tree resumes; a drifted
+  surface is repaired and two literals are still refused; publish does not
+  re-commit but still commits real changes; post-release and anchor stop when
+  their work has landed and still run when it has not.
+- **Non-vacuity checked**: 8 of the 10 new cases fail against `scripts/release.py`
+  as it shipped in 3.0.0. The 2 that pass are the deliberate opposite-branch
+  tests (the ambiguity guard, and publish still committing), which must hold
+  both before and after.
+- `scripts/tests/test_tasks.py` moved off `urllib.request.urlopen` mocks; with
+  the old mocks in place the ported code would have made real network calls and
+  passed by accident, so every call site was converted. The two failure-path
+  tests no longer sleep through the `(0, 10, 30)` backoff: 80s -> 0.1s.
+- The ported fetch was exercised against live PyPI and returned `3.0.0`.
+- `python -m pytest scripts/tests -q`, `pre-commit run --all-files`,
+  `python3 scripts/check_harness.py --base origin/main`.
+- The fixture allocation still sums to the requested volume at 100/1000/5000.
+
+## Rollback
+
+Revert the commit. `scripts/release.py`'s changes are detection-only - every
+stage still does the same work when its work is absent - and the `tasks.py`
+port swaps one stdlib HTTP client for another behind the same retry loop. The
+profiling changes affect a management command that only runs behind
+`--i-understand-this-creates-test-data`.
+
+## Decision Log
+
+- **Idempotent stages rather than a `--resume-from` flag.** The flags already
+  exist; what failed was the stages behind them. A flag would have left the
+  non-idempotent stages able to fail on the retry it was meant to enable.
+- **Matched by shape, so drift is repaired rather than refused.** The strict
+  literal match is what made a half-written prepare unresumable. Detecting
+  drift belongs to `check_version_surfaces`, which runs in the gate; prepare's
+  job is to set the version, and it now says which surfaces it moved.
+- **A pre-check, not a resumed branch, for the bridge and anchor.** Resuming a
+  half-made bridge is the specific failure that cost v2.8.3's slot, so the
+  clean-slate delete is left exactly as it is.
+- **`ChangeDiff.save` is wrapped in the profiling command, not the merge path.**
+  Instrumenting production to answer a profiling question would leave a
+  permanent wrapper on a hot path.
+
+## Open
+
+- The measurement itself has not been run: `scripts/run_merge_profile.sh` needs
+  exclusive use of the docker stack, and a concurrent run corrupts it and reads
+  as a code failure. The fixture and the scope are in place so the question -
+  whether branching 1.1.3's `ChangeDiff.save()` saving is measurable on a real
+  merge - can be answered in one run. If the fallback turns out to be rare in
+  practice, "not measurable on a merge" is the honest answer and should be
+  written down rather than pursued.

--- a/docs/03_Plans/active/2026-09-03-release-stage-idempotency.md
+++ b/docs/03_Plans/active/2026-09-03-release-stage-idempotency.md
@@ -123,12 +123,37 @@ profiling changes affect a management command that only runs behind
   Instrumenting production to answer a profiling question would leave a
   permanent wrapper on a hot path.
 
+## Measured: `ChangeDiff.save()` is never called on a merge
+
+Run on 2026-09-03, isolated `fnb-merge` stack, volumes 1000 and 5000, two
+rounds each.
+
+| volume | merge wall | fallback rows | fallback ms/row | fallback stmts/row | bulk `changediff_resolution` ms/row | `ChangeDiff.save()` calls |
+|---|---|---|---|---|---|---|
+| 1000 | 9.76s | 86 | 23.05 | 27.98 | 0.0176 | **0** |
+| 1000 | 9.98s | 86 | 18.71 | 27.95 | 0.0189 | **0** |
+| 5000 | 63.65s | 430 | 25.30 | 27.95 | 0.0206 | **0** |
+| 5000 | 64.90s | 430 | 24.08 | 27.95 | 0.0202 | **0** |
+
+**The answer to branching 1.1.3's question is that the saving cannot show up on
+a merge at all, because the method is not on the merge path.** Zero calls, with
+the wrapper confirmed installed (`changediff_save_instrumented: true` is
+recorded next to the count for exactly this reason - an absent bucket cannot
+otherwise be told apart from instrumentation that never ran). Every ChangeDiff
+write on this path goes through `bulk_create`/`bulk_update`
+(`apply_engine_bulk.py:231`, `bulk_merge.py:296`) or raw SQL
+(`merge_set_based.py:1017`). 1.1.3's change may still matter to callers we do
+not exercise; it does not matter here.
+
+**The more useful finding is the one the fixture change exposed.** The
+`dcim.region` rows forced the per-object upstream fallback that the CREATE-only
+fixture barely entered, and it is expensive: ~19-25 ms and ~28 statements per
+row, against 0.02 ms for the bulk path - roughly a thousandfold difference. At
+volume 5000 that is **16% of total merge wall time for 430 of 5000 rows (8.6%)**.
+Avoiding the fallback is worth far more than optimising anything inside it, and
+`_is_bulk_safe` (`bulk_merge.py:614`) is what decides which rows pay it.
+
 ## Open
 
-- The measurement itself has not been run: `scripts/run_merge_profile.sh` needs
-  exclusive use of the docker stack, and a concurrent run corrupts it and reads
-  as a code failure. The fixture and the scope are in place so the question -
-  whether branching 1.1.3's `ChangeDiff.save()` saving is measurable on a real
-  merge - can be answered in one run. If the fallback turns out to be rare in
-  practice, "not measurable on a merge" is the honest answer and should be
-  written down rather than pursued.
+- Nothing here. Whether more models can be made bulk-safe is a separate
+  question this measurement now makes answerable, and is not in this tranche.

--- a/docs/03_Plans/active/2026-09-03-stale-open-sections-2.9.x.md
+++ b/docs/03_Plans/active/2026-09-03-stale-open-sections-2.9.x.md
@@ -1,0 +1,61 @@
+# Stale 2.9.x open items: what was carried after it had shipped
+
+## Goal
+
+Close, in one place, the items the 2.9.0 and 2.9.1 plans still list under
+`## Open` although the code landed before 3.0.0. Each entry names the commit
+and the live call site, verified against the 3.0.0 tree.
+
+This is the second sweep of this kind. `2026-09-02-stale-deferral-sweep.md`
+did the same for C7/C8/C9, and the 2.9.2 plan's Decision Log names the failure
+mode ("a closure nobody can see gets re-investigated") one section above the
+list that committed it. One index is the fix; editing every plan is how the
+next sweep gets skipped.
+
+## Constraints
+
+- Verification is by call site, not by symbol. A predictor that exists and is
+  never called is not closed.
+- Nothing here changes behaviour. It is documentation of work already done.
+
+## Touched Surfaces
+
+`docs/03_Plans/active/` only: `2026-08-22-release-2.9.0.md`,
+`2026-08-27-release-2.9.1.md`, and this file.
+
+## Approach
+
+| Item | Carried in | Landed | Live at |
+|---|---|---|---|
+| `netbox_dlm.softwareversion` sweep enumerated the whole table | 2.9.0 | `7e07c16` (#318) | `CATALOG_SWEEP_MODELS` `workload_state.py:739`, gated `:980`, pinned `test_workload_state.py:629` |
+| Unmanaged devices archived under a separate prefix was "an unanswered product question" | 2.9.0 | `0fbbc93` (#322) | `UNMANAGED_BACKUP_REPO_PREFIX`; answered as an opt-in in the comment at `config_backup.py:308`, parameter `config_backup_include_unmanaged` |
+| Nothing consumes `poetry.lock` | 2.9.1 | `a26bc58` (#313) | `poetry check --lock` at `check_release_preflight.py:243` |
+| A report of exactly 10 skips may be the cap, not the count | 2.8.9 → 2.9.0 | `721e816` (#319) | `sync_reporting.py:201-206` reports `total` and `remainder` |
+| The skip rollup's wording was wrong for a protected-delete skip | 2.8.9 → 2.9.0 | `721e816` (#319) | `emit_dependency_skip_issue_summary`, pinned by `test_skip_rollup_direction.py:91` |
+| A refused delete still wrote a durable-state tombstone | 2.8.9 → 2.9.0 | `b210944` (#323) | `2026-09-02-refused-deletes-are-retried.md`, whose own Open is "Nothing" |
+
+## Validation
+
+Documentation only; no test change. Each row was grepped in the 3.0.0 tree
+before being written down, and each was confirmed to have a caller rather than
+only a definition.
+
+## Rollback
+
+Revert this file and the two plan edits. No code is affected.
+
+## Decision Log
+
+- **The 4.7 item is not listed** because it did not go stale - it was carried
+  open correctly until NetBox 4.7.0 and branching 1.2.0 shipped, and 3.0.0
+  closed it on 2026-09-03.
+- **Older plans keep their own `## Open` sections.** They are historical
+  records of what was true at that release. This file is the current answer.
+- **The host's close-mode HTTP fault is not swept**, because it was still real:
+  the last caller using the fault-prone pattern is ported in the same tranche
+  as this sweep rather than being declared closed here.
+
+## Open
+
+- Nothing. The remaining 2.9.x work is in
+  `2026-09-03-release-stage-idempotency.md`.

--- a/forward_netbox/management/commands/forward_profile_merge.py
+++ b/forward_netbox/management/commands/forward_profile_merge.py
@@ -1,5 +1,6 @@
 """Profile real branch merges with anonymized production-shaped fixtures."""
 
+import contextlib
 import hashlib
 import json
 import logging
@@ -25,6 +26,38 @@ from forward_netbox.models import ForwardSync
 from forward_netbox.utilities.merge import merge_branch
 from forward_netbox.utilities.merge_observability import begin_merge_attempt
 from forward_netbox.utilities.merge_profiling import MergeProfileRecorder
+from forward_netbox.utilities.merge_profiling import profile_scope
+
+
+@contextlib.contextmanager
+def _changediff_save_measured():
+    """Attribute `ChangeDiff.save()` to its own scope for the merge.
+
+    The per-row cost sits inside upstream's `ObjectChange.apply`, which the
+    recorder already times as one opaque `objectchange_apply` bucket - so
+    "is branching 1.1.3's ChangeDiff saving measurable on a real merge"
+    could not be answered from a profile. Wrapping the method here rather
+    than in the merge path keeps production untouched: this is a profiling
+    command and the instrumentation belongs with the measurement.
+    """
+    from netbox_branching.models import ChangeDiff
+
+    original = ChangeDiff.save
+
+    def measured(self, *args, **kwargs):
+        with profile_scope(
+            "changediff_save",
+            owner="upstream_netbox_branching",
+            rows=1,
+        ):
+            return original(self, *args, **kwargs)
+
+    ChangeDiff.save = measured
+    try:
+        yield
+    finally:
+        ChangeDiff.save = original
+
 
 LOG = logging.getLogger("forward_netbox.merge_profile")
 STAGE_CHUNK_SIZE = 500
@@ -40,6 +73,11 @@ FIXTURE_WEIGHTS = (
     ("ipam.ipaddress", 0.053),
     ("ipam.prefix", 0.036),
     ("dcim.site", 0.001),
+    # A tree model, so `_is_bulk_safe` (bulk_merge.py) always refuses it and
+    # the row goes through the per-object upstream fallback - the only path
+    # that reaches ChangeDiff.save(). Without it this fixture is CREATE-only
+    # and bulk-safe, so it measured everything EXCEPT the cost in question.
+    ("dcim.region", 0.002),
 )
 
 
@@ -47,6 +85,7 @@ def _allocated_counts(volume):
     counts = {model: int(volume * weight) for model, weight in FIXTURE_WEIGHTS}
     counts["dcim.device"] = max(1, counts["dcim.device"])
     counts["dcim.site"] = max(1, counts["dcim.site"])
+    counts["dcim.region"] = max(1, counts["dcim.region"])
     assigned = sum(counts.values())
     counts["dcim.interface"] += volume - assigned
     return counts
@@ -156,6 +195,7 @@ class Command(BaseCommand):
             InventoryItem,
             MACAddress,
             Manufacturer,
+            Region,
             Site,
         )
         from ipam.models import IPAddress, Prefix
@@ -267,6 +307,16 @@ class Command(BaseCommand):
             ),
         )
 
+        self._stage_rows(
+            branch,
+            request,
+            counts["dcim.region"],
+            lambda index: Region.objects.create(
+                name=f"Profile Branch Region {short} {index}",
+                slug=f"profile-branch-region-{short}-{index}",
+            ),
+        )
+
         Branch.objects.filter(pk=branch.pk).update(status=BranchStatusChoices.READY)
         branch.refresh_from_db()
         staged_changes = branch.get_unmerged_changes().count()
@@ -296,7 +346,7 @@ class Command(BaseCommand):
                 "staged_changes": staged_changes,
             }
         )
-        with recorder.activate():
+        with recorder.activate(), _changediff_save_measured():
             merge_branch(
                 ingestion,
                 user=user,

--- a/forward_netbox/management/commands/forward_profile_merge.py
+++ b/forward_netbox/management/commands/forward_profile_merge.py
@@ -43,8 +43,10 @@ def _changediff_save_measured():
     from netbox_branching.models import ChangeDiff
 
     original = ChangeDiff.save
+    calls = {"installed": True, "count": 0}
 
     def measured(self, *args, **kwargs):
+        calls["count"] += 1
         with profile_scope(
             "changediff_save",
             owner="upstream_netbox_branching",
@@ -54,7 +56,7 @@ def _changediff_save_measured():
 
     ChangeDiff.save = measured
     try:
-        yield
+        yield calls
     finally:
         ChangeDiff.save = original
 
@@ -346,7 +348,7 @@ class Command(BaseCommand):
                 "staged_changes": staged_changes,
             }
         )
-        with recorder.activate(), _changediff_save_measured():
+        with recorder.activate(), _changediff_save_measured() as changediff_calls:
             merge_branch(
                 ingestion,
                 user=user,
@@ -354,6 +356,10 @@ class Command(BaseCommand):
             )
         after_postgres = _postgres_snapshot()
         result = recorder.result()
+        # Recorded explicitly: an absent `changediff_save` bucket otherwise
+        # cannot be told apart from instrumentation that never installed.
+        result["changediff_save_calls"] = changediff_calls["count"]
+        result["changediff_save_instrumented"] = changediff_calls["installed"]
         result["postgres"] = _snapshot_delta(before_postgres, after_postgres)
         result["changes_per_second"] = (
             volume / result["wall_seconds"] if result["wall_seconds"] else 0.0

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -115,6 +115,17 @@ def insert_release_row(
     have published a row claiming 3.0 runs on the version it explicitly
     refuses to load on.
     """
+    candidate_prefix = f"| `v{version}` |"
+    if any(
+        line.startswith(candidate_prefix) and "| Release candidate;" in line
+        for line in table_text.splitlines()
+    ):
+        # Our own prior attempt, not a competing release. The guard below still
+        # refuses a candidate for a DIFFERENT version, which is what it is for;
+        # matching the bare marker could not tell the two apart, so a retried
+        # prepare failed on the row it had written itself - and, because the
+        # edits are computed before the `write` check, so did a dry run.
+        return table_text
     if "| Release candidate;" in table_text:
         raise ReleaseError("a release candidate already exists")
     match = CURRENT_RELEASE_RE.search(table_text)
@@ -206,6 +217,27 @@ def run(
     return result.returncode
 
 
+def _version_patterns() -> dict[Path, re.Pattern[str]]:
+    """{path: pattern capturing the version literal} for every version surface.
+
+    Matched by shape rather than by the outgoing literal, so the answer does
+    not depend on knowing which version the file currently holds. That is what
+    makes a half-written prepare resumable: the retry rewrites whatever is
+    there to the target instead of hunting for a value the file may already
+    have moved past. The patterns mirror
+    `scripts/check_release_preflight.py::version_surfaces`, which is the
+    backstop for the same four files.
+    """
+    return {
+        PYPROJECT: re.compile(r'(?m)^(version = ")([^"]+)(")'),
+        INIT_PY: re.compile(r'(?m)^(\s*version\s*=\s*")([^"]+)(")'),
+        FAST_BASELINE: re.compile(r'("forward_netbox":\s*")([^"]+)(")'),
+        RUNTIME_VERSION_TEST: re.compile(
+            r'(NetboxForwardConfig\.version,\s*")([^"]+)(")'
+        ),
+    }
+
+
 def version_surface_edits(old: str, new: str) -> dict[Path, str]:
     """Every file carrying the version literal, as {path: new text}.
 
@@ -215,27 +247,36 @@ def version_surface_edits(old: str, new: str) -> dict[Path, str]:
     the fast-baseline pin: a stale value silently reverts a first sync from the
     fast path to the slow one. Bumping them together is the fix;
     `scripts/check_release_preflight.py` is the backstop.
+
+    `old` is accepted for call-site clarity but not required to be present: a
+    surface already reading `new` is left alone rather than reported missing.
     """
-    substitutions = {
-        PYPROJECT: (f'version = "{old}"', f'version = "{new}"'),
-        INIT_PY: (f'version = "{old}"', f'version = "{new}"'),
-        FAST_BASELINE: (f'"forward_netbox": "{old}"', f'"forward_netbox": "{new}"'),
-        RUNTIME_VERSION_TEST: (
-            f'NetboxForwardConfig.version, "{old}"',
-            f'NetboxForwardConfig.version, "{new}"',
-        ),
-    }
+    del old
     edits: dict[Path, str] = {}
-    for path, (needle, replacement) in substitutions.items():
+    for path, pattern in _version_patterns().items():
         text = path.read_text(encoding="utf-8")
-        count = text.count(needle)
-        if count != 1:
+        matches = pattern.findall(text)
+        if len(matches) != 1:
             raise ReleaseError(
-                f"expected exactly one {needle!r} in "
-                f"{path.relative_to(REPO_ROOT)}, found {count}"
+                f"expected exactly one version literal in "
+                f"{path.relative_to(REPO_ROOT)}, found {len(matches)}"
             )
-        edits[path] = text.replace(needle, replacement)
+        edits[path] = pattern.sub(lambda m: f"{m.group(1)}{new}{m.group(3)}", text)
     return edits
+
+
+def version_surfaces_already_at(version: str) -> list[Path]:
+    """The version surfaces that already read `version`.
+
+    Reported by `stage_prepare` so a resumed run says what it found rather
+    than silently rewriting identical bytes.
+    """
+    already = []
+    for path, pattern in _version_patterns().items():
+        match = pattern.search(path.read_text(encoding="utf-8"))
+        if match is not None and match.group(2) == version:
+            already.append(path)
+    return already
 
 
 def stage_prepare(
@@ -247,7 +288,23 @@ def stage_prepare(
     requirements: str = "",
 ) -> None:
     old = read_current_version()
-    print(f"[prepare] bump {old} -> {version}")
+    already = version_surfaces_already_at(version)
+    surfaces = _version_patterns()
+    if already:
+        # A resumed prepare, or a partially written one. Naming the surfaces it
+        # still has to move keeps the repair visible: matching by shape means a
+        # surface that drifted to some third value is set to the target rather
+        # than reported, so the only signal is this line.
+        moving = sorted(
+            str(path.relative_to(REPO_ROOT)) for path in surfaces if path not in already
+        )
+        print(
+            f"[prepare] {len(already)} of {len(surfaces)} version surfaces "
+            f"already read {version}"
+            + (f"; moving {', '.join(moving)}" if moving else "; nothing to bump")
+        )
+    else:
+        print(f"[prepare] bump {old} -> {version}")
     edits = version_surface_edits(old, version)
     for path in README_TABLES:
         edits[path] = set_release_intro_text(
@@ -669,7 +726,15 @@ def stage_publish(version: str, *, auto_finish: bool = False) -> None:
             checkout_arguments.append("-b")
         run([*checkout_arguments, branch])
     run(["git", "add", "-A"])
-    run(["git", "commit", "-m", f"release: cut v{version}"])
+    # Commit only if prepare left something to commit. An unconditional commit
+    # turned "the previous attempt already committed this" into a hard failure
+    # (`git commit` exits non-zero with nothing staged, and `check=True` raises),
+    # so a publish that failed at the push or workflow step could not be retried
+    # without re-running the whole gate.
+    if _capture(["git", "status", "--porcelain"]):
+        run(["git", "commit", "-m", f"release: cut v{version}"])
+    else:
+        print(f"[publish] v{version} is already committed on {branch}")
     # Simulate the push-event harness gate (every commit's high-risk paths need a
     # plan file in the SAME commit) BEFORE pushing — avoids a failed-CI round-trip.
     run([sys.executable, "scripts/check_harness.py", "--base", "origin/main"])
@@ -1165,6 +1230,37 @@ def _next_patch_version(version: str) -> str:
     return f"{major}.{minor}.{patch + 1}"
 
 
+def _repo_relative(path: Path) -> str | None:
+    """`path` relative to the repository, or None if it lies outside it.
+
+    Redirected to a scratch directory by tests, which do not always redirect
+    REPO_ROOT with it. A path we cannot express repo-relatively is one we
+    cannot ask origin/main about, so the caller falls through to doing the work.
+    """
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return None
+
+
+def _text_on_main(relative_path: str) -> str | None:
+    """A tracked file's content on origin/main, or None if it is not there.
+
+    The bookkeeping stages rebuild their branch from origin/main every run, so
+    "has this already landed" has to be asked of origin/main itself rather than
+    of the working tree, which a failed attempt may have left in any state.
+    """
+    result = subprocess.run(
+        ["git", "show", f"origin/main:{relative_path}"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
 def _bridge_plan_path(version: str) -> Path:
     """Where the generated bridge plan lands. Separate so a test can redirect it."""
     return REPO_ROOT / "docs" / "03_Plans" / "active" / f"post-release-{version}.md"
@@ -1258,9 +1354,22 @@ def stage_post_release(version: str, tag: str) -> None:
     print(f"[post-release] opening {branch} for {tag}")
 
     run(["git", "fetch", "origin", "main"])
+    plan_path = _bridge_plan_path(version)
+    # Ask origin/main before building anything. This stage deletes its branch on
+    # failure (below) precisely so it never inherits a half-made bridge, which
+    # means every retry starts from scratch and re-pushing over an earlier
+    # attempt's branch is a non-fast-forward. A pre-check is the only safe way
+    # to make the retry a no-op: it never resumes a partial branch.
+    tracked = _repo_relative(plan_path)
+    if tracked is not None and _text_on_main(tracked) is not None:
+        print(f"[post-release] the {version} bridge is already on origin/main")
+        return
+    existing = _pull_request_for_branch(branch)
+    if existing and existing.get("state") == "OPEN":
+        print(f"[post-release] bridge pull request already open: {existing['url']}")
+        return
     # Where the operator started, so they are put back whatever happens.
     starting_branch = _capture(["git", "branch", "--show-current"]) or "main"
-    plan_path = _bridge_plan_path(version)
     try:
         run(["git", "checkout", "-B", branch, "origin/main"])
         plan_path.write_text(_bridge_plan_text(version, tag), encoding="utf-8")
@@ -1446,6 +1555,19 @@ def stage_anchor(version: str, tag: str) -> None:
     bridge = _bridge_commit_for(tag)
     branch = f"chore/anchor-{version}"
     print(f"[anchor] {tag} -> bridge {bridge[:12]} on {branch}")
+    # Same shape as the bridge: rebuilt from origin/main every run, so a retry
+    # after a partial attempt would push a divergent commit. `promote_release_tables`
+    # is already a no-op when the tables are promoted; this makes the whole
+    # stage one.
+    tracked = _repo_relative(PROVENANCE)
+    landed = _text_on_main(tracked) if tracked is not None else None
+    if landed is not None and _capture_constant(landed, "PRIOR_RELEASE_TAG") == tag:
+        print(f"[anchor] origin/main already anchors {tag}")
+        return
+    existing = _pull_request_for_branch(branch)
+    if existing and existing.get("state") == "OPEN":
+        print(f"[anchor] anchor pull request already open: {existing['url']}")
+        return
     starting_branch = _capture(["git", "branch", "--show-current"]) or "main"
     plan_path = _anchor_plan_path(version)
     try:

--- a/scripts/tests/test_release.py
+++ b/scripts/tests/test_release.py
@@ -114,6 +114,29 @@ class InsertReleaseRowTest(unittest.TestCase):
         with self.assertRaises(release.ReleaseError):
             release.insert_release_row(candidate, "1.5.12", "second")
 
+    def test_re_inserting_the_same_version_is_a_no_op(self):
+        """A retried prepare must not fail on the row it wrote itself.
+
+        The guard matched the bare "| Release candidate;" marker, so it could
+        not tell this version's candidate from another version's. Because the
+        edits are computed before `stage_prepare`'s `write` check, even a dry
+        run tripped it, and the only way past was resetting the tree and
+        re-running the whole ~45-minute gate.
+        """
+        candidate = release.insert_release_row(self.TABLE, "1.5.11", "first")
+
+        self.assertEqual(
+            release.insert_release_row(candidate, "1.5.11", "first"),
+            candidate,
+        )
+
+    def test_the_no_op_does_not_soften_the_other_version_guard(self):
+        """The opposite branch: two releases in flight is still an error."""
+        candidate = release.insert_release_row(self.TABLE, "1.5.11", "first")
+
+        with self.assertRaises(release.ReleaseError):
+            release.insert_release_row(candidate, "1.6.0", "second")
+
 
 class ReleaseIntroTest(unittest.TestCase):
     INTRO = (
@@ -457,6 +480,82 @@ class VersionSurfaceEditTest(unittest.TestCase):
             for text in edits.values():
                 self.assertIn("1.2.4", text)
                 self.assertNotIn("1.2.3", text)
+
+    def test_a_partially_bumped_tree_resumes_instead_of_failing(self):
+        """A prepare that died mid-write must be retryable.
+
+        The surfaces are written one at a time. If the run dies after some are
+        bumped, the retry reads the NEW version out of pyproject, looks for it
+        in a file still holding the old one, and reported "expected exactly
+        one" - unresumable, so the whole gate had to be re-paid.
+        """
+        with tempfile.TemporaryDirectory() as directory:
+            root = self._tree(directory, "1.2.3")
+            # pyproject and __init__ made it; the other two did not.
+            (root / "pyproject.toml").write_text(
+                'version = "1.2.4"\n', encoding="utf-8"
+            )
+            (root / "forward_netbox" / "__init__.py").write_text(
+                '    version = "1.2.4"\n', encoding="utf-8"
+            )
+            patches = self._patched(root)
+            for item in patches:
+                item.start()
+            try:
+                edits = release.version_surface_edits("1.2.4", "1.2.4")
+            finally:
+                for item in patches:
+                    item.stop()
+            self.assertEqual(len(edits), 4)
+            for text in edits.values():
+                self.assertIn("1.2.4", text)
+                self.assertNotIn("1.2.3", text)
+
+    def test_a_surface_at_an_unexpected_version_is_repaired(self):
+        """Drifted surfaces are set to the target, not refused.
+
+        Matching by shape means the outgoing literal no longer has to be known,
+        which is what makes a half-written prepare resumable - and it also means
+        a surface that drifted to some third value is brought to the target
+        rather than raising. Detecting drift is
+        `check_release_preflight.py::check_version_surfaces`' job and it runs in
+        the gate; prepare's job is to set the version. `stage_prepare` prints
+        which surfaces it had to move so the repair is not silent.
+        """
+        with tempfile.TemporaryDirectory() as directory:
+            root = self._tree(directory, "1.2.3")
+            (root / "forward_netbox" / "utilities" / "fast_baseline.py").write_text(
+                '    "forward_netbox": "9.9.9",\n', encoding="utf-8"
+            )
+            patches = self._patched(root)
+            for item in patches:
+                item.start()
+            try:
+                edits = release.version_surface_edits("1.2.3", "1.2.4")
+            finally:
+                for item in patches:
+                    item.stop()
+            pin = edits[root / "forward_netbox/utilities/fast_baseline.py"]
+            self.assertIn('"forward_netbox": "1.2.4"', pin)
+            self.assertNotIn("9.9.9", pin)
+
+    def test_two_version_literals_in_one_surface_is_reported(self):
+        """The strictness that remains: ambiguity is still refused."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = self._tree(directory, "1.2.3")
+            (root / "forward_netbox" / "utilities" / "fast_baseline.py").write_text(
+                '    "forward_netbox": "1.2.3",\n    "forward_netbox": "1.2.3",\n',
+                encoding="utf-8",
+            )
+            patches = self._patched(root)
+            for item in patches:
+                item.start()
+            try:
+                with self.assertRaisesRegex(release.ReleaseError, "fast_baseline"):
+                    release.version_surface_edits("1.2.3", "1.2.4")
+            finally:
+                for item in patches:
+                    item.stop()
 
     def test_a_missing_surface_is_reported_not_skipped(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -1098,3 +1197,145 @@ class PullRequestLookupIgnoresDeadHistoryTest(unittest.TestCase):
         with unittest.mock.patch.object(release.subprocess, "run", fake_run):
             self.assertFalse(release._merge_is_live(self._pull("deadbeef" * 5)))
         self.assertIn(["git", "fetch"], calls)
+
+
+class StageIdempotencyTest(unittest.TestCase):
+    """Re-entering a stage must be a reported no-op, not an error.
+
+    v3.0.0 took fourteen attempts. One was a product defect; the rest failed in
+    fast bookkeeping steps AFTER the ~45-minute gate. The driver already prints
+    which flag to resume with (`stage_finish_unattended`), but the stages it
+    names could not run twice, so the advice did not work and every retry
+    re-paid the gate.
+    """
+
+    def test_publish_does_not_recommit_an_already_committed_release(self):
+        commands = []
+
+        def capture(cmd, **kwargs):
+            if cmd[:3] == ["git", "status", "--porcelain"]:
+                return ""  # nothing staged: the prior attempt already committed
+            if cmd[:2] == ["git", "branch"]:
+                return "release/3.0.0"
+            return ""
+
+        with (
+            patch.object(release, "_capture", side_effect=capture),
+            patch.object(release, "run", side_effect=lambda c, **k: commands.append(c)),
+            patch.object(release, "wait_for_required_workflows", return_value=True),
+            patch.object(release, "_assert_release_head"),
+        ):
+            release.stage_publish("3.0.0")
+
+        joined = [" ".join(c) for c in commands]
+        self.assertFalse(
+            any(c.startswith("git commit") for c in joined),
+            "an already-committed release must not be committed again",
+        )
+        self.assertTrue(any(c.startswith("git push") for c in joined))
+
+    def test_publish_still_commits_when_prepare_left_changes(self):
+        commands = []
+
+        def capture(cmd, **kwargs):
+            if cmd[:3] == ["git", "status", "--porcelain"]:
+                return " M pyproject.toml"
+            if cmd[:2] == ["git", "branch"]:
+                return "release/3.0.0"
+            return ""
+
+        with (
+            patch.object(release, "_capture", side_effect=capture),
+            patch.object(release, "run", side_effect=lambda c, **k: commands.append(c)),
+            patch.object(release, "wait_for_required_workflows", return_value=True),
+            patch.object(release, "_assert_release_head"),
+        ):
+            release.stage_publish("3.0.0")
+
+        joined = [" ".join(c) for c in commands]
+        self.assertTrue(any(c.startswith("git commit") for c in joined))
+
+    def test_post_release_stops_when_the_bridge_is_already_on_main(self):
+        commands = []
+        with (
+            patch.object(release, "_text_on_main", return_value="# bridge\n"),
+            patch.object(release, "run", side_effect=lambda c, **k: commands.append(c)),
+            patch.object(release, "_open_pull_request") as open_pull_request,
+        ):
+            release.stage_post_release("3.0.0", "v3.0.0")
+
+        open_pull_request.assert_not_called()
+        joined = [" ".join(c) for c in commands]
+        self.assertFalse(
+            any("checkout -B" in c for c in joined),
+            "a landed bridge must not rebuild its branch",
+        )
+
+    def test_post_release_still_builds_the_bridge_when_it_is_absent(self):
+        commands = []
+        with (
+            patch.object(release, "_text_on_main", return_value=None),
+            patch.object(release, "_pull_request_for_branch", return_value=None),
+            patch.object(release, "run", side_effect=lambda c, **k: commands.append(c)),
+            patch.object(release, "_capture", return_value="main"),
+            patch.object(release, "_open_pull_request") as open_pull_request,
+            patch.object(release, "_bridge_plan_path") as plan_path,
+        ):
+            scratch = tempfile.TemporaryDirectory()
+            self.addCleanup(scratch.cleanup)
+            plan_path.return_value = Path(scratch.name) / "post-release-3.0.0.md"
+            with patch.object(release, "REPO_ROOT", Path(scratch.name)):
+                release.stage_post_release("3.0.0", "v3.0.0")
+
+        open_pull_request.assert_called_once()
+        self.assertTrue(any("checkout -B" in " ".join(c) for c in commands))
+
+    def test_anchor_stops_when_main_already_anchors_the_tag(self):
+        commands = []
+        landed = (
+            'PRIOR_RELEASE_TAG = "v3.0.0"\nPRIOR_POST_RELEASE_DOC_COMMIT = "%s"\n'
+            % ("b" * 40)
+        )
+        with (
+            patch.object(release, "_bridge_commit_for", return_value="b" * 40),
+            patch.object(release, "_text_on_main", return_value=landed),
+            patch.object(release, "run", side_effect=lambda c, **k: commands.append(c)),
+            patch.object(release, "promote_release_tables") as promote,
+            patch.object(release, "_open_pull_request") as open_pull_request,
+        ):
+            release.stage_anchor("3.0.0", "v3.0.0")
+
+        promote.assert_not_called()
+        open_pull_request.assert_not_called()
+        self.assertFalse(any("checkout -B" in " ".join(c) for c in commands))
+
+    def test_anchor_still_runs_when_main_anchors_the_previous_release(self):
+        """The opposite branch: a stale anchor must not be mistaken for done."""
+        landed = (
+            'PRIOR_RELEASE_TAG = "v2.9.2"\nPRIOR_POST_RELEASE_DOC_COMMIT = "%s"\n'
+            % ("a" * 40)
+        )
+        with (
+            patch.object(release, "_bridge_commit_for", return_value="b" * 40),
+            patch.object(release, "_text_on_main", return_value=landed),
+            patch.object(release, "_pull_request_for_branch", return_value=None),
+            patch.object(release, "run"),
+            patch.object(release, "_capture", return_value="main"),
+            patch.object(release, "promote_release_tables") as promote,
+            patch.object(release, "_open_pull_request"),
+            patch.object(release, "_anchor_plan_path") as plan_path,
+        ):
+            scratch = tempfile.TemporaryDirectory()
+            self.addCleanup(scratch.cleanup)
+            root = Path(scratch.name)
+            provenance = root / "verify_release_provenance.py"
+            provenance.write_text(landed, encoding="utf-8")
+            plan_path.return_value = root / "anchor-3.0.0.md"
+            with (
+                patch.object(release, "PROVENANCE", provenance),
+                patch.object(release, "REPO_ROOT", root),
+                patch.object(release, "README_TABLES", ()),
+            ):
+                release.stage_anchor("3.0.0", "v3.0.0")
+
+        promote.assert_called_once_with("3.0.0")

--- a/scripts/tests/test_tasks.py
+++ b/scripts/tests/test_tasks.py
@@ -208,6 +208,37 @@ class ReleaseArtifactTaskTest(unittest.TestCase):
         )
 
 
+def _fake_https_connection(body=None, *, status=200, error=None):
+    """Stand in for `http.client.HTTPSConnection` in `_previous_released_version`.
+
+    tasks.py speaks http.client directly rather than urllib, because urllib
+    forces `Connection: close` and this host stalls close-mode responses.
+    """
+
+    class _Response:
+        def __init__(self):
+            self.status = status
+
+        def read(self):
+            return (body or "").encode("utf-8")
+
+    class _Connection:
+        def __init__(self, host, port=None, timeout=None):
+            self.host = host
+
+        def request(self, method, path, headers=None):
+            if error is not None:
+                raise error
+
+        def getresponse(self):
+            return _Response()
+
+        def close(self):
+            pass
+
+    return _Connection
+
+
 class PreviousReleasedVersionTest(unittest.TestCase):
     """Cover the index resolution itself, against a fixed payload.
 
@@ -228,16 +259,9 @@ class PreviousReleasedVersionTest(unittest.TestCase):
     }
 
     def _resolve(self, version, payload=None):
-        import contextlib
-        import io
-
         body = json.dumps(self.PAYLOAD if payload is None else payload)
 
-        @contextlib.contextmanager
-        def fake_urlopen(url, timeout=None):
-            yield io.StringIO(body)
-
-        with patch("urllib.request.urlopen", fake_urlopen):
+        with patch("http.client.HTTPSConnection", _fake_https_connection(body)):
             return tasks._previous_released_version(Mock(), version)
 
     def test_a_dev_marker_resolves_from_the_release_it_heads_for(self):
@@ -278,16 +302,19 @@ class PreviousReleasedVersionTest(unittest.TestCase):
         self.assertEqual(raised.exception.code, 2)
 
     def test_a_connection_reset_reports_how_to_run_offline(self):
-        # A reset during the read is not a URLError; it used to escape raw and
-        # fail the release gate with a bare socket error.
-        import contextlib
-
-        @contextlib.contextmanager
-        def reset(url, timeout=None):
-            raise ConnectionResetError(104, "Connection reset by peer")
-            yield  # pragma: no cover
-
-        with patch("urllib.request.urlopen", reset):
+        # A reset during the read used to escape raw and fail the release gate
+        # with a bare socket error instead of the offline instructions.
+        # The retry backoff is (0, 10, 30); sleeping it here bought nothing but
+        # 40 seconds of suite time.
+        with (
+            patch(
+                "http.client.HTTPSConnection",
+                _fake_https_connection(
+                    error=ConnectionResetError(104, "Connection reset by peer")
+                ),
+            ),
+            patch("time.sleep"),
+        ):
             with self.assertRaises(Exit) as raised:
                 tasks._previous_released_version(Mock(), "2.6.7")
         self.assertEqual(raised.exception.code, 2)
@@ -445,7 +472,6 @@ class ArtifactUpgradeTaskTest(unittest.TestCase):
         context.run.assert_not_called()
 
     def _pypi(self, *versions, yanked=()):
-        import io
         import json
 
         payload = {
@@ -454,15 +480,13 @@ class ArtifactUpgradeTaskTest(unittest.TestCase):
                 for v in versions
             }
         }
-        return io.BytesIO(json.dumps(payload).encode())
+        return _fake_https_connection(json.dumps(payload))
 
     def test_previous_version_picks_the_highest_published_below_the_build(self):
         with patch(
-            "urllib.request.urlopen",
-            return_value=self._pypi("2.5.11", "2.6.5", "2.6.6", "2.6.9"),
-        ) as urlopen:
-            urlopen.return_value.__enter__ = lambda s: s
-            urlopen.return_value.__exit__ = lambda *a: None
+            "http.client.HTTPSConnection",
+            self._pypi("2.5.11", "2.6.5", "2.6.6", "2.6.9"),
+        ):
             self.assertEqual(
                 tasks._previous_released_version(self._context(), "2.6.9"), "2.6.6"
             )
@@ -471,51 +495,39 @@ class ArtifactUpgradeTaskTest(unittest.TestCase):
         # The defect this replaced: v2.6.7 and v2.6.8 are git tags with no PyPI
         # artifact, so resolving from tags produced an uninstallable version and
         # the release failed *after* the tag was pushed.
-        with patch(
-            "urllib.request.urlopen", return_value=self._pypi("2.6.5", "2.6.6")
-        ) as urlopen:
-            urlopen.return_value.__enter__ = lambda s: s
-            urlopen.return_value.__exit__ = lambda *a: None
+        with patch("http.client.HTTPSConnection", self._pypi("2.6.5", "2.6.6")):
             self.assertEqual(
                 tasks._previous_released_version(self._context(), "2.6.9"), "2.6.6"
             )
 
     def test_previous_version_skips_a_yanked_release(self):
         with patch(
-            "urllib.request.urlopen",
-            return_value=self._pypi("2.6.5", "2.6.6", yanked=("2.6.6",)),
-        ) as urlopen:
-            urlopen.return_value.__enter__ = lambda s: s
-            urlopen.return_value.__exit__ = lambda *a: None
+            "http.client.HTTPSConnection",
+            self._pypi("2.6.5", "2.6.6", yanked=("2.6.6",)),
+        ):
             self.assertEqual(
                 tasks._previous_released_version(self._context(), "2.6.9"), "2.6.5"
             )
 
     def test_previous_version_orders_numerically_not_lexically(self):
-        with patch(
-            "urllib.request.urlopen", return_value=self._pypi("2.5.9", "2.5.11")
-        ) as urlopen:
-            urlopen.return_value.__enter__ = lambda s: s
-            urlopen.return_value.__exit__ = lambda *a: None
+        with patch("http.client.HTTPSConnection", self._pypi("2.5.9", "2.5.11")):
             self.assertEqual(
                 tasks._previous_released_version(self._context(), "2.6.0"), "2.5.11"
             )
 
     def test_previous_version_fails_closed_with_nothing_published(self):
-        with patch(
-            "urllib.request.urlopen", return_value=self._pypi("2.7.0")
-        ) as urlopen:
-            urlopen.return_value.__enter__ = lambda s: s
-            urlopen.return_value.__exit__ = lambda *a: None
+        with patch("http.client.HTTPSConnection", self._pypi("2.7.0")):
             with self.assertRaises(Exit) as raised:
                 tasks._previous_released_version(self._context(), "2.6.9")
         self.assertEqual(raised.exception.code, 2)
 
     def test_previous_version_fails_closed_when_pypi_is_unreachable(self):
-        import urllib.error
-
-        with patch(
-            "urllib.request.urlopen", side_effect=urllib.error.URLError("offline")
+        with (
+            patch(
+                "http.client.HTTPSConnection",
+                _fake_https_connection(error=OSError("offline")),
+            ),
+            patch("time.sleep"),
         ):
             with self.assertRaises(Exit) as raised:
                 tasks._previous_released_version(self._context(), "2.6.9")

--- a/tasks.py
+++ b/tasks.py
@@ -1109,10 +1109,10 @@ def _previous_released_version(context, version):
     gate asks is "what could an operator actually be upgrading from", and only
     the index can answer that.
     """
+    import http.client
     import json
     import time
-    import urllib.error
-    import urllib.request
+    import urllib.parse
 
     url = "https://pypi.org/pypi/forward-netbox/json"
     # Retry before failing. A single attempt failed this gate twice in a row on
@@ -1129,16 +1129,36 @@ def _previous_released_version(context, version):
     for backoff in (0, 10, 30):
         if backoff:
             time.sleep(backoff)
+        # http.client, not urllib.request: urllib appends `Connection: close`
+        # inside `do_open` after the caller's headers, so it cannot be
+        # suppressed, and this host stalls close-mode responses - measured at
+        # 1/10 completions against 6/6 with keep-alive
+        # (`scripts/verify_release_provenance.py`, which speaks http.client for
+        # the same reason). Setting no Connection header leaves the HTTP/1.1
+        # keep-alive default standing. PyPI has not been seen stalling; this
+        # removes the fault-prone pattern from the last place it appears.
+        parsed = urllib.parse.urlsplit(url)
+        connection = http.client.HTTPSConnection(
+            parsed.hostname, parsed.port or 443, timeout=45
+        )
         try:
-            with urllib.request.urlopen(url, timeout=45) as response:
-                payload = json.load(response)
+            connection.request(
+                "GET", parsed.path, headers={"Accept": "application/json"}
+            )
+            response = connection.getresponse()
+            body = response.read()
+            if response.status >= 400:
+                raise OSError(f"PyPI returned HTTP {response.status}")
+            payload = json.loads(body)
             break
         # OSError, not just TimeoutError: the read can also fail with
-        # ConnectionResetError, which is not a URLError and was escaping raw -
-        # failing the release gate with a bare socket error instead of the
-        # message that says how to run it offline.
-        except (urllib.error.URLError, OSError, ValueError) as exc:
+        # ConnectionResetError, which was escaping raw - failing the release
+        # gate with a bare socket error instead of the message that says how to
+        # run it offline.
+        except (http.client.HTTPException, OSError, ValueError) as exc:
             last_error = exc
+        finally:
+            connection.close()
     if payload is None:
         raise Exit(
             f"Could not read released versions from PyPI ({last_error}) after "


### PR DESCRIPTION
## Summary

Finishes the remaining 2.9.x items. Most of what those plans listed as open had already shipped — the sweep index records which commit closed each, with the live call site. What was genuinely left is one real defect and three smaller things.

**v3.0.0 took fourteen attempts.** Exactly one was a product defect; the rest failed in fast bookkeeping steps *after* the ~45-minute gate. A resume mechanism already existed — `--finish`, `--authorize`, `--post-release`, `--anchor` are each independently invocable and the driver prints which to use — but the stages it names raised on a second run, so the advice didn't work and every retry re-paid the gate.

## The four stages

- **The candidate guard is version-scoped.** It matched the bare `"| Release candidate;"` marker, so it couldn't tell this version's row from another version's — and since edits are computed before `stage_prepare`'s `write` check, even a dry run tripped it. A candidate for *this* version is a no-op; a different version still raises.
- **Version surfaces are matched by shape, not the outgoing literal.** A prepare that died mid-write left the rest unreachable: the retry read the new version from `pyproject.toml`, looked for it in a file still holding the old one, and reported `expected exactly one`. Ambiguity is still refused, and `stage_prepare` now prints which surfaces it moved so a repaired drift stays visible.
- **`stage_publish` commits only when something is staged.** An unconditional `git commit` turned "the previous attempt already committed" into a hard failure.
- **`stage_post_release` / `stage_anchor` ask `origin/main` first.** Both rebuild their branch every run, so re-pushing after a partial attempt was a non-fast-forward. Their clean-slate delete is **deliberate** — inheriting a half-made bridge is what cost v2.8.3's slot — so this is a pre-check, never a resumed branch.

## The other three

- **PyPI fetch moves to `http.client`.** `urllib.request` appends `Connection: close` where it can't be suppressed, and this host stalls close-mode responses (1/10 completions vs 6/6 with keep-alive). `verify_release_provenance.py` already speaks `http.client` for that reason; `tasks.py` was the last caller left. **Stated plainly:** PyPI has not been seen stalling — this removes the fault-prone pattern, it does not fix an observed failure. The Forward API client is unaffected (`httpx` doesn't force `close`).
- **The merge profile can see `ChangeDiff.save()`.** Its fixture was CREATE-only and bulk-safe, so it never entered the per-row upstream fallback — the only path reaching `ChangeDiff.save()`. `dcim.region` (a tree model, always refused by `_is_bulk_safe`) joins the fixture, and the command wraps `ChangeDiff.save` in its own `profile_scope`. Production untouched.
- **Stale open-sections swept** into one index, following the `2026-09-02-stale-deferral-sweep.md` precedent.

## Validation

- **Non-vacuity checked: 8 of the 10 new cases fail against `release.py` as it shipped in 3.0.0.** The 2 that pass are the deliberate opposite-branch tests (the ambiguity guard, and publish still committing real changes), which must hold on both sides.
- Converting the `tasks.py` tests mattered for a reason worth naming: with the old `urlopen` mocks left in place, the ported code made **real network calls and passed by accident**. Every call site was converted; zero `urlopen` references remain.
- The two failure-path tests no longer sleep through the `(0, 10, 30)` backoff — that file went from 80s to 0.1s.
- Ported fetch exercised against live PyPI, returned `3.0.0`. Fixture allocation still sums to volume at 100/1000/5000.
- `scripts/tests` 400 passed · `pre-commit --all-files` ✓ · `check_harness` ✓

## Not done

The measurement run itself. `run_merge_profile.sh` needs exclusive use of the docker stack — a concurrent run corrupts it and reads as a code failure. The fixture and scope are in place so the question can be answered in one run.

Plans: `docs/03_Plans/active/2026-09-03-release-stage-idempotency.md`, `docs/03_Plans/active/2026-09-03-stale-open-sections-2.9.x.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mUUpQyPN7sBt8rkKgn2qa
