### PR TITLE
feat: a release can come from a branch that is not main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,25 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.14"
-      - name: Verify protected main-branch release provenance
+      - name: Verify protected release-branch provenance
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git fetch --no-tags origin main:refs/remotes/origin/main
-          git fetch --force origin refs/tags/v2.9.1:refs/tags/v2.9.1
+          # Both values are read from the scripts, never written here, so the
+          # workflow and the verifier cannot disagree about which branch a tag
+          # may come from. The prior-release tag used to be a literal, and
+          # nothing advanced it when the anchor moved - so this fetched the tag
+          # from two releases back and the bridge check had no object.
+          export PYTHONPATH=scripts
+          BRANCH="$(python -c \
+          'import release_lane as r; print(r.RELEASE_BRANCH)')"
+          PRIOR_TAG="$(python -c \
+          'import verify_release_provenance as v; print(v.PRIOR_RELEASE_TAG)')"
+          echo "Release lane: ${BRANCH}; prior release: ${PRIOR_TAG}"
+          git fetch --no-tags origin \
+            "${BRANCH}:refs/remotes/origin/${BRANCH}"
+          git fetch --force origin \
+            "refs/tags/${PRIOR_TAG}:refs/tags/${PRIOR_TAG}"
           set -o pipefail
           for attempt in $(seq 1 120); do
             provenance_log="$(mktemp)"
@@ -56,11 +69,11 @@ jobs:
               exit 1
             fi
             rm -f "${provenance_log}"
-            echo "Main-commit provenance is still settling;"
+            echo "Lane-commit provenance is still settling;"
             echo "retry ${attempt}/120."
             sleep 30
           done
-          echo "Timed out waiting for successful main-commit provenance."
+          echo "Timed out waiting for successful lane-commit provenance."
           exit 1
       - name: Set up Node
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6

--- a/docs/00_Project_Knowledge/release-playbook.md
+++ b/docs/00_Project_Knowledge/release-playbook.md
@@ -2,19 +2,48 @@
 
 Use this playbook for check-gated production releases.
 
+## Release lanes
+
+Since 3.0.0 there is more than one release branch. `main` carries the NetBox
+4.7 line; `maint/2.9.x` carries the 4.6 line, because `main` declares
+`min_version = "4.7.0"` and a 4.6 fix has nowhere else to land.
+
+**Which branch a checkout releases from is declared in
+`scripts/release_lane.py`, and only there.** Every gate reads it: the driver
+checks out and resets to that branch, the harness base is that branch, the
+provenance verifier requires the release commit to be an ancestor of it, and it
+names the branch ruleset that must protect it. Each lane carries its own copy of
+that file, so the values differ between branches by design.
+
+A version from another series is refused by name before any stage runs. That is
+belt and braces - the ancestry check would refuse it anyway - but a release
+stopped by "version 3.0.1 is in the 3.0 series, but this checkout releases the
+2.9 series from maint/2.9.x" is one an operator can act on, and a merge-base
+error is not.
+
+To add a lane: cut the branch from the last release tag of that series, edit
+`scripts/release_lane.py` on it, and create a branch ruleset for it with the
+same shape as `main-release-integrity` (no bypass actors, deletion and
+non-fast-forward blocked, linear history, squash-only through a pull request
+with conversation resolution). `python scripts/verify_release_provenance.py
+--controls-only` run from that branch confirms the ruleset before any tag
+exists.
+
 ## Preconditions
 
 - Worktree is clean except for intended release changes.
 - Version is updated in `pyproject.toml` and `forward_netbox/__init__.py`.
 - Release notes are updated in `README.md`, `docs/README.md`, and `docs/01_User_Guide/README.md`.
 - No customer identifiers, network IDs, snapshot IDs, credentials, or private screenshots are in tracked content.
-- Repository rulesets `main-release-integrity` and `version-tag-integrity` are
-  active. Main has no bypass actors and
+- The branch ruleset naming this lane (`scripts/release_lane.py` declares
+  which; `maint-2-9-x-release-integrity` here) and `version-tag-integrity` are
+  active. The release branch has no bypass actors and
   requires a pull request, resolved conversations, the trusted
   candidate scan, exact NetBox 4.6.5 CI, both CodeQL analyses, and the separate
   GitHub Advanced Security CodeQL result. Version tags
   reject deletion and movement. Releases use a normal annotated tag created by
-  the authenticated maintainer from an exact validated `main` commit.
+  the authenticated maintainer from an exact validated commit on the lane's
+  release branch.
 - Environment `pypi` accepts only `v*` tags and has no reviewer gate. PyPI
   Trusted Publishing uses GitHub OIDC; no repository or environment PyPI token
   is stored.

--- a/docs/03_Plans/active/2026-09-03-release-lanes.md
+++ b/docs/03_Plans/active/2026-09-03-release-lanes.md
@@ -1,0 +1,122 @@
+# A release can come from a branch that is not main
+
+## Goal
+
+Make `maint/2.9.x` releasable. The 4.6 lane exists as a branch but every
+release gate asks whether a commit is on `main`, so a `v2.9.3` tag cut there
+would be refused - not by one check, but by four independent ones.
+
+## Constraints
+
+- **The gates must keep failing closed.** Parameterising "main" must not turn
+  any refusal into a pass. A wrong lane value has to refuse the release, not
+  accept a different one.
+- **Each lane keeps its own declaration.** The scripts live on the branch they
+  release, so the lane is branch-local by construction. That is the property
+  that makes a wrong value safe: the tagged commit will not be an ancestor of
+  the branch the file names.
+- **No new bypass.** The maintenance branch needs the same protection main has,
+  or a release from it is a release from an unprotected branch. The verifier
+  already refuses that; it must keep refusing it.
+- **`main`'s release path must not change behaviour.** Its lane declaration
+  names `main`, so every gate resolves exactly as it did before.
+
+## Touched Surfaces
+
+- `scripts/release_lane.py` (new) - the declaration and the series guard
+- `scripts/release.py` - checkout, reset, fetch, PR base, harness base
+- `scripts/verify_release_provenance.py` - ruleset, PR base ref, workflow head
+  branch, ancestry
+- `scripts/check_release_preflight.py`, `scripts/check_release_lineage.py`
+- `.github/workflows/release.yml`
+- `scripts/tests/test_release_lane.py` (new) and the four existing test modules
+  that pinned "main"
+- `docs/00_Project_Knowledge/release-playbook.md`
+
+## Approach
+
+### 1. Declare the lane, do not derive it
+
+`scripts/release_lane.py` holds one `ReleaseLane` - branch, series, and the
+name of the branch ruleset that must protect it - and derives every ref form
+from the branch so a slash in `maint/2.9.x` cannot be mishandled by one caller
+and not another.
+
+Declared rather than inferred, for the reason `tested_runtime.py` declares
+runtime pins: a value read from the current checkout is a value that silently
+follows a bad merge, and this one decides which branch's history a release may
+come from.
+
+### 2. Substitute, do not abstract
+
+Roughly thirty literal `"main"` and `"origin/main"` uses become the lane's
+values. No new indirection beyond the one module: the gates keep their shape,
+and a reader who knew where "main" was written still finds the same code doing
+the same thing.
+
+Operator-facing messages name the lane rather than saying "main", because a
+message that says main while running on `maint/2.9.x` is worse than no message.
+
+### 3. Refuse the wrong series by name
+
+`require_version_in_lane` runs before any stage in the driver and before any
+GitHub call in the verifier. The ancestry check would refuse a cross-lane tag
+anyway; this turns a merge-base error into a sentence naming both series and
+the branch to use instead.
+
+### 4. Derive the prior-release tag in the workflow
+
+The workflow fetched `refs/tags/v2.9.1` as a literal so the bridge check had an
+object to resolve. Nothing advanced it when the release anchor moved, so on
+this branch it fetched the tag from two releases back while
+`PRIOR_RELEASE_TAG` already said `v2.9.2`. It is now read from the verifier,
+which is the only place that decides it.
+
+### 5. Protect the branch
+
+`maint-2-9-x-release-integrity` mirrors `main-release-integrity` exactly: no
+bypass actors, deletion and non-fast-forward blocked, linear history, and
+squash-only through a pull request with conversation resolution.
+
+## Validation
+
+- `python -m pytest scripts/tests` - 382 tests. The four modules that pinned
+  "main" now assert against the lane, so they still pin the contract rather
+  than being relaxed to accept anything.
+- The provenance fixtures move from a 2.6.0 tag to 2.9.3. A fixture releasing
+  2.6.0 from the 2.9 maintenance branch was never coherent; now the test says
+  what the branch actually does.
+- **Live**: `python scripts/verify_release_provenance.py --controls-only` run
+  from this branch, against the real ruleset. This is the check that would have
+  refused a release from an unprotected branch, and it passes.
+- `pre-commit run --all-files`, `python3 scripts/check_harness.py --base
+  origin/maint/2.9.x`.
+
+## Rollback
+
+Revert the commit and delete the ruleset. The lane module is additive; nothing
+outside the release tooling imports it, and no shipped code changes - `packages
+= [{include = "forward_netbox"}]`, so none of this reaches the wheel.
+
+## Decision Log
+
+- **One declaration per branch, not a lane table.** A table mapping series to
+  branches would have to be identical on every branch and would be a merge
+  conflict every time a lane was added. The scripts are already branch-local;
+  the declaration follows them.
+- **The series guard is belt and braces, and worth it.** Ancestry already fails
+  closed. The guard exists so the failure names the mistake instead of naming
+  merge-base.
+- **The verifier's fixtures moved series rather than the guard being
+  weakened.** Patching the lane out in tests would have left the guard
+  untested at exactly the point it matters.
+- **No `--lane` flag.** A lane that can be passed on the command line is a lane
+  that can be passed wrongly, and the whole point is that the branch decides.
+
+## Open
+
+- **Forward-porting to `main`.** `main` needs the same change so the two lanes
+  do not diverge and a future 3.x maintenance branch works. Not done here: this
+  branch is the one that needs it, and main's release path works today.
+- **Nothing has been released through this yet.** The controls check passes
+  live, and the rest is proven by tests; the first real proof is `v2.9.3`.

--- a/docs/03_Plans/active/2026-09-03-release-lanes.md
+++ b/docs/03_Plans/active/2026-09-03-release-lanes.md
@@ -37,6 +37,14 @@ would be refused - not by one check, but by four independent ones.
 
 ### 1. Declare the lane, do not derive it
 
+`series` is optional. A maintenance lane exists to carry exactly one series, so
+pinning it there is the point; the trunk is where new series are born - it
+released 2.9, then 3.0, and will release whatever comes next - so pinning it
+would refuse the next minor bump and would have to be edited on every one of
+them. `None` means the lane is not confined, and ancestry remains the real gate
+either way.
+
+
 `scripts/release_lane.py` holds one `ReleaseLane` - branch, series, and the
 name of the branch ruleset that must protect it - and derives every ref form
 from the branch so a slash in `maint/2.9.x` cannot be mishandled by one caller

--- a/scripts/check_harness.py
+++ b/scripts/check_harness.py
@@ -197,7 +197,13 @@ REQUIRED_TEXT = {
     ],
     ".github/workflows/release.yml": [
         "fetch-depth: 0",
-        "refs/tags/v2.9.1",
+        # The prior-release tag is read from the verifier, not written here.
+        # It was a literal, and nothing advanced it when the anchor moved, so
+        # the workflow fetched a tag from two releases back.
+        "import verify_release_provenance as v; print(v.PRIOR_RELEASE_TAG)",
+        # The lane is read the same way, so the workflow cannot fetch one
+        # branch while the verifier checks ancestry against another.
+        "import release_lane as r",
         "verify_release_provenance.py",
         "--git-files",
         "--protected-history",
@@ -1097,7 +1103,9 @@ def _check_standard_release_tag_flow(failures: list[str]) -> None:
         "BOOTSTRAP_REQUIRED_FILES",
         "BOOTSTRAP_FILE_DIGESTS",
         'operation.add_argument("--controls-only", action="store_true")',
-        '"merge-base", "--is-ancestor", release_commit, current_main',
+        '"merge-base", "--is-ancestor", release_commit, current_head',
+        # The release branch is declared, never inferred from the checkout.
+        "from release_lane import LANE",
     ):
         if fragment not in texts["provenance"]:
             failures.append(f"release provenance must contain: {fragment}")
@@ -1120,7 +1128,7 @@ def main() -> int:
         "--base",
         help=(
             "Validate every commit in <base>..HEAD against the push-event plan "
-            "gate (use before pushing, e.g. --base origin/main)."
+            "gate (use before pushing, e.g. --base origin/<release branch>)."
         ),
     )
     args = parser.parse_args()

--- a/scripts/check_release_lineage.py
+++ b/scripts/check_release_lineage.py
@@ -31,6 +31,13 @@ from __future__ import annotations
 
 import argparse
 import subprocess
+
+# Imported as a sibling when run directly and as a package member when
+# the tests import it; both spellings resolve to the same module.
+try:  # pragma: no cover - exercised by whichever entry point is in use
+    from release_lane import REMOTE_RELEASE_REF
+except ImportError:  # pragma: no cover
+    from scripts.release_lane import REMOTE_RELEASE_REF
 import sys
 from pathlib import Path
 
@@ -152,15 +159,15 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--version", required=True, help="Release version, e.g. 2.7.11")
     parser.add_argument(
         "--release-commit",
-        default="origin/main",
-        help="Commit about to be tagged (default: origin/main).",
+        default=REMOTE_RELEASE_REF,
+        help=f"Commit about to be tagged (default: {REMOTE_RELEASE_REF}).",
     )
     args = parser.parse_args(argv)
     try:
         result = check_release_lineage(args.release_commit, args.version)
     except LineageError as exc:
         # Name what was measured, not just the verdict. `--release-commit`
-        # defaults to `origin/main`, which is right when this runs after the
+        # defaults to the release branch head, which is right after the
         # release PR merges and wrong before it - and a bare "lineage has 3
         # commits and needs at least 4" reads as a real refusal either way.
         # Resolving the ref here costs nothing and turns "the release is

--- a/scripts/check_release_preflight.py
+++ b/scripts/check_release_preflight.py
@@ -26,6 +26,13 @@ import sys
 import tomllib
 from pathlib import Path
 
+# Imported as a sibling when run directly and as a package member when
+# the tests import it; both spellings resolve to the same module.
+try:  # pragma: no cover - exercised by whichever entry point is in use
+    from release_lane import REMOTE_RELEASE_REF
+except ImportError:  # pragma: no cover
+    from scripts.release_lane import REMOTE_RELEASE_REF
+
 import verify_release_provenance as provenance
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -383,27 +390,27 @@ def check_release_plan_evidence_base(version: str) -> str:
 
     Authorization binds the tagged commit to its parent. A release branch's own
     parent is *not* that commit: the release squash-merges, so on `main` the
-    release commit's parent is `origin/main`'s head at merge time. Recording the
+    release commit's parent is the release branch's head at merge time. Recording the
     branch-side parent therefore always mismatches once merged, and the release
     cannot be tagged until a second PR corrects it — which costs a full CI cycle
     for a one-line change.
 
     Reported here, before the push, so the round trip is seconds instead of an
-    hour. Skipped when `origin/main` is unknown (a fresh clone or offline run),
+    hour. Skipped when the release branch is unknown (a fresh clone or offline run),
     since a missing remote ref is not evidence of a wrong value.
 
-    `origin/main` is only the right comparison *before* the merge. Once the
-    release has merged, `origin/main` is the release commit itself, so demanding
+    The branch head is only the right comparison *before* the merge. Once the
+    release has merged, that head is the release commit itself, so demanding
     it here would tell the operator to record the tagged commit in place of its
     parent — the exact value `release_evidence_commit_binding` then rejects,
     since it binds against `HEAD^`. In that window the two checks contradicted
     each other and the release could not be tagged at all. So when `HEAD` is
-    already `origin/main`, compare against `HEAD^`: same rule, evaluated from
+    already the branch head, compare against `HEAD^`: same rule, evaluated from
     the side of the merge the repository is actually on.
     """
     if _git("tag", "--list", f"v{version}"):
         # Already tagged: the recorded value was correct at tag time and is now
-        # history. Re-checking it against a moved origin/main is meaningless.
+        # history. Re-checking it against a moved branch head is meaningless.
         return f"skipped (v{version} is already tagged)"
     plans = sorted((REPO_ROOT / "docs" / "03_Plans").rglob(f"*release-{version}*.md"))
     if len(plans) != 1:
@@ -416,12 +423,12 @@ def check_release_plan_evidence_base(version: str) -> str:
     )
     if match is None:
         return "skipped (plan records no evidence base commit yet)"
-    remote_main = _git("rev-parse", "origin/main")
-    if len(remote_main) != 40:
-        return "skipped (origin/main is unknown in this checkout)"
-    merged = _git("rev-parse", "HEAD") == remote_main
-    reference = "HEAD^" if merged else "origin/main"
-    expected = _git("rev-parse", reference) if merged else remote_main
+    remote_head = _git("rev-parse", REMOTE_RELEASE_REF)
+    if len(remote_head) != 40:
+        return f"skipped ({REMOTE_RELEASE_REF} is unknown in this checkout)"
+    merged = _git("rev-parse", "HEAD") == remote_head
+    reference = "HEAD^" if merged else REMOTE_RELEASE_REF
+    expected = _git("rev-parse", reference) if merged else remote_head
     if len(expected) != 40:
         return f"skipped ({reference} is unknown in this checkout)"
     recorded = match.group(1)
@@ -431,7 +438,7 @@ def check_release_plan_evidence_base(version: str) -> str:
             f"and its parent is {expected}"
             if merged
             else f"a squash merge will make the release commit's parent "
-            f"{expected} (origin/main)"
+            f"{expected} ({REMOTE_RELEASE_REF})"
         )
         raise PreflightError(
             f"{plans[0].relative_to(REPO_ROOT)} records evidence base commit "
@@ -506,7 +513,7 @@ def _outcome(detail: str) -> str:
     """Say `skipped` for a check that declined to run.
 
     Several checks return a `skipped (reason)` string when they cannot decide -
-    no plan yet, no `origin/main`, already tagged. Every one of them was printed
+    no plan yet, no release branch, already tagged. Every one of them was printed
     under a `passed:` prefix, so the release log read
 
         release preflight passed: evidence base commit skipped (v2.8.3 is

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -40,6 +40,21 @@ from datetime import datetime
 from datetime import timezone
 from pathlib import Path
 
+# `release_lane` is imported two ways: as a sibling when a script is run
+# directly (`python scripts/release.py`, where `scripts/` is on sys.path), and
+# as a package member when the tests import `scripts.release`. Both spellings
+# resolve to the same module; neither is a fallback for the other failing.
+try:  # pragma: no cover - exercised by whichever entry point is in use
+    from release_lane import RELEASE_BRANCH
+    from release_lane import ReleaseLaneError
+    from release_lane import REMOTE_RELEASE_REF
+    from release_lane import require_version_in_lane
+except ImportError:  # pragma: no cover
+    from scripts.release_lane import RELEASE_BRANCH
+    from scripts.release_lane import ReleaseLaneError
+    from scripts.release_lane import REMOTE_RELEASE_REF
+    from scripts.release_lane import require_version_in_lane
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 INIT_PY = REPO_ROOT / "forward_netbox/__init__.py"
@@ -645,7 +660,7 @@ def stage_publish(version: str, *, auto_finish: bool = False) -> None:
     run(["git", "commit", "-m", f"release: cut v{version}"])
     # Simulate the push-event harness gate (every commit's high-risk paths need a
     # plan file in the SAME commit) BEFORE pushing — avoids a failed-CI round-trip.
-    run([sys.executable, "scripts/check_harness.py", "--base", "origin/main"])
+    run([sys.executable, "scripts/check_harness.py", "--base", REMOTE_RELEASE_REF])
     run(["git", "push", "--no-verify", "-u", "origin", branch])
     published_head = _capture(["git", "rev-parse", "HEAD"])
     if not wait_for_required_workflows(
@@ -717,10 +732,10 @@ def _wait_for_pull_request_merge(
 
 
 def _checkout_merged_main() -> str:
-    """Put the checkout on `main` at exactly `origin/main` and return that SHA."""
-    run(["git", "fetch", "origin", "main"])
-    run(["git", "checkout", "--force", "main"])
-    run(["git", "reset", "--hard", "origin/main"])
+    """Put the checkout on the release branch at its remote head, and return it."""
+    run(["git", "fetch", "origin", RELEASE_BRANCH])
+    run(["git", "checkout", "--force", RELEASE_BRANCH])
+    run(["git", "reset", "--hard", REMOTE_RELEASE_REF])
     return _capture(["git", "rev-parse", "HEAD"])
 
 
@@ -735,7 +750,7 @@ def _pull_request_for_branch(branch: str) -> dict | None:
             "--head",
             branch,
             "--base",
-            "main",
+            RELEASE_BRANCH,
             "--state",
             "all",
             "--limit",
@@ -772,7 +787,7 @@ def _open_release_pull_request(version: str, branch: str, *, evidence: bool) -> 
                 "--repo",
                 GITHUB_REPOSITORY,
                 "--base",
-                "main",
+                RELEASE_BRANCH,
                 "--head",
                 branch,
                 "--title",
@@ -932,7 +947,7 @@ def stage_finish(version: str) -> None:
         # tag, because the harness ties the anchor to the current release and
         # refuses either one moving alone - see `promote_release_tables`.
         head_commit = _capture(["git", "rev-parse", "HEAD"])
-        run([sys.executable, "scripts/check_harness.py", "--base", "origin/main"])
+        run([sys.executable, "scripts/check_harness.py", "--base", REMOTE_RELEASE_REF])
         run(["git", "push", "--no-verify", "origin", production_branch])
         if not wait_for_required_workflows(
             head_commit,
@@ -949,7 +964,7 @@ def stage_finish(version: str) -> None:
 
     if current_branch == evidence_branch:
         head_commit = _capture(["git", "rev-parse", "HEAD"])
-        run([sys.executable, "scripts/check_harness.py", "--base", "origin/main"])
+        run([sys.executable, "scripts/check_harness.py", "--base", REMOTE_RELEASE_REF])
         run(
             [
                 sys.executable,
@@ -972,16 +987,20 @@ def stage_finish(version: str) -> None:
         )
         return
 
-    if current_branch != "main":
+    if current_branch != RELEASE_BRANCH:
         raise ReleaseError(
-            f"finish requires {production_branch}, {evidence_branch}, or main; "
+            f"finish requires {production_branch}, {evidence_branch}, or "
+            f"{RELEASE_BRANCH}; "
             f"found {current_branch!r}"
         )
-    run(["git", "fetch", "origin", "main"])
+    run(["git", "fetch", "origin", RELEASE_BRANCH])
     head_commit = _capture(["git", "rev-parse", "HEAD"])
-    remote_main = _capture(["git", "rev-parse", "origin/main"])
+    remote_main = _capture(["git", "rev-parse", REMOTE_RELEASE_REF])
     if head_commit != remote_main:
-        raise ReleaseError("local main must exactly match origin/main before tagging")
+        raise ReleaseError(
+            f"local {RELEASE_BRANCH} must exactly match {REMOTE_RELEASE_REF} "
+            f"before tagging"
+        )
     run(
         [
             sys.executable,
@@ -990,8 +1009,10 @@ def stage_finish(version: str) -> None:
             version,
         ]
     )
-    if not wait_for_required_workflows(head_commit, expected_branch="main"):
-        raise ReleaseError("Final main exact workflows did not all succeed")
+    if not wait_for_required_workflows(head_commit, expected_branch=RELEASE_BRANCH):
+        raise ReleaseError(
+            f"Final {RELEASE_BRANCH} exact workflows did not all succeed"
+        )
     tag = f"v{version}"
     ensure_release_tag(tag, head_commit)
     conclusion = wait_for_release_workflow(version)
@@ -1100,7 +1121,7 @@ def stage_post_release(version: str, tag: str) -> None:
 
     It failed. The bump touches `pyproject.toml` and
     `forward_netbox/utilities/fast_baseline.py`, both high-risk paths, and
-    `check_harness.py --base origin/main` requires a plan file in the same
+    `check_harness.py --base <lane>` requires a plan file in the same
     commit. `stage_open_next` writes none, so the stage rejected its own commit
     on every release.
 
@@ -1128,18 +1149,18 @@ def stage_post_release(version: str, tag: str) -> None:
     branch = f"docs/post-release-{version}"
     print(f"[post-release] opening {branch} for {tag}")
 
-    run(["git", "fetch", "origin", "main"])
+    run(["git", "fetch", "origin", RELEASE_BRANCH])
     # Where the operator started, so they are put back whatever happens.
-    starting_branch = _capture(["git", "branch", "--show-current"]) or "main"
+    starting_branch = _capture(["git", "branch", "--show-current"]) or RELEASE_BRANCH
     plan_path = _bridge_plan_path(version)
     try:
-        run(["git", "checkout", "-B", branch, "origin/main"])
+        run(["git", "checkout", "-B", branch, REMOTE_RELEASE_REF])
         plan_path.write_text(_bridge_plan_text(version, tag), encoding="utf-8")
         # This path only. `git add -A` here would sweep anything else the
         # working tree happens to hold into a commit that must carry one file.
         run(["git", "add", str(plan_path)])
         run(["git", "commit", "-m", f"docs: record the {version} post-release bridge"])
-        run([sys.executable, "scripts/check_harness.py", "--base", "origin/main"])
+        run([sys.executable, "scripts/check_harness.py", "--base", REMOTE_RELEASE_REF])
         run(["git", "push", "--no-verify", "-u", "origin", branch])
         _open_pull_request(
             branch,
@@ -1152,7 +1173,7 @@ def stage_post_release(version: str, tag: str) -> None:
     except Exception:
         # A failed stage leaves nothing behind. The branch was created by this
         # function and holds at most the one commit it made; deleting it means
-        # the next attempt starts from origin/main rather than inheriting a
+        # the next attempt starts from the lane head rather than inheriting a
         # half-made bridge - which is how v2.8.3's slot was lost.
         run(["git", "checkout", "--force", starting_branch], check=False)
         run(["git", "branch", "-D", branch], check=False)
@@ -1184,7 +1205,7 @@ def _open_pull_request(branch: str, *, title: str, body: str) -> dict:
                 "--repo",
                 GITHUB_REPOSITORY,
                 "--base",
-                "main",
+                RELEASE_BRANCH,
                 "--head",
                 branch,
                 "--title",
@@ -1214,13 +1235,21 @@ def _open_pull_request(branch: str, *, title: str, body: str) -> dict:
 
 
 def _bridge_commit_for(tag: str) -> str:
-    """The first first-parent commit after ``tag`` on origin/main: the bridge."""
-    run(["git", "fetch", "origin", "main"])
+    """The first first-parent commit after ``tag`` on the lane: the bridge."""
+    run(["git", "fetch", "origin", RELEASE_BRANCH])
     lineage = _capture(
-        ["git", "rev-list", "--first-parent", "--reverse", f"{tag}..origin/main"]
+        [
+            "git",
+            "rev-list",
+            "--first-parent",
+            "--reverse",
+            f"{tag}..{REMOTE_RELEASE_REF}",
+        ]
     ).splitlines()
     if not lineage:
-        raise ReleaseError(f"nothing has landed on origin/main after {tag} yet")
+        raise ReleaseError(
+            f"nothing has landed on {REMOTE_RELEASE_REF} after {tag} yet"
+        )
     bridge = lineage[0]
     tag_commit = _capture(["git", "rev-list", "-n", "1", tag])
     changed = [
@@ -1285,7 +1314,7 @@ the previous release to superseded.
 
 ## Validation
 
-`check_harness.py --base origin/main` passes with the anchor advanced.
+`check_harness.py --base <lane>` passes with the anchor advanced.
 
 ## Rollback
 
@@ -1317,10 +1346,10 @@ def stage_anchor(version: str, tag: str) -> None:
     bridge = _bridge_commit_for(tag)
     branch = f"chore/anchor-{version}"
     print(f"[anchor] {tag} -> bridge {bridge[:12]} on {branch}")
-    starting_branch = _capture(["git", "branch", "--show-current"]) or "main"
+    starting_branch = _capture(["git", "branch", "--show-current"]) or RELEASE_BRANCH
     plan_path = _anchor_plan_path(version)
     try:
-        run(["git", "checkout", "-B", branch, "origin/main"])
+        run(["git", "checkout", "-B", branch, REMOTE_RELEASE_REF])
         text = PROVENANCE.read_text(encoding="utf-8")
         text = bump_version_text(
             text,
@@ -1355,7 +1384,7 @@ def stage_anchor(version: str, tag: str) -> None:
                 f"chore: advance the release provenance anchor to {version}",
             ]
         )
-        run([sys.executable, "scripts/check_harness.py", "--base", "origin/main"])
+        run([sys.executable, "scripts/check_harness.py", "--base", REMOTE_RELEASE_REF])
         run(["git", "push", "--no-verify", "-u", "origin", branch])
         _open_pull_request(
             branch,
@@ -1445,7 +1474,7 @@ def stage_authorize(version: str) -> None:
     """Append the Release Authorization section on the evidence branch.
 
     Runs after the production pull request has merged, because the evidence
-    base commit is the commit the tag's parent will be - `origin/main` at that
+    base commit is the commit the tag's parent will be - the lane head at that
     moment - and nothing else.
     """
     record = read_evidence_record(version)
@@ -1455,7 +1484,7 @@ def stage_authorize(version: str) -> None:
     text = plan_path.read_text(encoding="utf-8")
     if "## Release Authorization" in text:
         raise ReleaseError(f"{plan_path.name} already carries a Release Authorization")
-    run(["git", "checkout", "-B", evidence_branch, "origin/main"])
+    run(["git", "checkout", "-B", evidence_branch, REMOTE_RELEASE_REF])
     section = render_release_authorization(record, evidence_base)
     plan_path.write_text(text.rstrip("\n") + "\n\n" + section, encoding="utf-8")
     run(["git", "add", str(plan_path.relative_to(REPO_ROOT))])
@@ -1557,6 +1586,13 @@ def main(argv: list[str] | None = None) -> int:
 
     if not SEMVER_RE.match(args.version):
         parser.error(f"version must be X.Y.Z, got {args.version!r}")
+    # Before any stage touches git or GitHub. Releasing the wrong series from
+    # this checkout would otherwise fail deep inside an ancestry check, with an
+    # error about merge-base rather than about the mistake.
+    try:
+        require_version_in_lane(args.version)
+    except ReleaseLaneError as error:
+        parser.error(str(error))
 
     try:
         if args.anchor:

--- a/scripts/release_lane.py
+++ b/scripts/release_lane.py
@@ -1,0 +1,76 @@
+# Which branch this checkout releases from.
+#
+# Until 3.0.0 there was one lane and "main" was written into the release
+# tooling about thirty times. That was correct while it was true, and it stopped
+# being true the moment `main` moved to NetBox 4.7 only: the 4.6 lane lives on
+# `maint/2.9.x`, and a tag cut there was refused by every gate that asked
+# whether the commit was on main.
+#
+# The lane is DECLARED here rather than derived, for the same reason
+# `tested_runtime.py` declares runtime pins: a value inferred from the current
+# checkout is a value that silently follows a bad merge, and this one decides
+# which branch's history a release is allowed to come from.
+#
+# Each lane carries its own copy of this file, so the constants differ between
+# branches by design. That is safe in both directions - a wrong value fails
+# closed, because the tagged commit will not be an ancestor of the branch the
+# file names - and `require_version_in_lane` turns that failure from a confusing
+# ancestry error into a sentence naming the mistake.
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReleaseLane:
+    """The branch a release comes from, and what proves it is protected."""
+
+    branch: str
+    series: str
+    ruleset: str
+
+    @property
+    def remote_ref(self) -> str:
+        """`origin/<branch>`, for rev-parse and `--base` arguments."""
+        return f"origin/{self.branch}"
+
+    @property
+    def remote_tracking_ref(self) -> str:
+        """The full remote-tracking ref, for an unambiguous rev-parse."""
+        return f"refs/remotes/origin/{self.branch}"
+
+    @property
+    def ref_pattern(self) -> str:
+        """The ruleset ref pattern that must protect this branch."""
+        return f"refs/heads/{self.branch}"
+
+
+# 2.9.x is the NetBox 4.6 maintenance lane. `main` is 4.7 only from 3.0.0, so a
+# 4.6 fix has nowhere else to land.
+LANE = ReleaseLane(
+    branch="maint/2.9.x",
+    series="2.9",
+    ruleset="maint-2-9-x-release-integrity",
+)
+
+RELEASE_BRANCH = LANE.branch
+REMOTE_RELEASE_REF = LANE.remote_ref
+
+
+class ReleaseLaneError(RuntimeError):
+    """This version does not belong to the lane this checkout releases."""
+
+
+def require_version_in_lane(version: str) -> None:
+    """Refuse a version from another series before anything else runs.
+
+    The failure this exists to catch is a merge that carries one lane's
+    `LANE` onto the other's branch. Ancestry would still refuse the release,
+    but with an error about merge-base that reads as a git problem rather than
+    as "you are releasing 3.0.1 from the 2.9 branch".
+    """
+    series = ".".join(str(version).split(".")[:2])
+    if series != LANE.series:
+        raise ReleaseLaneError(
+            f"version {version} is in the {series} series, but this checkout "
+            f"releases the {LANE.series} series from {LANE.branch}. Release it "
+            f"from its own lane."
+        )

--- a/scripts/release_lane.py
+++ b/scripts/release_lane.py
@@ -21,11 +21,20 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class ReleaseLane:
-    """The branch a release comes from, and what proves it is protected."""
+    """The branch a release comes from, and what proves it is protected.
+
+    `series` is the version series this lane is CONFINED to, and it is optional
+    on purpose. A maintenance lane exists to carry exactly one series, so
+    pinning it there is the point. The trunk is where new series are born - it
+    released 2.9, then 3.0, and will release whatever comes next - so pinning it
+    would refuse the next minor bump and would have to be edited on every one of
+    them. `None` means "this lane is not confined", and ancestry remains the
+    real gate either way.
+    """
 
     branch: str
-    series: str
     ruleset: str
+    series: str | None = None
 
     @property
     def remote_ref(self) -> str:
@@ -47,8 +56,8 @@ class ReleaseLane:
 # 4.6 fix has nowhere else to land.
 LANE = ReleaseLane(
     branch="maint/2.9.x",
-    series="2.9",
     ruleset="maint-2-9-x-release-integrity",
+    series="2.9",
 )
 
 RELEASE_BRANCH = LANE.branch
@@ -66,7 +75,14 @@ def require_version_in_lane(version: str) -> None:
     `LANE` onto the other's branch. Ancestry would still refuse the release,
     but with an error about merge-base that reads as a git problem rather than
     as "you are releasing 3.0.1 from the 2.9 branch".
+
+    A lane with no declared series accepts any version. That is not a weakened
+    check, it is the absence of one that never applied: the trunk is where the
+    next series comes from, and refusing it there would be refusing the normal
+    case.
     """
+    if LANE.series is None:
+        return
     series = ".".join(str(version).split(".")[:2])
     if series != LANE.series:
         raise ReleaseLaneError(

--- a/scripts/tests/test_check_harness.py
+++ b/scripts/tests/test_check_harness.py
@@ -609,7 +609,8 @@ BOOTSTRAP_FILE_DIGESTS
 BASE_REQUIRED_STATUS_CHECKS
 TRUSTED_STATUS_CONTEXT
 operation.add_argument("--controls-only", action="store_true")
-"merge-base", "--is-ancestor", release_commit, current_main
+"merge-base", "--is-ancestor", release_commit, current_head
+from release_lane import LANE
 """
 
     def _check(self, *, release=None, provenance=None):

--- a/scripts/tests/test_release.py
+++ b/scripts/tests/test_release.py
@@ -859,7 +859,7 @@ class StageAnchorTest(unittest.TestCase):
             patch.object(release, "_anchor_plan_path", return_value=plan),
             patch.object(release, "promote_release_tables") as promote,
             patch.object(release, "_open_pull_request") as open_pull_request,
-            patch.object(release, "_capture", return_value="main"),
+            patch.object(release, "_capture", return_value=release.RELEASE_BRANCH),
             patch.object(release, "run", side_effect=run),
         ):
             try:
@@ -882,13 +882,16 @@ class StageAnchorTest(unittest.TestCase):
         promote.assert_called_once_with("2.9.2")
         open_pull_request.assert_called_once()
         joined = [" ".join(call) for call in calls]
-        self.assertIn("git checkout -B chore/anchor-2.9.2 origin/main", joined)
+        self.assertIn(
+            f"git checkout -B chore/anchor-2.9.2 {release.REMOTE_RELEASE_REF}",
+            joined,
+        )
         commit = next(i for i, c in enumerate(joined) if "git commit" in c)
         harness = next(i for i, c in enumerate(joined) if "check_harness.py" in c)
         push = next(i for i, c in enumerate(joined) if c.startswith("git push"))
         self.assertLess(commit, harness)
         self.assertLess(harness, push)
-        self.assertEqual(joined[-1], "git checkout --force main")
+        self.assertEqual(joined[-1], f"git checkout --force {release.RELEASE_BRANCH}")
 
     def test_the_generated_plan_carries_the_harness_headings(self):
         _text, plan, _calls, _promote, _open = self._run()
@@ -947,7 +950,10 @@ class StageAuthorizeTest(unittest.TestCase):
         self.assertIn("## Release Authorization", text)
         self.assertIn("- Evidence base commit: `" + "e" * 40 + "`", text)
         joined = [" ".join(call) for call in calls]
-        self.assertIn("git checkout -B release/2.9.2-evidence origin/main", joined)
+        self.assertIn(
+            f"git checkout -B release/2.9.2-evidence {release.REMOTE_RELEASE_REF}",
+            joined,
+        )
         self.assertTrue(any("release: authorize v2.9.2" in c for c in joined))
         self.assertTrue(any("check_release_authorization.py" in c for c in joined))
 

--- a/scripts/tests/test_release_flow_post_release.py
+++ b/scripts/tests/test_release_flow_post_release.py
@@ -70,10 +70,13 @@ class StagePostReleaseTest(unittest.TestCase):
         _calls, written = self._run()
         self.assertIn("# Post-release bridge for 2.7.0", written)
 
-    def test_it_branches_from_origin_main_and_pushes(self):
+    def test_it_branches_from_the_release_branch_and_pushes(self):
         calls, _written = self._run()
         joined = [" ".join(call) for call in calls]
-        self.assertIn("git checkout -B docs/post-release-2.7.0 origin/main", joined)
+        self.assertIn(
+            f"git checkout -B docs/post-release-2.7.0 {release.REMOTE_RELEASE_REF}",
+            joined,
+        )
         self.assertTrue(
             any(
                 call.startswith("git push") and "docs/post-release-2.7.0" in call

--- a/scripts/tests/test_release_lane.py
+++ b/scripts/tests/test_release_lane.py
@@ -4,7 +4,7 @@
 # merge that carries one lane's declaration onto the other's branch. Ancestry
 # would still refuse the release, but with an error about merge-base that reads
 # as a git problem rather than as "you are releasing the wrong series here".
-import unittest
+import unittest.mock
 
 from scripts.release_lane import LANE
 from scripts.release_lane import RELEASE_BRANCH
@@ -16,7 +16,7 @@ from scripts.release_lane import require_version_in_lane
 
 class TheLaneNamesOneBranchTest(unittest.TestCase):
     def test_the_refs_all_derive_from_the_branch(self):
-        lane = ReleaseLane(branch="maint/1.2.x", series="1.2", ruleset="whatever")
+        lane = ReleaseLane(branch="maint/1.2.x", ruleset="whatever", series="1.2")
         self.assertEqual(lane.remote_ref, "origin/maint/1.2.x")
         self.assertEqual(lane.remote_tracking_ref, "refs/remotes/origin/maint/1.2.x")
         self.assertEqual(lane.ref_pattern, "refs/heads/maint/1.2.x")
@@ -52,3 +52,25 @@ class AVersionFromAnotherSeriesIsRefusedTest(unittest.TestCase):
     def test_a_longer_version_is_still_matched_on_its_series(self):
         with self.assertRaises(ReleaseLaneError):
             require_version_in_lane("10.9.3")
+
+    def test_this_lane_is_confined_to_one_series(self):
+        # A maintenance lane exists to carry exactly one series. If this ever
+        # reads None, the branch has stopped being a maintenance lane and the
+        # guard below it has stopped applying.
+        self.assertEqual(LANE.series, "2.9")
+
+
+class AnUnconfinedLaneAcceptsAnySeriesTest(unittest.TestCase):
+    """The trunk is where the next series is born.
+
+    Pinning a series there would refuse the next minor bump and would have to
+    be edited on every one of them. Ancestry stays the real gate.
+    """
+
+    def test_a_lane_without_a_series_refuses_nothing(self):
+        trunk = ReleaseLane(branch="main", ruleset="main-release-integrity")
+        self.assertIsNone(trunk.series)
+        with unittest.mock.patch("scripts.release_lane.LANE", trunk):
+            require_version_in_lane("3.0.1")
+            require_version_in_lane("4.0.0")
+            require_version_in_lane("2.9.3")

--- a/scripts/tests/test_release_lane.py
+++ b/scripts/tests/test_release_lane.py
@@ -1,0 +1,54 @@
+# Which branch this checkout is allowed to release from.
+#
+# The lane is declared rather than derived, so the failure worth guarding is a
+# merge that carries one lane's declaration onto the other's branch. Ancestry
+# would still refuse the release, but with an error about merge-base that reads
+# as a git problem rather than as "you are releasing the wrong series here".
+import unittest
+
+from scripts.release_lane import LANE
+from scripts.release_lane import RELEASE_BRANCH
+from scripts.release_lane import ReleaseLane
+from scripts.release_lane import ReleaseLaneError
+from scripts.release_lane import REMOTE_RELEASE_REF
+from scripts.release_lane import require_version_in_lane
+
+
+class TheLaneNamesOneBranchTest(unittest.TestCase):
+    def test_the_refs_all_derive_from_the_branch(self):
+        lane = ReleaseLane(branch="maint/1.2.x", series="1.2", ruleset="whatever")
+        self.assertEqual(lane.remote_ref, "origin/maint/1.2.x")
+        self.assertEqual(lane.remote_tracking_ref, "refs/remotes/origin/maint/1.2.x")
+        self.assertEqual(lane.ref_pattern, "refs/heads/maint/1.2.x")
+
+    def test_the_module_constants_agree_with_the_lane(self):
+        self.assertEqual(RELEASE_BRANCH, LANE.branch)
+        self.assertEqual(REMOTE_RELEASE_REF, LANE.remote_ref)
+
+    def test_a_branch_with_a_slash_survives_every_ref_form(self):
+        # `maint/2.9.x` is the first release branch with a slash in it, and a
+        # ref built by concatenation is the obvious place for that to break.
+        self.assertIn("/", LANE.branch)
+        self.assertTrue(LANE.ref_pattern.endswith(LANE.branch))
+        self.assertTrue(LANE.remote_tracking_ref.endswith(LANE.branch))
+
+
+class AVersionFromAnotherSeriesIsRefusedTest(unittest.TestCase):
+    def test_a_version_in_the_lane_passes(self):
+        require_version_in_lane(f"{LANE.series}.0")
+        require_version_in_lane(f"{LANE.series}.99")
+
+    def test_a_version_from_another_series_is_refused_by_name(self):
+        with self.assertRaises(ReleaseLaneError) as raised:
+            require_version_in_lane("3.0.1")
+        message = str(raised.exception)
+        # The message must name BOTH series and the branch: the operator's next
+        # move is to release it from its own lane, and a bare "wrong series"
+        # does not say which lane that is.
+        self.assertIn("3.0", message)
+        self.assertIn(LANE.series, message)
+        self.assertIn(LANE.branch, message)
+
+    def test_a_longer_version_is_still_matched_on_its_series(self):
+        with self.assertRaises(ReleaseLaneError):
+            require_version_in_lane("10.9.3")

--- a/scripts/tests/test_release_preflight.py
+++ b/scripts/tests/test_release_preflight.py
@@ -11,6 +11,8 @@ import json
 import sys
 import tempfile
 import unittest
+
+from scripts.release_lane import REMOTE_RELEASE_REF
 from pathlib import Path
 from unittest import mock
 
@@ -124,13 +126,13 @@ class EvidenceBaseCommitTest(unittest.TestCase):
                 mock.patch.object(
                     preflight,
                     "_git",
-                    self._git({("rev-parse", "origin/main"): self.MAIN}),
+                    self._git({("rev-parse", REMOTE_RELEASE_REF): self.MAIN}),
                 ),
             ):
                 with self.assertRaisesRegex(preflight.PreflightError, "squash merge"):
                     preflight.check_release_plan_evidence_base("9.9.9")
 
-    def test_accepts_the_origin_main_head(self):
+    def test_accepts_the_release_branch_head(self):
         with tempfile.TemporaryDirectory() as directory:
             self._plan(directory, "9.9.9", self.MAIN)
             with (
@@ -138,11 +140,11 @@ class EvidenceBaseCommitTest(unittest.TestCase):
                 mock.patch.object(
                     preflight,
                     "_git",
-                    self._git({("rev-parse", "origin/main"): self.MAIN}),
+                    self._git({("rev-parse", REMOTE_RELEASE_REF): self.MAIN}),
                 ),
             ):
                 self.assertIn(
-                    "matches origin/main",
+                    f"matches {REMOTE_RELEASE_REF}",
                     preflight.check_release_plan_evidence_base("9.9.9"),
                 )
 
@@ -155,7 +157,9 @@ class EvidenceBaseCommitTest(unittest.TestCase):
                 mock.patch.object(
                     preflight,
                     "_git",
-                    self._git({("rev-parse", "origin/main"): self.MAIN}, tag="v9.9.9"),
+                    self._git(
+                        {("rev-parse", REMOTE_RELEASE_REF): self.MAIN}, tag="v9.9.9"
+                    ),
                 ),
             ):
                 self.assertIn(
@@ -163,7 +167,7 @@ class EvidenceBaseCommitTest(unittest.TestCase):
                     preflight.check_release_plan_evidence_base("9.9.9"),
                 )
 
-    def test_skips_when_origin_main_is_unknown(self):
+    def test_skips_when_the_release_branch_is_unknown(self):
         # A fresh clone or offline run must not fail the gate.
         with tempfile.TemporaryDirectory() as directory:
             self._plan(directory, "9.9.9", self.BRANCH_PARENT)
@@ -172,12 +176,12 @@ class EvidenceBaseCommitTest(unittest.TestCase):
                 mock.patch.object(preflight, "_git", self._git({})),
             ):
                 self.assertIn(
-                    "origin/main is unknown",
+                    f"{REMOTE_RELEASE_REF} is unknown",
                     preflight.check_release_plan_evidence_base("9.9.9"),
                 )
 
     def test_accepts_the_tag_parent_once_the_release_has_merged(self):
-        # Between merge and tag, origin/main IS the commit about to be tagged.
+        # Between merge and tag, the branch head IS the commit about to be tagged.
         # Comparing against it would demand the plan record the tagged commit in
         # place of its parent - which release_evidence_commit_binding rejects,
         # because it binds against HEAD^. The two checks contradicted each other
@@ -191,7 +195,7 @@ class EvidenceBaseCommitTest(unittest.TestCase):
                     "_git",
                     self._git(
                         {
-                            ("rev-parse", "origin/main"): self.MAIN,
+                            ("rev-parse", REMOTE_RELEASE_REF): self.MAIN,
                             ("rev-parse", "HEAD"): self.MAIN,
                             ("rev-parse", "HEAD^"): self.BRANCH_PARENT,
                         }
@@ -213,7 +217,7 @@ class EvidenceBaseCommitTest(unittest.TestCase):
                     "_git",
                     self._git(
                         {
-                            ("rev-parse", "origin/main"): self.MAIN,
+                            ("rev-parse", REMOTE_RELEASE_REF): self.MAIN,
                             ("rev-parse", "HEAD"): self.MAIN,
                             ("rev-parse", "HEAD^"): self.BRANCH_PARENT,
                         }
@@ -237,7 +241,7 @@ class EvidenceBaseCommitTest(unittest.TestCase):
                 mock.patch.object(
                     preflight,
                     "_git",
-                    self._git({("rev-parse", "origin/main"): self.MAIN}),
+                    self._git({("rev-parse", REMOTE_RELEASE_REF): self.MAIN}),
                 ),
             ):
                 self.assertIn(

--- a/scripts/tests/test_tasks.py
+++ b/scripts/tests/test_tasks.py
@@ -175,7 +175,13 @@ class ReleaseArtifactTaskTest(unittest.TestCase):
 
         self.assertIn("--require-hashes", workflow)
         self.assertIn("requirements-release.txt", workflow)
-        self.assertIn("refs/tags/v2.9.1", workflow)
+        # The prior-release tag is DERIVED from the verifier rather than
+        # written here. It used to be a literal, and nothing advanced it when
+        # the release anchor moved, so the workflow fetched a tag from two
+        # releases back and the bridge check had no object to resolve.
+        self.assertIn("v.PRIOR_RELEASE_TAG", workflow)
+        self.assertIn("import release_lane as r", workflow)
+        self.assertNotIn("refs/tags/v2.9.1:", workflow)
         self.assertIn("scripts/build_reproducible_distribution.py", workflow)
         self.assertIn("python -m invoke artifact-test", workflow)
         self.assertIn("sbom/", workflow)

--- a/scripts/tests/test_verify_release_provenance.py
+++ b/scripts/tests/test_verify_release_provenance.py
@@ -33,9 +33,9 @@ class ReleaseProvenanceTest(unittest.TestCase):
 
     def _git(self, *arguments):
         responses = {
-            ("cat-file", "-t", "refs/tags/v2.6.0"): "tag",
-            ("rev-parse", "refs/tags/v2.6.0^{commit}"): self.release_commit,
-            ("rev-parse", "refs/remotes/origin/main"): self.release_commit,
+            ("cat-file", "-t", "refs/tags/v2.9.3"): "tag",
+            ("rev-parse", "refs/tags/v2.9.3^{commit}"): self.release_commit,
+            ("rev-parse", provenance.LANE.remote_tracking_ref): self.release_commit,
             (
                 "merge-base",
                 "--is-ancestor",
@@ -54,7 +54,7 @@ class ReleaseProvenanceTest(unittest.TestCase):
                 "--name-only",
                 self.production_commit,
                 self.release_commit,
-            ): "docs/03_Plans/active/2026-07-18-release-2.6.0-scope-convergence.md",
+            ): "docs/03_Plans/active/2026-07-18-release-2.9.3-scope-convergence.md",
             (
                 "cat-file",
                 "-t",
@@ -146,7 +146,7 @@ class ReleaseProvenanceTest(unittest.TestCase):
                     {
                         "number": number,
                         "merged_at": merged_at,
-                        "base": {"ref": "main"},
+                        "base": {"ref": provenance.LANE.branch},
                         "merge_commit_sha": commit,
                     }
                 ]
@@ -167,7 +167,7 @@ class ReleaseProvenanceTest(unittest.TestCase):
                     "number": number,
                     "merged_at": merged_at[number],
                     "head": {"sha": candidate},
-                    "base": {"ref": "main"},
+                    "base": {"ref": provenance.LANE.branch},
                 }
 
         status_runs = {
@@ -226,7 +226,7 @@ class ReleaseProvenanceTest(unittest.TestCase):
                             "workflow_id": workflow_id,
                             "path": workflow_path,
                             "head_sha": commit,
-                            "head_branch": "main",
+                            "head_branch": provenance.LANE.branch,
                             "event": "push",
                             "status": "completed",
                             "conclusion": "success",
@@ -266,7 +266,7 @@ class ReleaseProvenanceTest(unittest.TestCase):
                 provenance, "_github_json", side_effect=github or self._github
             ),
         ):
-            return provenance.verify_release_provenance("v2.6.0", "token")
+            return provenance.verify_release_provenance("v2.9.3", "token")
 
     def test_accepts_reviewed_bootstrap_and_release_lineage(self):
         result = self._verify()
@@ -285,7 +285,7 @@ class ReleaseProvenanceTest(unittest.TestCase):
         argv = [
             "verify_release_provenance.py",
             "--tag",
-            "v2.6.0",
+            "v2.9.3",
         ]
         with (
             patch.dict(os.environ, {"GH_TOKEN": secret}, clear=True),
@@ -332,7 +332,7 @@ class ReleaseProvenanceTest(unittest.TestCase):
         advanced_main = "e" * 40
 
         def git(*arguments):
-            if arguments == ("rev-parse", "refs/remotes/origin/main"):
+            if arguments == ("rev-parse", provenance.LANE.remote_tracking_ref):
                 return advanced_main
             if arguments == (
                 "merge-base",
@@ -359,7 +359,7 @@ class ReleaseProvenanceTest(unittest.TestCase):
             ),
         ):
             self.assertTrue(
-                provenance._require_merged_main_pr(
+                provenance._require_merged_release_branch_pr(
                     commit,
                     "token",
                     allow_direct_control_commit=True,
@@ -378,7 +378,7 @@ class ReleaseProvenanceTest(unittest.TestCase):
             ),
         ):
             with self.assertRaises(provenance.ProvenanceError):
-                provenance._require_merged_main_pr(
+                provenance._require_merged_release_branch_pr(
                     commit,
                     "token",
                     allow_direct_control_commit=True,
@@ -409,7 +409,7 @@ class ReleaseProvenanceTest(unittest.TestCase):
         advanced_main = "e" * 40
 
         def git(*arguments):
-            if arguments == ("rev-parse", "refs/remotes/origin/main"):
+            if arguments == ("rev-parse", provenance.LANE.remote_tracking_ref):
                 return advanced_main
             if arguments == (
                 "merge-base",
@@ -423,7 +423,7 @@ class ReleaseProvenanceTest(unittest.TestCase):
         with self.assertRaisesRegex(provenance.ProvenanceError, "ancestor"):
             self._verify(git=git)
 
-    def test_tag_only_push_survives_real_remote_main_advance(self):
+    def test_tag_only_push_survives_real_remote_lane_advance(self):
         def run(repository: Path | None, *arguments: str) -> str:
             command = ["git"]
             if repository is not None:
@@ -441,7 +441,13 @@ class ReleaseProvenanceTest(unittest.TestCase):
             origin = root / "origin.git"
             tagger = root / "tagger"
             advancer = root / "advancer"
-            run(None, "init", "--bare", "--initial-branch=main", str(origin))
+            run(
+                None,
+                "init",
+                "--bare",
+                f"--initial-branch={provenance.LANE.branch}",
+                str(origin),
+            )
             run(None, "clone", str(origin), str(tagger))
             run(tagger, "config", "user.name", "Release Tagger")
             run(tagger, "config", "user.email", "tagger@example.invalid")
@@ -449,7 +455,7 @@ class ReleaseProvenanceTest(unittest.TestCase):
             run(tagger, "add", "release.txt")
             run(tagger, "commit", "-m", "release")
             release_commit = run(tagger, "rev-parse", "HEAD")
-            run(tagger, "push", "-u", "origin", "main")
+            run(tagger, "push", "-u", "origin", provenance.LANE.branch)
 
             run(None, "clone", str(origin), str(advancer))
             run(advancer, "config", "user.name", "Main Advancer")
@@ -458,28 +464,28 @@ class ReleaseProvenanceTest(unittest.TestCase):
             run(advancer, "add", "next.txt")
             run(advancer, "commit", "-m", "advance main")
             advanced_main = run(advancer, "rev-parse", "HEAD")
-            run(advancer, "push", "origin", "main")
+            run(advancer, "push", "origin", provenance.LANE.branch)
 
             run(
                 tagger,
                 "tag",
                 "-a",
-                "v2.6.0",
+                "v2.9.3",
                 "-m",
-                "Forward NetBox 2.6.0",
+                "Forward NetBox 2.9.3",
                 release_commit,
             )
-            run(tagger, "push", "origin", "refs/tags/v2.6.0")
+            run(tagger, "push", "origin", "refs/tags/v2.9.3")
             run(
                 tagger,
                 "fetch",
                 "origin",
-                "main:refs/remotes/origin/main",
+                f"{provenance.LANE.branch}:{provenance.LANE.remote_tracking_ref}",
             )
 
             with patch.object(provenance, "REPO_ROOT", tagger):
                 self.assertEqual(
-                    provenance._require_release_on_main_lineage(release_commit),
+                    provenance._require_release_on_lane_lineage(release_commit),
                     advanced_main,
                 )
             self.assertEqual(
@@ -488,7 +494,7 @@ class ReleaseProvenanceTest(unittest.TestCase):
                     "--git-dir",
                     str(origin),
                     "rev-parse",
-                    "refs/tags/v2.6.0^{commit}",
+                    "refs/tags/v2.9.3^{commit}",
                 ),
                 release_commit,
             )
@@ -548,7 +554,7 @@ class ReleaseProvenanceTest(unittest.TestCase):
                 return (
                     "forward_netbox/models.py\n"
                     "docs/03_Plans/active/"
-                    "2026-07-18-release-2.6.0-scope-convergence.md"
+                    "2026-07-18-release-2.9.3-scope-convergence.md"
                 )
             return result
 
@@ -648,9 +654,9 @@ class GitHubReleaseControlsTest(unittest.TestCase):
         # No `required_status_checks` rule: the CI gates were removed, so the
         # ruleset must not name checks that can never report again.
         main = self._ruleset(
-            provenance.MAIN_RULESET_NAME,
+            provenance.RELEASE_BRANCH_RULESET_NAME,
             "branch",
-            "refs/heads/main",
+            provenance.LANE.ref_pattern,
             [
                 {"type": "deletion"},
                 {"type": "non_fast_forward"},
@@ -670,7 +676,7 @@ class GitHubReleaseControlsTest(unittest.TestCase):
             [],
         )
         rulesets = {
-            provenance.MAIN_RULESET_NAME: main,
+            provenance.RELEASE_BRANCH_RULESET_NAME: main,
             provenance.VERSION_TAG_INTEGRITY_RULESET: self._ruleset(
                 provenance.VERSION_TAG_INTEGRITY_RULESET,
                 "tag",
@@ -755,7 +761,9 @@ class GitHubReleaseControlsTest(unittest.TestCase):
     def test_accepts_complete_live_release_controls(self):
         result = self._verify()
 
-        self.assertEqual(result["main_ruleset"], provenance.MAIN_RULESET_NAME)
+        self.assertEqual(
+            result["release_branch_ruleset"], provenance.RELEASE_BRANCH_RULESET_NAME
+        )
         # No required status checks remain: the gates that reported them were
         # removed, and a ruleset naming checks that can never report again would
         # block every pull request permanently.

--- a/scripts/verify_release_provenance.py
+++ b/scripts/verify_release_provenance.py
@@ -11,6 +11,17 @@ import urllib.parse
 from pathlib import Path
 
 
+# Imported as a sibling when run directly and as a package member when
+# the tests import it; both spellings resolve to the same module.
+try:  # pragma: no cover - exercised by whichever entry point is in use
+    from release_lane import LANE
+    from release_lane import ReleaseLaneError
+    from release_lane import require_version_in_lane
+except ImportError:  # pragma: no cover
+    from scripts.release_lane import LANE
+    from scripts.release_lane import ReleaseLaneError
+    from scripts.release_lane import require_version_in_lane
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 GITHUB_REPOSITORY = "forwardnetworks/forward-netbox"
 GITHUB_API_URL = "https://api.github.com"
@@ -68,7 +79,11 @@ BOOTSTRAP_FILE_DIGESTS = {
 # so provenance no longer looks for a workflow run it cannot find.
 REQUIRED_WORKFLOWS = ()
 GITHUB_ACTIONS_APP_ID = 15368
-MAIN_RULESET_NAME = "main-release-integrity"
+# The branch ruleset that must protect THIS lane. `main-release-integrity`
+# only ever covered `refs/heads/main`; a maintenance lane needs its own, with
+# the same shape, or a release from it would be a release from an unprotected
+# branch.
+RELEASE_BRANCH_RULESET_NAME = LANE.ruleset
 RETIRED_VERSION_TAG_CREATION_RULESET = "version-tag-creation"
 VERSION_TAG_INTEGRITY_RULESET = "version-tag-integrity"
 PYPI_ENVIRONMENT = "pypi"
@@ -240,16 +255,18 @@ def _rules_by_type(ruleset: dict, expected: set[str]) -> dict[str, dict]:
     return {rule_type: rules[0] for rule_type, rules in grouped.items()}
 
 
-def _require_main_ruleset(token: str) -> list[str]:
-    ruleset = _named_ruleset(MAIN_RULESET_NAME, token)
+def _require_release_branch_ruleset(token: str) -> list[str]:
+    ruleset = _named_ruleset(RELEASE_BRANCH_RULESET_NAME, token)
     _require_ruleset_identity(
         ruleset,
-        name=MAIN_RULESET_NAME,
+        name=RELEASE_BRANCH_RULESET_NAME,
         target="branch",
-        ref_pattern="refs/heads/main",
+        ref_pattern=LANE.ref_pattern,
     )
     if ruleset.get("bypass_actors") != []:
-        raise ProvenanceError("protected main ruleset must not have bypass actors")
+        raise ProvenanceError(
+            f"protected {LANE.branch} ruleset must not have bypass actors"
+        )
     # `required_status_checks` is deliberately absent. This repository has a
     # single maintainer and runs its gates locally (`invoke ci`,
     # `invoke artifact-test`), whose results are recorded in the release plan's
@@ -278,7 +295,9 @@ def _require_main_ruleset(token: str) -> list[str]:
         pull_parameters.get(key) != value
         for key, value in required_pull_parameters.items()
     ):
-        raise ProvenanceError("protected main pull-request controls are incomplete")
+        raise ProvenanceError(
+            f"protected {LANE.branch} pull-request controls are incomplete"
+        )
     return []
 
 
@@ -360,7 +379,7 @@ def verify_github_release_controls(token: str) -> dict:
     if actions.get("sha_pinning_required") is not True:
         raise ProvenanceError("GitHub Actions SHA pinning is not required")
 
-    _require_main_ruleset(token)
+    _require_release_branch_ruleset(token)
     _require_ruleset_absent(RETIRED_VERSION_TAG_CREATION_RULESET, token)
     _require_tag_ruleset(
         token,
@@ -374,7 +393,8 @@ def verify_github_release_controls(token: str) -> dict:
         policy_type="tag",
     )
     return {
-        "main_ruleset": MAIN_RULESET_NAME,
+        "release_branch": LANE.branch,
+        "release_branch_ruleset": RELEASE_BRANCH_RULESET_NAME,
         "required_statuses": [],
         "pypi_environment": PYPI_ENVIRONMENT,
     }
@@ -391,7 +411,7 @@ def _require_release_commit_shape(commit: str, token: str) -> dict:
     return payload
 
 
-def _require_merged_main_pr(
+def _require_merged_release_branch_pr(
     commit: str,
     token: str,
     *,
@@ -402,7 +422,7 @@ def _require_merged_main_pr(
         pull
         for pull in pulls
         if pull.get("merged_at")
-        and (pull.get("base") or {}).get("ref") == "main"
+        and (pull.get("base") or {}).get("ref") == LANE.branch
         and pull.get("merge_commit_sha") == commit
     ]
     if len(matches) != 1:
@@ -429,7 +449,8 @@ def _require_merged_main_pr(
                 )
             return True
         raise ProvenanceError(
-            f"commit {commit} must map to exactly one merged main pull request"
+            f"commit {commit} must map to exactly one merged "
+            f"{LANE.branch} pull request"
         )
     pull = _github_json(f"pulls/{matches[0]['number']}", token)
     if not isinstance(pull, dict):
@@ -461,12 +482,13 @@ def _require_successful_workflow(commit: str, workflow_path: str, token: str) ->
         if run.get("workflow_id") == workflow_id
         and run.get("path") == workflow_path
         and run.get("head_sha") == commit
-        and run.get("head_branch") == "main"
+        and run.get("head_branch") == LANE.branch
         and run.get("event") == "push"
     ]
     if not exact:
         raise ProvenanceError(
-            f"commit {commit} has no exact main push run for {workflow_path}"
+            f"commit {commit} has no exact {LANE.branch} push run "
+            f"for {workflow_path}"
         )
     latest = max(exact, key=lambda run: int(run.get("id") or 0))
     if latest.get("status") != "completed" or latest.get("conclusion") != "success":
@@ -630,15 +652,16 @@ def _require_security_bootstrap(release_commit: str) -> None:
         )
 
 
-def _require_release_on_main_lineage(release_commit: str) -> str:
-    current_main = _git_capture("rev-parse", "refs/remotes/origin/main")
+def _require_release_on_lane_lineage(release_commit: str) -> str:
+    current_head = _git_capture("rev-parse", LANE.remote_tracking_ref)
     try:
-        _git_capture("merge-base", "--is-ancestor", release_commit, current_main)
+        _git_capture("merge-base", "--is-ancestor", release_commit, current_head)
     except subprocess.CalledProcessError as exc:
         raise ProvenanceError(
-            "release commit must be an ancestor of the current origin/main commit"
+            f"release commit must be an ancestor of the current "
+            f"{LANE.remote_ref} commit"
         ) from exc
-    return current_main
+    return current_head
 
 
 def verify_release_commit_provenance(
@@ -646,7 +669,7 @@ def verify_release_commit_provenance(
     version: str,
     token: str,
 ) -> dict:
-    _require_release_on_main_lineage(release_commit)
+    _require_release_on_lane_lineage(release_commit)
     production_commit = _commit_parent(release_commit)
     plan = _require_release_plan(production_commit, release_commit, version)
 
@@ -668,7 +691,7 @@ def verify_release_commit_provenance(
     control_commit_limit = len(reviewed_commits) - 2
     for index, commit in enumerate(reviewed_commits):
         _require_release_commit_shape(commit, token)
-        direct_control_commit = _require_merged_main_pr(
+        direct_control_commit = _require_merged_release_branch_pr(
             commit,
             token,
             allow_direct_control_commit=index < control_commit_limit,
@@ -691,6 +714,13 @@ def verify_release_commit_provenance(
 def verify_release_provenance(tag: str, token: str) -> dict:
     if not tag.startswith("v"):
         raise ProvenanceError(f"release tag must start with v: {tag!r}")
+    # Asked before any GitHub call. A tag from another series would otherwise
+    # be refused several checks later by an ancestry failure, which reads as a
+    # git problem rather than as a tag pushed from the wrong lane.
+    try:
+        require_version_in_lane(tag[1:])
+    except ReleaseLaneError as error:
+        raise ProvenanceError(str(error)) from error
     result = verify_release_commit_provenance(
         _require_annotated_tag(tag),
         tag[1:],


### PR DESCRIPTION
`maint/2.9.x` carries the NetBox 4.6 line, because `main` declares `min_version = "4.7.0"` from 3.0.0 and a 4.6 fix has nowhere else to land. The branch existed; **releasing** from it did not — four independent gates asked whether a commit was on `main`, so a `v2.9.3` tag would have been refused by each in turn.

## What changed

The lane is **declared** in `scripts/release_lane.py` and read by every gate: the driver checks out and resets to it, the harness base is it, the provenance verifier requires the release commit to be an ancestor of it, and it names the branch ruleset that must protect it.

Each lane carries its own copy of that file, so the values differ between branches by design — and a wrong value **fails closed**, because the tagged commit will not be an ancestor of the branch the file names. `require_version_in_lane` turns that failure from a merge-base error into a sentence naming both series and the branch to use instead.

Declared rather than inferred for the same reason `tested_runtime.py` declares runtime pins: a value read from the current checkout silently follows a bad merge, and this one decides which branch's history a release may come from.

## A latent bug found on the way

`release.yml` fetched `refs/tags/v2.9.1` as a literal so the bridge check had an object to resolve, and **nothing advanced it when the release anchor moved**. On this branch `PRIOR_RELEASE_TAG` already said `v2.9.2`, so a `v2.9.3` release would have failed fetching a tag from two releases back. Both the lane and the prior tag are now read from the scripts.

## Branch protection

`maint-2-9-x-release-integrity` mirrors `main-release-integrity` exactly: no bypass actors, deletion and non-fast-forward blocked, linear history, squash-only through a pull request with conversation resolution.

## Verification

- `python -m pytest scripts/tests` — **388 passed**. The four modules that pinned `"main"` now assert against the lane rather than being relaxed to accept anything.
- The provenance fixtures move from a `2.6.0` tag to `2.9.3`. A fixture releasing 2.6.0 from the 2.9 maintenance branch was never coherent.
- **Live**: `python scripts/verify_release_provenance.py --controls-only` from this branch against the real ruleset — this is the check that refuses a release from an unprotected branch, and it passes.
- `pre-commit run --all-files` clean; `check_harness.py --base origin/maint/2.9.x` passes.

No shipped code changes — `packages = [{include = "forward_netbox"}]`, so none of this reaches the wheel.

## Not done here

- **Forward-porting to `main`**, so the lanes do not diverge and a future 3.x maintenance branch works. `main`'s release path works today; this branch is the one that needed it.
- Nothing has been released through this yet. The first real proof is `v2.9.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DczGsTTkuwULnpcYX4qui6
