### PR TITLE
fix: OSPF rows that no sync can ever resolve

### DIFF
--- a/docs/03_Plans/active/2026-09-01-uncovered-device-tag.md
+++ b/docs/03_Plans/active/2026-09-01-uncovered-device-tag.md
@@ -134,10 +134,15 @@ Forward result, not from the tag.
 
 ## Limits
 
-- The `unclaimed` half stays un-enumerable beyond its 25-name sample. That is
-  intentional - it is not this sync's data - but it means an operator whose
-  count is mostly unclaimed still cannot list it from this page.
+- ~~The `unclaimed` half stays un-enumerable beyond its 25-name sample.~~
+  **Closed in this same release.** Both halves list in full:
+  `forwardsync_unclaimed_devices` and `forwardsync_uncovered_devices`
+  (`views.py:1545,1551`), reached by the "List all N" buttons on the scope
+  panel. The limit was written against the sample-only version and never
+  updated when the device ids were kept for exactly this purpose
+  (`scope_reconciliation.py`, `unclaimed_device_ids`).
 - The tag reflects the most recent reconciliation run, not live Forward state.
   A device re-enabled in Forward keeps the tag until the next run.
 - Nothing back-fills the tag onto devices whose absence predates this change
-  until the next reconciliation runs.
+  until the next reconciliation runs. This resolves itself on the next run; it
+  is a timing note, not an outstanding defect.

--- a/docs/03_Plans/active/2026-09-02-stale-deferral-sweep.md
+++ b/docs/03_Plans/active/2026-09-02-stale-deferral-sweep.md
@@ -37,6 +37,7 @@ and the live call site, both verified against the 2.9.2 tree.
 | `.dev0` on main decided; `--open-next` removed | #313 | absent from `scripts/release.py` |
 | Undeletable ingestions #45/#46 | - | no `PROTECT` relation to `ForwardIngestion` remains |
 | Route probe covers registered detail views | #330/#331 | `scripts/validate_installed_routes.py` |
+| Uncovered `unclaimed` half is enumerable | #317 | `views.py:1545,1551`; "List all N" on the scope panel |
 
 ## Validation
 

--- a/docs/03_Plans/active/2026-09-04-ospf-rows-that-never-converge.md
+++ b/docs/03_Plans/active/2026-09-04-ospf-rows-that-never-converge.md
@@ -1,0 +1,121 @@
+# OSPF rows that no sync can ever resolve
+
+## Goal
+
+Stop reporting drift that cannot be fixed. On a customer estate 180 of 2854
+`netbox_routing.ospfinterface` rows drifted on every run - including a
+comparison taken 22 minutes after a sync that applied 8240 changes with zero
+failures, against the same snapshot. `In sync` could never become Yes, and an
+operator who learns that stops reading the number at all.
+
+## Why
+
+`forward_ospf_interfaces.nqe:33` selects `foreach neighbor in area.neighbors`:
+**one row per OSPF neighbour**, each carrying `local_interface`. A broadcast
+segment with three neighbours is three rows with the same interface.
+
+`ensure_ospf_interface` (`sync_routing_impl.py:807`) upserts with
+`coalesce_sets=[("interface",)]`: **one OSPFInterface per NetBox interface**.
+
+So the three rows collapse onto one object and each writes its own `comments` -
+remote device, remote interface, remote interface IP and remote router ID all
+differ per neighbour. The last row wins. Every later comparison then finds the
+other two still wanting to write theirs, and reports them as drift. Forever.
+
+The count is stable rather than growing because it is exactly the surplus:
+`N - 1` rows per multi-neighbour interface, on every run.
+
+`netbox_routing.ospfarea` has the same shape - `coalesce_sets=[("area_id",)]`
+with a row per reporting device - and showed 5 of 28.
+
+This is NOT the volatile-counter churn fixed for BGP peers
+(`test_bgp_peer_comment_churn.py`); `ospf_interface_comments` renders nothing
+that moves between snapshots. The rows are stable and still never converge,
+because the problem is arithmetic, not volatility.
+
+## Constraints
+
+- **The single-neighbour case must be byte-identical.** Most interfaces have
+  one neighbour, and a merge that reformatted them would rewrite the estate to
+  fix a minority.
+- **The apply and the comparison must collapse identically.** The defect is the
+  two disagreeing about how many objects a row set means; doing it in one of
+  them would be the same defect in a new place.
+- **The merge must not depend on Forward's row order**, or a churn that recurs
+  every run becomes one that recurs whenever ordering moves - which looks
+  intermittent and is harder to diagnose.
+- **A real change must still be reported.** A fix that stops looking is not a
+  fix.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/row_collapsing.py` (new)
+- `forward_netbox/utilities/sync_routing_impl.py` - `COLLAPSED_COMMENTS_KEY`
+  and the one lookup in `ospf_interface_comments`
+- `forward_netbox/utilities/sync_reporting.py` - `apply_model_rows`
+- `forward_netbox/utilities/drift_comparison.py` - `compare_model_rows`
+- `forward_netbox/tests/test_row_collapsing.py`,
+  `forward_netbox/tests/test_ospf_neighbour_rows_converge.py` (new)
+
+## Approach
+
+Collapse rows to one per object **upstream of both** the apply and the
+comparison, in a module both import.
+
+For `ospfinterface` the group key is the device plus the canonical interface
+name, expanded through the lookup's own alias table so `gi0/0` and
+`GigabitEthernet0/0` group exactly when they would resolve to the same NetBox
+interface. The longest alias wins, because the table holds both `gi` and
+`gigabitethernet` and the short one also matches the long one's expansion.
+
+The merged row is the first neighbour's row, sorted, carrying the other
+neighbours' detail appended to its comments under a reserved key that
+`ospf_interface_comments` reads. A one-neighbour group returns its row
+untouched and never carries the key, so its comments are exactly what they
+were.
+
+For `ospfarea` nothing is merged - the area's fields are the area's, not the
+reporting device's - only a deterministic winner is chosen, so that two devices
+disagreeing about `area_type` stop taking turns.
+
+## Validation
+
+- `test_ospf_neighbour_rows_converge` drives `compare_model_rows` with three
+  neighbours on one interface. **Against the shipped 2.9.2 code it reports 2
+  updates** - `N - 1`, exactly the field symptom - and 0 after the fix.
+- The upgrade cost is pinned rather than discovered: an estate synced by the
+  old code rewrites **once** per affected interface and is then stable.
+- Order independence, alias grouping, single-row byte-identity and
+  "a real change still reports" each have their own test.
+- The existing OSPF, peering and BGP-churn suites are unchanged and still pass.
+- Full Django suite.
+
+## Rollback
+
+Revert. The collapse is additive and reversible; the only persisted effect is
+the merged `comments` text on multi-neighbour interfaces, which a revert
+rewrites back on the next sync.
+
+## Decision Log
+
+- **Collapse rather than dedupe in the report.** Counting only the first row
+  per object would fix the number and leave the sync still writing one object
+  N times, with the ObjectChange and branch-merge cost that implies.
+- **Not fixed in the NQE query.** Aggregating neighbours query-side is the
+  cleaner data model, but the bundled queries are published into customer org
+  libraries and a shape change there is a migration for every deployment. This
+  is a Python change to a maintenance branch.
+- **`bgppeer` is NOT included.** It showed 126 drifted rows on the same estate
+  and may be the same shape, but its coalesce key spans a router and scope
+  built from other fields, and nothing here has demonstrated the collapse. A
+  fix that looked right and was not would be worse than the honest gap.
+
+## Open
+
+- **`netbox_routing.bgppeer`: 126 rows on the customer estate, unexplained.**
+  Volatile counters were already excluded from `bgp_peer_comments`, so it is
+  something else. Needs the same treatment this got: reproduce first.
+- **The comparison cost is untouched.** 1010213 ms for 648353 rows in 246591
+  queries, `dcim.macaddress` alone 297643 ms of it with 247134 ms in SQL. The
+  collapse removes some adapter row work, but the macaddress cost is a separate
+  question and this does not claim to have moved it.

--- a/forward_netbox/tests/test_bgp_peer_round_trip_variants.py
+++ b/forward_netbox/tests/test_bgp_peer_round_trip_variants.py
@@ -1,0 +1,231 @@
+# BGP peer round trips through the FULL apply path, over the shapes a real
+# estate has: VRF-scoped sessions, neighbour addresses that already exist on
+# interfaces, devices that peer with each other, IPv6, long descriptions.
+#
+# The existing round trip calls the peer adapter directly, so it never runs
+# the dependency-cache priming the sync runs before every batch. This one
+# goes through `apply_model_rows`, exactly as a sync does, and then compares.
+from unittest.mock import Mock
+
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import Interface
+from dcim.models import Manufacturer
+from dcim.models import Site
+from django.test import TestCase
+from ipam.models import IPAddress
+from ipam.models import VRF
+
+from forward_netbox.models import ForwardSource
+from forward_netbox.models import ForwardSync
+from forward_netbox.utilities.drift_comparison import compare_model_rows
+from forward_netbox.utilities.sync import ForwardSyncRunner
+from forward_netbox.utilities.sync_reporting import apply_model_rows
+
+BGP_PEER = "netbox_routing.bgppeer"
+
+
+def _routing_models():
+    from django.apps import apps
+
+    return (
+        apps.get_model("netbox_routing", "BGPRouter"),
+        apps.get_model("netbox_routing", "BGPScope"),
+        apps.get_model("netbox_routing", "BGPPeer"),
+    )
+
+
+class BgpPeerRoundTripVariantsTest(TestCase):
+    def setUp(self):
+        self.source = ForwardSource.objects.create(
+            name="rtv-source",
+            type="saas",
+            url="https://forward.example.com",
+            status="ready",
+            parameters={
+                "username": "u@example.com",
+                "password": "p",
+                "verify": True,
+                "network_id": "net-1",
+            },
+        )
+        self.sync = ForwardSync.objects.create(
+            name="rtv-sync",
+            source=self.source,
+            parameters={"snapshot_id": "latestProcessed"},
+        )
+        site = Site.objects.create(name="RTV Site", slug="rtv-site")
+        mfr = Manufacturer.objects.create(name="RTV Mfr", slug="rtv-mfr")
+        dtype = DeviceType.objects.create(
+            manufacturer=mfr, model="RTV DT", slug="rtv-dt"
+        )
+        role = DeviceRole.objects.create(name="RTV Role", slug="rtv-role")
+        self.dev_a = Device.objects.create(
+            name="rtv-a", site=site, device_type=dtype, role=role, status="active"
+        )
+        self.dev_b = Device.objects.create(
+            name="rtv-b", site=site, device_type=dtype, role=role, status="active"
+        )
+        self.if_a = Interface.objects.create(
+            device=self.dev_a, name="Ethernet1", type="1000base-t"
+        )
+        self.if_b = Interface.objects.create(
+            device=self.dev_b, name="Ethernet1", type="1000base-t"
+        )
+        self.vrf = VRF.objects.create(name="CUST-A")
+
+    def _runner(self):
+        return ForwardSyncRunner(
+            sync=self.sync, ingestion=None, client=None, logger_=Mock()
+        )
+
+    def _row(self, **extra):
+        row = {
+            "device": "rtv-a",
+            "vrf": None,
+            "local_asn": 65000,
+            "router_id": "10.0.0.1",
+            "neighbor_address": "10.1.1.2",
+            "peer_asn": 65001,
+            "peer_type": "PeerType.EXTERNAL",
+            "enabled": True,
+            "status": "active",
+            "session_state": "SessionState.ESTABLISHED",
+            "peer_device": None,
+            "peer_vrf": None,
+            "peer_router_id": None,
+            "description": "",
+            "advertised_prefixes": 12,
+            "received_prefixes": 3,
+        }
+        row.update(extra)
+        return row
+
+    def _apply(self, rows):
+        apply_model_rows(self._runner(), BGP_PEER, list(rows))
+
+    def _assert_converged(self, rows, label):
+        _, _, BGPPeer = _routing_models()
+        self._apply(rows)
+        peers_after_first = BGPPeer.objects.count()
+        ips_after_first = IPAddress.objects.count()
+        # A second apply must write nothing new.
+        self._apply(rows)
+        self.assertEqual(BGPPeer.objects.count(), peers_after_first, label)
+        self.assertEqual(IPAddress.objects.count(), ips_after_first, label)
+        result = compare_model_rows(None, BGP_PEER, list(rows))
+        self.assertIsNotNone(result, label)
+        self.assertEqual(
+            (result["creates"], result["updates"], result["rejected"]),
+            (0, 0, 0),
+            f"{label}: {result}",
+        )
+
+    def test_global_neighbour_already_on_an_interface(self):
+        IPAddress.objects.create(
+            address="10.1.1.2/30",
+            assigned_object=self.if_b,
+            status="active",
+        )
+        self._assert_converged([self._row()], "global, /30 on interface")
+
+    def test_vrf_neighbour_already_on_an_interface(self):
+        IPAddress.objects.create(
+            address="10.1.1.2/30",
+            vrf=self.vrf,
+            assigned_object=self.if_b,
+            status="active",
+        )
+        self._assert_converged([self._row(vrf="CUST-A")], "vrf, /30 on interface")
+
+    def test_vrf_neighbour_absent(self):
+        self._assert_converged([self._row(vrf="CUST-A")], "vrf, absent")
+
+    def test_global_session_with_neighbour_only_in_a_vrf(self):
+        IPAddress.objects.create(
+            address="10.1.1.2/30",
+            vrf=self.vrf,
+            assigned_object=self.if_b,
+            status="active",
+        )
+        self._assert_converged([self._row()], "global session, ip only in vrf")
+
+    def test_two_devices_peering_with_each_other(self):
+        IPAddress.objects.create(
+            address="10.1.1.1/30", assigned_object=self.if_a, status="active"
+        )
+        IPAddress.objects.create(
+            address="10.1.1.2/30", assigned_object=self.if_b, status="active"
+        )
+        rows = [
+            self._row(
+                device="rtv-a",
+                neighbor_address="10.1.1.2",
+                peer_device="rtv-b",
+                peer_router_id="10.0.0.2",
+            ),
+            self._row(
+                device="rtv-b",
+                router_id="10.0.0.2",
+                local_asn=65001,
+                peer_asn=65000,
+                neighbor_address="10.1.1.1",
+                peer_device="rtv-a",
+                peer_router_id="10.0.0.1",
+            ),
+        ]
+        self._assert_converged(rows, "mutual peers")
+
+    def test_ibgp_full_mesh_shares_router_and_scope(self):
+        rows = [
+            self._row(
+                neighbor_address="10.255.0.2",
+                peer_asn=65000,
+                peer_type="PeerType.INTERNAL",
+            ),
+            self._row(
+                neighbor_address="10.255.0.3",
+                peer_asn=65000,
+                peer_type="PeerType.INTERNAL",
+            ),
+            self._row(
+                neighbor_address="10.255.0.4",
+                peer_asn=65000,
+                peer_type="PeerType.INTERNAL",
+            ),
+        ]
+        self._assert_converged(rows, "ibgp mesh")
+
+    def test_ipv6_neighbour(self):
+        self._assert_converged([self._row(neighbor_address="2001:db8::2")], "ipv6")
+
+    def test_long_description_and_null_router_id(self):
+        self._assert_converged(
+            [self._row(description="x" * 300, router_id=None)],
+            "long description",
+        )
+
+    def test_local_as_override_makes_a_second_router(self):
+        rows = [
+            self._row(neighbor_address="10.1.1.2"),
+            self._row(neighbor_address="10.1.2.2", local_asn=64999),
+        ]
+        self._assert_converged(rows, "two local ASNs on one device")
+
+    def test_same_neighbour_in_two_vrfs(self):
+        rows = [
+            self._row(neighbor_address="10.1.1.2"),
+            self._row(neighbor_address="10.1.1.2", vrf="CUST-A"),
+        ]
+        self._assert_converged(rows, "same address, global and vrf")
+
+    def test_disabled_peer(self):
+        self._assert_converged(
+            [
+                self._row(
+                    enabled=False, status="offline", session_state="SessionState.IDLE"
+                )
+            ],
+            "disabled",
+        )

--- a/forward_netbox/tests/test_ospf_neighbour_rows_converge.py
+++ b/forward_netbox/tests/test_ospf_neighbour_rows_converge.py
@@ -1,0 +1,149 @@
+# Two OSPF neighbours on one interface must not drift forever.
+#
+# `forward_ospf_interfaces.nqe` selects `foreach neighbor in area.neighbors`,
+# so a broadcast segment with three neighbours produces THREE Forward rows that
+# all carry the same `local_interface`. `ensure_ospf_interface` upserts them
+# with `coalesce_sets=[("interface",)]` - one OSPFInterface per NetBox
+# interface - so all three collapse onto one object, and each writes a
+# different `comments` (remote device, remote interface, remote router ID all
+# differ per neighbour).
+#
+# Last writer wins. Every subsequent comparison then finds the other rows still
+# wanting to write their own version, so they report as drift on every run
+# forever, and no sync can resolve them. On a customer estate that is 180 of
+# 2854 rows permanently drifted and `In sync: No` that can never become Yes.
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import Interface
+from dcim.models import Manufacturer
+from dcim.models import Site
+from django.test import TestCase
+
+from forward_netbox.utilities.drift_comparison import compare_model_rows
+
+OSPF_INTERFACE = "netbox_routing.ospfinterface"
+
+
+def _ospf_models():
+    from forward_netbox.utilities.sync_primitives import optional_model
+
+    return (
+        optional_model("netbox_routing", "OSPFInstance", "netbox_routing.ospfinstance"),
+        optional_model("netbox_routing", "OSPFArea", "netbox_routing.ospfarea"),
+        optional_model("netbox_routing", "OSPFInterface", OSPF_INTERFACE),
+    )
+
+
+class BroadcastSegmentRowsConvergeTest(TestCase):
+    def setUp(self):
+        site = Site.objects.create(name="N Site", slug="n-site")
+        mfr = Manufacturer.objects.create(name="N Mfr", slug="n-mfr")
+        dtype = DeviceType.objects.create(manufacturer=mfr, model="N DT", slug="n-dt")
+        role = DeviceRole.objects.create(name="N Role", slug="n-role")
+        self.device = Device.objects.create(
+            name="ospf-dev", site=site, device_type=dtype, role=role, status="active"
+        )
+        self.interface = Interface.objects.create(
+            device=self.device, name="GigabitEthernet0/0", type="1000base-t"
+        )
+
+    def _row(self, **extra):
+        row = {
+            "device": "ospf-dev",
+            "process_id": "1",
+            "router_id": "10.0.0.1",
+            "area_id": "0.0.0.0",
+            "area_type": "standard",
+            "local_interface": "GigabitEthernet0/0",
+        }
+        row.update(extra)
+        return row
+
+    def _neighbours(self):
+        """Three neighbours seen on ONE local interface, as Forward reports it."""
+        return [
+            self._row(remote_device="peer-a", remote_router_id="10.0.0.2"),
+            self._row(remote_device="peer-b", remote_router_id="10.0.0.3"),
+            self._row(remote_device="peer-c", remote_router_id="10.0.0.4"),
+        ]
+
+    def _apply_once(self, rows, *, legacy=False):
+        """Persist what a sync would write for these rows.
+
+        `legacy=True` reproduces what the pre-fix apply left behind: the LAST
+        row's comments, because each row overwrote the one before it.
+        """
+        from forward_netbox.utilities.row_collapsing import collapse_rows
+        from forward_netbox.utilities.sync_routing_impl import ospf_interface_comments
+
+        collapsed = collapse_rows(OSPF_INTERFACE, rows)
+
+        OSPFInstance, OSPFArea, OSPFInterface = _ospf_models()
+        instance = OSPFInstance.objects.create(
+            name=f"{self.device.name} OSPF 1",
+            router_id="10.0.0.1",
+            process_id=1,
+            device=self.device,
+            vrf=None,
+        )
+        area = OSPFArea.objects.create(
+            area_id="0.0.0.0",
+            area_type="standard",
+            description="Observed by Forward from structured OSPF state.",
+        )
+        # One object for the whole group, carrying whatever the apply settled
+        # on - which today is the LAST row's comments.
+        return OSPFInterface.objects.create(
+            instance=instance,
+            area=area,
+            interface=self.interface,
+            priority=None,
+            comments=ospf_interface_comments(rows[-1] if legacy else collapsed[0]),
+        )
+
+    def test_a_synced_broadcast_segment_reports_no_drift(self):
+        rows = self._neighbours()
+        self._apply_once(rows)
+
+        result = compare_model_rows(None, OSPF_INTERFACE, rows)
+
+        # Every row describes a state the estate is already in. None of them is
+        # a difference between NetBox and Forward, so none of them is drift.
+        self.assertEqual(result["updates"], 0)
+        self.assertEqual(result["creates"], 0)
+
+    def test_the_surplus_neighbours_are_not_counted_as_separate_work(self):
+        rows = self._neighbours()
+        self._apply_once(rows)
+
+        result = compare_model_rows(None, OSPF_INTERFACE, rows)
+
+        # Three rows, one object. Estimated apply work must describe objects
+        # the sync would write, not rows it would read.
+        self.assertEqual(result["updates"] + result["creates"], 0)
+
+    def test_an_estate_synced_by_the_old_code_converges_in_one_run(self):
+        # The upgrade cost, stated rather than discovered: an interface whose
+        # comments were written last-writer-wins rewrites ONCE to the merged
+        # form and is then stable. One update per affected interface, not the
+        # N-1 that recurred on every run before.
+        rows = self._neighbours()
+        self._apply_once(rows, legacy=True)
+
+        result = compare_model_rows(None, OSPF_INTERFACE, rows)
+
+        self.assertEqual(result["updates"], 1)
+        self.assertEqual(result["creates"], 0)
+
+    def test_a_real_change_on_the_segment_is_still_reported(self):
+        # The guard against fixing this by simply not looking: if the segment
+        # genuinely changes, exactly one object's worth of drift must appear.
+        rows = self._neighbours()
+        self._apply_once(rows)
+        changed = [self._row(remote_device="peer-a", remote_router_id="10.0.0.9")]
+
+        result = compare_model_rows(None, OSPF_INTERFACE, changed + rows[1:])
+
+        self.assertEqual(result["creates"], 0)
+        self.assertEqual(result["updates"], 1)

--- a/forward_netbox/tests/test_routing_apply_compare_round_trip.py
+++ b/forward_netbox/tests/test_routing_apply_compare_round_trip.py
@@ -1,0 +1,161 @@
+# What a sync writes, the next comparison must call unchanged.
+#
+# Every existing adapter-drift test builds its "already converged" fixture BY
+# HAND, with ORM creates and the apply's own renderers. That proves the
+# comparison agrees with a state someone described, and it cannot prove the
+# comparison agrees with the state the APPLY ACTUALLY PRODUCES. A round trip
+# where the apply writes one thing and the comparison expects another is
+# invisible to all of them - which is how 180 permanently drifted OSPF rows
+# reached a customer.
+#
+# So: run the real apply, then compare the same rows, and require zero drift.
+# It is the weakest possible assertion and the one that matters, because a sync
+# that does not converge is a sync whose drift number can never be trusted.
+from unittest.mock import Mock
+
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import Interface
+from dcim.models import Manufacturer
+from dcim.models import Site
+from django.test import TestCase
+
+from forward_netbox.models import ForwardSource
+from forward_netbox.models import ForwardSync
+from forward_netbox.utilities.drift_comparison import compare_model_rows
+from forward_netbox.utilities.sync import ForwardSyncRunner
+
+BGP_PEER = "netbox_routing.bgppeer"
+OSPF_INTERFACE = "netbox_routing.ospfinterface"
+
+
+class RoutingRoundTripTest(TestCase):
+    def setUp(self):
+        self.source = ForwardSource.objects.create(
+            name="rt-source",
+            type="saas",
+            url="https://forward.example.com",
+            status="ready",
+            parameters={
+                "username": "u@example.com",
+                "password": "p",
+                "verify": True,
+                "network_id": "net-1",
+            },
+        )
+        self.sync = ForwardSync.objects.create(
+            name="rt-sync",
+            source=self.source,
+            parameters={"snapshot_id": "latestProcessed"},
+        )
+        site = Site.objects.create(name="RT Site", slug="rt-site")
+        mfr = Manufacturer.objects.create(name="RT Mfr", slug="rt-mfr")
+        dtype = DeviceType.objects.create(manufacturer=mfr, model="RT DT", slug="rt-dt")
+        role = DeviceRole.objects.create(name="RT Role", slug="rt-role")
+        self.device = Device.objects.create(
+            name="rt-dev", site=site, device_type=dtype, role=role, status="active"
+        )
+        self.interface = Interface.objects.create(
+            device=self.device, name="GigabitEthernet0/0", type="1000base-t"
+        )
+
+    def _runner(self):
+        return ForwardSyncRunner(
+            sync=self.sync, ingestion=None, client=None, logger_=Mock()
+        )
+
+    # --- BGP peers ---------------------------------------------------------
+
+    def _peer_row(self, **extra):
+        row = {
+            "device": "rt-dev",
+            "vrf": None,
+            "local_asn": 65000,
+            "router_id": "10.0.0.1",
+            "neighbor_address": "10.1.1.2",
+            "peer_asn": 65001,
+            "peer_type": "EBGP",
+            "enabled": True,
+            "status": "active",
+            "description": "",
+        }
+        row.update(extra)
+        return row
+
+    def test_an_applied_bgp_peer_compares_unchanged(self):
+        from forward_netbox.utilities.sync_routing_impl import (
+            apply_netbox_routing_bgppeer,
+        )
+
+        rows = [self._peer_row()]
+        apply_netbox_routing_bgppeer(self._runner(), rows[0])
+
+        result = compare_model_rows(None, BGP_PEER, rows)
+
+        # A create here means the comparison cannot find what the apply just
+        # wrote, so the row would be reported as new on every run forever.
+        self.assertEqual(result["creates"], 0)
+        self.assertEqual(result["updates"], 0)
+
+    def test_applying_twice_writes_nothing_the_second_time(self):
+        from forward_netbox.utilities.sync_routing_impl import (
+            apply_netbox_routing_bgppeer,
+        )
+
+        row = self._peer_row()
+        apply_netbox_routing_bgppeer(self._runner(), row)
+        apply_netbox_routing_bgppeer(self._runner(), row)
+
+        result = compare_model_rows(None, BGP_PEER, [row])
+
+        self.assertEqual(result["creates"], 0)
+        self.assertEqual(result["updates"], 0)
+
+    # --- OSPF interfaces ---------------------------------------------------
+
+    def _ospf_row(self, **extra):
+        row = {
+            "device": "rt-dev",
+            "process_id": "1",
+            "router_id": "10.0.0.1",
+            "area_id": "0.0.0.0",
+            "area_type": "standard",
+            "local_interface": "GigabitEthernet0/0",
+        }
+        row.update(extra)
+        return row
+
+    def _apply_ospf(self, rows):
+        from forward_netbox.utilities.row_collapsing import collapse_rows
+        from forward_netbox.utilities.sync_routing_impl import (
+            apply_netbox_routing_ospfinterface,
+        )
+
+        runner = self._runner()
+        for row in collapse_rows(OSPF_INTERFACE, rows):
+            apply_netbox_routing_ospfinterface(runner, row)
+
+    def test_an_applied_ospf_interface_compares_unchanged(self):
+        rows = [self._ospf_row(remote_device="peer-a", remote_router_id="10.0.0.2")]
+        self._apply_ospf(rows)
+
+        result = compare_model_rows(None, OSPF_INTERFACE, rows)
+
+        self.assertEqual(result["creates"], 0)
+        self.assertEqual(result["updates"], 0)
+
+    def test_an_applied_broadcast_segment_compares_unchanged(self):
+        # The regression that reached a customer: three neighbours on one
+        # interface, applied and then compared, must be zero drift.
+        rows = [
+            self._ospf_row(remote_device="peer-a", remote_router_id="10.0.0.2"),
+            self._ospf_row(remote_device="peer-b", remote_router_id="10.0.0.3"),
+            self._ospf_row(remote_device="peer-c", remote_router_id="10.0.0.4"),
+        ]
+        self._apply_ospf(rows)
+
+        result = compare_model_rows(None, OSPF_INTERFACE, rows)
+
+        self.assertEqual(result["creates"], 0)
+        self.assertEqual(result["updates"], 0)

--- a/forward_netbox/tests/test_row_collapsing.py
+++ b/forward_netbox/tests/test_row_collapsing.py
@@ -1,0 +1,136 @@
+# Collapsing rows that write one object, and the properties that make it safe.
+#
+# The collapse exists because some Forward queries report one row per
+# OBSERVATION while the apply upserts one object per IDENTITY. Three properties
+# have to hold or it trades one churn for another:
+#
+#   - a single-observation row must come through untouched, or every
+#     unaffected interface on the estate rewrites for nothing;
+#   - the merged text must not depend on the order Forward returned rows in;
+#   - a genuine difference must still survive the merge.
+from django.test import SimpleTestCase
+
+from forward_netbox.utilities.row_collapsing import collapse_rows
+from forward_netbox.utilities.sync_routing_impl import COLLAPSED_COMMENTS_KEY
+from forward_netbox.utilities.sync_routing_impl import ospf_interface_comments
+
+OSPF_INTERFACE = "netbox_routing.ospfinterface"
+OSPF_AREA = "netbox_routing.ospfarea"
+
+
+def _row(**extra):
+    row = {
+        "device": "dev-1",
+        "process_id": "1",
+        "area_id": "0.0.0.0",
+        "area_type": "standard",
+        "local_interface": "GigabitEthernet0/0",
+        "cost": 10,
+    }
+    row.update(extra)
+    return row
+
+
+class AModelWithNoCollapserIsUntouchedTest(SimpleTestCase):
+    def test_rows_pass_straight_through(self):
+        rows = [_row(), _row(device="dev-2")]
+        self.assertIs(collapse_rows("dcim.device", rows), rows)
+
+
+class OneNeighbourIsNotAGroupTest(SimpleTestCase):
+    """The common case must be byte-identical or the whole estate rewrites."""
+
+    def test_a_single_row_is_returned_unchanged(self):
+        row = _row(remote_device="peer-a", remote_router_id="10.0.0.2")
+        collapsed = collapse_rows(OSPF_INTERFACE, [row])
+        self.assertEqual(collapsed, [row])
+        self.assertNotIn(COLLAPSED_COMMENTS_KEY, collapsed[0])
+
+    def test_its_comments_are_what_they_always_were(self):
+        row = _row(remote_device="peer-a", remote_router_id="10.0.0.2")
+        collapsed = collapse_rows(OSPF_INTERFACE, [row])
+        self.assertEqual(
+            ospf_interface_comments(collapsed[0]), ospf_interface_comments(row)
+        )
+
+    def test_two_interfaces_stay_two_rows(self):
+        rows = [_row(), _row(local_interface="GigabitEthernet0/1")]
+        self.assertEqual(len(collapse_rows(OSPF_INTERFACE, rows)), 2)
+
+    def test_the_same_interface_on_two_devices_stays_two_rows(self):
+        rows = [_row(), _row(device="dev-2")]
+        self.assertEqual(len(collapse_rows(OSPF_INTERFACE, rows)), 2)
+
+
+class NeighboursOnOneInterfaceBecomeOneRowTest(SimpleTestCase):
+    def _neighbours(self):
+        return [
+            _row(remote_device="peer-b", remote_router_id="10.0.0.3"),
+            _row(remote_device="peer-a", remote_router_id="10.0.0.2"),
+        ]
+
+    def test_they_collapse_to_one(self):
+        self.assertEqual(len(collapse_rows(OSPF_INTERFACE, self._neighbours())), 1)
+
+    def test_every_neighbour_survives_the_merge(self):
+        collapsed = collapse_rows(OSPF_INTERFACE, self._neighbours())[0]
+        comments = ospf_interface_comments(collapsed)
+        for value in ("peer-a", "peer-b", "10.0.0.2", "10.0.0.3"):
+            self.assertIn(value, comments)
+
+    def test_the_merge_does_not_depend_on_the_order_forward_returned(self):
+        rows = self._neighbours()
+        forwards = collapse_rows(OSPF_INTERFACE, rows)[0]
+        backwards = collapse_rows(OSPF_INTERFACE, list(reversed(rows)))[0]
+        # An unsorted merge would swap a churn that recurs for one that
+        # recurs whenever Forward's ordering moves, which is worse: it would
+        # look intermittent.
+        self.assertEqual(
+            ospf_interface_comments(forwards), ospf_interface_comments(backwards)
+        )
+
+    def test_the_interfaces_own_fields_are_kept(self):
+        collapsed = collapse_rows(OSPF_INTERFACE, self._neighbours())[0]
+        self.assertEqual(collapsed["local_interface"], "GigabitEthernet0/0")
+        self.assertEqual(collapsed["device"], "dev-1")
+
+    def test_an_alias_and_its_expansion_are_the_same_interface(self):
+        rows = [
+            _row(local_interface="gi0/0", remote_device="peer-a"),
+            _row(local_interface="GigabitEthernet0/0", remote_device="peer-b"),
+        ]
+        # They resolve to one NetBox interface, so they must collapse to one
+        # row - grouping on the raw string would leave them fighting.
+        self.assertEqual(len(collapse_rows(OSPF_INTERFACE, rows)), 1)
+
+    def test_a_changed_neighbour_changes_the_merged_text(self):
+        before = collapse_rows(OSPF_INTERFACE, self._neighbours())[0]
+        after = collapse_rows(
+            OSPF_INTERFACE,
+            [
+                _row(remote_device="peer-b", remote_router_id="10.0.0.3"),
+                _row(remote_device="peer-a", remote_router_id="10.0.0.9"),
+            ],
+        )[0]
+        self.assertNotEqual(
+            ospf_interface_comments(before), ospf_interface_comments(after)
+        )
+
+
+class AnAreaIsOneObjectHoweverManyDevicesReportItTest(SimpleTestCase):
+    def test_rows_for_one_area_collapse(self):
+        rows = [_row(device="dev-1"), _row(device="dev-2"), _row(device="dev-3")]
+        self.assertEqual(len(collapse_rows(OSPF_AREA, rows)), 1)
+
+    def test_distinct_areas_stay_distinct(self):
+        rows = [_row(), _row(area_id="0.0.0.1")]
+        self.assertEqual(len(collapse_rows(OSPF_AREA, rows)), 2)
+
+    def test_a_disagreement_resolves_the_same_way_every_run(self):
+        # Two devices reporting different types for one area is a data
+        # conflict. Whatever it means, the two must not take turns winning and
+        # report drift forever.
+        rows = [_row(area_type="stub"), _row(device="dev-2", area_type="nssa")]
+        first = collapse_rows(OSPF_AREA, rows)[0]
+        second = collapse_rows(OSPF_AREA, list(reversed(rows)))[0]
+        self.assertEqual(first["area_type"], second["area_type"])

--- a/forward_netbox/utilities/drift_comparison.py
+++ b/forward_netbox/utilities/drift_comparison.py
@@ -1043,6 +1043,12 @@ def compare_model_rows(sync, model_string, rows):
     they are in sync when nothing checked.
     """
     from .apply_engine_bulk import bulk_orm_apply_simple_models
+    from .row_collapsing import collapse_rows
+
+    # The same collapse the apply performs, and for the same reason. If only
+    # one of the two did it they would disagree about how many objects a row
+    # set means, which is the defect this fixes rather than a variation on it.
+    rows = collapse_rows(model_string, rows)
 
     # No shortcut for an empty row list.
     #

--- a/forward_netbox/utilities/row_collapsing.py
+++ b/forward_netbox/utilities/row_collapsing.py
@@ -1,0 +1,140 @@
+# Rows that write the same object, collapsed into one before anything reads them.
+#
+# Some Forward queries return one row per OBSERVATION while the apply upserts
+# one object per IDENTITY. `forward_ospf_interfaces.nqe` selects
+# `foreach neighbor in area.neighbors`, so a broadcast segment with three
+# neighbours yields three rows carrying the same `local_interface`;
+# `ensure_ospf_interface` coalesces on `("interface",)`, so all three collapse
+# onto one OSPFInterface.
+#
+# Left alone that is not merely wasteful, it never converges. Each row writes
+# its own `comments`, the last writer wins, and every later comparison finds
+# the other rows still wanting to write theirs - so they report as drift on
+# every run, forever, and no sync can resolve them. A customer estate showed
+# 180 of 2854 OSPF interface rows permanently drifted, which is what makes
+# `In sync` a question that can never be answered Yes.
+#
+# The collapse happens ONCE, upstream of both the apply and the comparison,
+# because the bug this fixes is precisely the two disagreeing about how many
+# objects a set of rows means. A collapse applied to only one of them would be
+# the same defect wearing different clothes.
+from .sync_routing_impl import COLLAPSED_COMMENTS_KEY
+from .sync_routing_impl import ospf_interface_comments
+from .sync_routing_impl import ROUTING_INTERFACE_PREFIX_ALIASES
+
+
+def _canonical_interface(name):
+    """The name the interface lookup will settle on, for grouping purposes.
+
+    Expands the LONGEST matching alias, reusing the lookup's own table, so
+    `gi0/0` and `GigabitEthernet0/0` group together exactly when they would
+    resolve to the same NetBox interface. Longest wins because the table holds
+    both `gi` and `gigabitethernet`, and the short one matches the long one's
+    expansion too - taking any match would map a name onto itself twice over.
+    """
+    raw = str(name or "").strip()
+    if not raw:
+        return ""
+    lowered = raw.lower()
+    match = None
+    for alias, canonical in ROUTING_INTERFACE_PREFIX_ALIASES:
+        if lowered.startswith(alias) and (match is None or len(alias) > len(match[0])):
+            match = (alias, canonical)
+    if match is None:
+        return lowered
+    alias, canonical = match
+    return f"{canonical}{raw[len(alias):]}".lower()
+
+
+# The fields that differ between neighbours on one interface. Everything else
+# in the row describes the interface itself and is identical across the group.
+_NEIGHBOUR_LABELS = (
+    ("Remote device", "remote_device"),
+    ("Remote interface", "remote_interface"),
+    ("Remote interface IP", "remote_interface_ip"),
+    ("Remote router ID", "remote_router_id"),
+)
+
+
+def _neighbour_sort_key(row):
+    return tuple(str(row.get(key) or "") for _label, key in _NEIGHBOUR_LABELS)
+
+
+def _ospf_interface_key(row):
+    return (
+        str(row.get("device") or ""),
+        _canonical_interface(row.get("local_interface")),
+    )
+
+
+def _merge_ospf_interface_rows(rows):
+    """One row per interface, carrying every neighbour seen on it.
+
+    Sorted, so the merged text is identical on every run whatever order
+    Forward returned the neighbours in - an unsorted merge would swap the
+    churn for a subtler one.
+
+    A single-neighbour interface returns the untouched row, so the overwhelming
+    majority of an estate keeps byte-identical comments and does not rewrite.
+    """
+    ordered = sorted(rows, key=_neighbour_sort_key)
+    if len(ordered) == 1:
+        return ordered[0]
+
+    blocks = [ospf_interface_comments(ordered[0])]
+    for row in ordered[1:]:
+        lines = [
+            f"{label}: {row.get(key)}"
+            for label, key in _NEIGHBOUR_LABELS
+            if row.get(key) not in ("", None)
+        ]
+        if lines:
+            blocks.append("\n".join(lines))
+
+    merged = dict(ordered[0])
+    merged[COLLAPSED_COMMENTS_KEY] = "\n\n".join(blocks)
+    return merged
+
+
+def _ospf_area_key(row):
+    return str(row.get("area_id") or "")
+
+
+def _merge_ospf_area_rows(rows):
+    """Every device in an area contributes a row; the area is one object.
+
+    Nothing is merged into the text - the area's fields are the area's, not the
+    reporting device's. The rows are sorted so that when two of them disagree
+    about `area_type` the same one wins on every run. That disagreement is a
+    data conflict worth surfacing separately; what must not happen is the two
+    taking turns and reporting drift forever.
+    """
+    return sorted(rows, key=lambda row: str(row.get("area_type") or ""))[0]
+
+
+_COLLAPSERS = {
+    "netbox_routing.ospfinterface": (_ospf_interface_key, _merge_ospf_interface_rows),
+    "netbox_routing.ospfarea": (_ospf_area_key, _merge_ospf_area_rows),
+}
+
+
+def collapses_rows(model_string) -> bool:
+    return model_string in _COLLAPSERS
+
+
+def collapse_rows(model_string, rows):
+    """Rows reduced to one per object the apply would write.
+
+    Order-preserving on first appearance, so the apply still walks the estate
+    in the order Forward reported it and a log read against a previous run
+    stays comparable.
+    """
+    collapser = _COLLAPSERS.get(model_string)
+    if collapser is None:
+        return rows
+
+    key_of, merge = collapser
+    groups: dict = {}
+    for row in rows:
+        groups.setdefault(key_of(row), []).append(row)
+    return [merge(group) for group in groups.values()]

--- a/forward_netbox/utilities/sync_reporting.py
+++ b/forward_netbox/utilities/sync_reporting.py
@@ -625,8 +625,15 @@ def record_issue(
 
 
 def apply_model_rows(runner, model_string, rows):
+    from .row_collapsing import collapse_rows
+
     rows = list(rows)
     total_rows = len(rows)
+    # Before the row count is taken for anything else. Some queries report one
+    # row per observation while the apply writes one object per identity, and
+    # writing that object once per observation is how a row set that never
+    # converges is produced.
+    rows = collapse_rows(model_string, rows)
     if model_string == "dcim.interface":
         rows = sorted(rows, key=lambda row: bool(row.get("lag")))
     handler_name = f"_apply_{model_string.replace('.', '_')}"

--- a/forward_netbox/utilities/sync_routing_impl.py
+++ b/forward_netbox/utilities/sync_routing_impl.py
@@ -693,7 +693,17 @@ def ospf_instance_comments(row, process_label):
     return "\n".join(lines)
 
 
+# Where a collapsed group's merged text is carried. Set only by
+# `row_collapsing` and only when one interface really did report more than one
+# neighbour; a single-neighbour row never has it, so its comments stay exactly
+# what they were.
+COLLAPSED_COMMENTS_KEY = "_forward_collapsed_comments"
+
+
 def ospf_interface_comments(row):
+    merged = row.get(COLLAPSED_COMMENTS_KEY)
+    if merged is not None:
+        return merged
     lines = ["Observed by Forward from structured OSPF neighbor state."]
     for label, key in (
         ("Cost", "cost"),


### PR DESCRIPTION
On a customer estate **180 of 2854** `netbox_routing.ospfinterface` rows drifted on every run — including a comparison taken 22 minutes after a sync that applied 8240 changes with **zero failures**, against the **same snapshot**. `In sync` could never become Yes, and an operator who learns that stops reading the number at all.

## The mechanism

`forward_ospf_interfaces.nqe:33` selects `foreach neighbor in area.neighbors` — **one row per OSPF neighbour**, each carrying `local_interface`. A broadcast segment with three neighbours is three rows with the same interface.

`ensure_ospf_interface` (`sync_routing_impl.py:807`) upserts with `coalesce_sets=[("interface",)]` — **one OSPFInterface per NetBox interface**.

The rows collapse onto one object and each writes its own `comments` (remote device, remote interface, remote interface IP, remote router ID all differ per neighbour). Last row wins; every later comparison finds the others still wanting to write theirs. The count is stable rather than growing because it is exactly the surplus: `N-1` rows per multi-neighbour interface, forever.

**This is not the volatile-counter churn already fixed for BGP peers** (`test_bgp_peer_comment_churn.py`). `ospf_interface_comments` renders nothing that moves between snapshots. The rows are stable and still never converge, because the problem is arithmetic.

`netbox_routing.ospfarea` has the same shape — `coalesce_sets=[("area_id",)]` with a row per reporting device — and showed 5 of 28.

## The fix

Rows are collapsed to one per object **upstream of both** the apply and the comparison. Doing it in only one would be the same defect in a new place: the two disagreeing about how many objects a row set means.

A single-neighbour interface — the overwhelming majority of an estate — comes through untouched and its comments stay byte-identical, so nothing rewrites to fix a minority. `ospfarea` merges nothing (the area's fields are the area's, not the reporting device's); it only picks a deterministic winner so two devices disagreeing about `area_type` stop taking turns.

## Verification

- **The reproduction reports 2 updates against shipped 2.9.2 code** — `N-1`, exactly the field symptom — and 0 after the fix.
- **The upgrade cost is pinned, not discovered:** an estate synced by the old code rewrites *once* per affected interface, then stays stable.
- Order-independence, alias grouping (`gi0/0` ≡ `GigabitEthernet0/0`), single-row byte-identity, and "a real change still reports" each have their own test. The alias test caught a genuine bug in the first canonicaliser, which mapped `GigabitEthernet0/0` onto `GigabitEthernetgabitEthernet0/0` because both `gi` and `gigabitethernet` are in the table.
- Full Django suite: **2605 tests, OK**. `pre-commit` clean, harness passes.

## Deliberately not included

- **`netbox_routing.bgppeer`'s 126 rows** on the same estate. It may be the same shape, but its coalesce key spans a router and scope built from other fields, and nothing here has demonstrated the collapse. Recorded as open — reproduce first, which is the discipline that made this fix trustworthy.
- **The 17-minute comparison** (`1010213 ms`, 246591 queries, `dcim.macaddress` alone 297643 ms with 247134 ms in SQL). The collapse removes some adapter row work; the macaddress cost is a separate question and this does not claim to have moved it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DczGsTTkuwULnpcYX4qui6
