### PR TITLE
perf: an interface lookup an index can actually serve

### DIFF
--- a/docs/03_Plans/active/2026-09-04-interface-lookup-query-shape.md
+++ b/docs/03_Plans/active/2026-09-04-interface-lookup-query-shape.md
@@ -1,0 +1,96 @@
+# The interface lookup that could not use an index
+
+## Goal
+
+Cut the SQL cost of resolving interfaces during a comparison. A customer's
+drift report spent **1010213 ms** over 648353 rows in 246591 queries, and named
+its own worst offender: `dcim.macaddress at 297643 ms in 756 queries, 247134 ms
+of it in SQL`. Four of those minutes were one lookup shape.
+
+## Why
+
+`bulk_orm_apply_macaddress` must resolve every row's interface before it can
+classify anything. That lookup chunked the `(device name, interface name)`
+PAIRS 500 at a time and built, per chunk, one `Q(device__name=..., name__in=[...])`
+branch per device, OR'd together - joining `dcim_device` by **name**.
+
+Postgres cannot use an index for an OR-tree of that shape, so every chunk
+scanned `dcim_interface` whole. On the estate that reported it that is 360,771
+rows, and 124k MAC rows is roughly 248 chunks. The scan is the 247 seconds.
+
+The join was unnecessary as well as expensive: both call sites resolve
+`devices_by_name` immediately above, so the device ids were already in hand.
+
+## Constraints
+
+- **The result must be identical.** Chunking by device means the name filter is
+  a superset across the chunk, so an exact pair check is not optional - without
+  it an interface would match on the wrong device, which is worse than slow.
+- **Devices absent from NetBox stay absent.** A pair whose device did not
+  resolve must not silently match anything.
+- **No behaviour change beyond cost.** This is the comparison and the apply
+  reading the same rows they always did.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/apply_engine_bulk.py` -
+  `_interfaces_by_device_and_name` replaces `_device_scoped_name_query` at both
+  call sites, and the dead builder is removed
+- `forward_netbox/tests/test_interface_lookup_query_shape.py` (new)
+
+## Approach
+
+Chunk by **device** rather than by pair. Each chunk is one query filtering
+`device_id IN (...)` with the union of the names wanted across those devices,
+which is a predicate an index can serve. The exact pair match then happens in
+Python, where it costs nothing.
+
+`.order_by()` clears NetBox's default Interface ordering - device name, then
+the naturalized `_name` under a collation. The rows go straight into a dict, so
+nothing reads the order, but the database was paying for the sort on every
+chunk.
+
+`sync_primitives` has its own same-named helper that is already id-based and is
+deliberately untouched: it serves the dependency-lookup priming path, which was
+tuned separately, and widening this change into it would be changing something
+this evidence says nothing about.
+
+## Validation
+
+- The query is asserted on its **predicate**, not its text: `device_id IN` is
+  present, a device name is not, and there is no `OR` - the three properties
+  that decide whether an index can be used.
+- Query count is asserted to scale with devices rather than pairs: 24 pairs
+  across 6 devices is one query.
+- Correctness is pinned where the superset could bite: every device in the
+  fixture has an `Ethernet0`, and asking for one device's must return only
+  that one.
+- A device outside the resolved set is skipped; an absent name is simply
+  absent; no pairs asks nothing.
+- Full Django suite: 2617 tests.
+
+## Rollback
+
+Revert. The helper is self-contained and the call sites are two lines each.
+
+## Decision Log
+
+- **Chunk by device, not by pair.** Pair chunking was there to avoid a
+  device/interface Cartesian product across batches; grouping by device solves
+  the same problem without an OR-tree, because a device's interfaces are the
+  natural unit of the lookup.
+- **`select_related("device")` is kept.** It adds a join, but on a primary key
+  and only over rows already filtered. Callers read `interface.device`, and
+  removing it would trade a cheap join for a per-row query.
+- **The predicate is asserted, not the SQL string.** Pinning the whole
+  statement would break on any unrelated NetBox field addition and teach the
+  next reader to delete the test.
+
+## Open
+
+- **This does not close the macaddress cost.** It removes the scan; whether the
+  remaining time is the MAC batch lookup, the classification, or something
+  else needs the per-model breakdown from a run that has this fix.
+- **246591 queries overall is still the shape to look at next.** Adapter models
+  compare one row at a time, so a model with 12310 rows issues 12310 preview
+  applies. That is a design question, not a bug, and it is untouched here.

--- a/forward_netbox/tests/test_interface_lookup_query_shape.py
+++ b/forward_netbox/tests/test_interface_lookup_query_shape.py
@@ -1,0 +1,114 @@
+# The interface lookup that cost a customer four minutes of SQL in one model.
+#
+# `bulk_orm_apply_macaddress` resolves every row's interface before it can
+# classify anything. That lookup used to build one
+# `Q(device__name=..., name__in=[...])` branch per device and OR up to 500 of
+# them together, joining `dcim_device` by NAME. Postgres cannot use an index
+# for that shape, so each chunk scanned the interface table whole - 360,771
+# rows on the estate that reported it - once per chunk of 500 pairs.
+#
+# The reported cost was `dcim.macaddress at 297643 ms in 756 queries, 247134 ms
+# of it in SQL`, inside a comparison that took seventeen minutes overall.
+#
+# Two properties are pinned here. The lookup must issue a number of queries
+# that scales with DEVICES rather than with pairs, and it must still return
+# exactly the pairs asked for - the name filter is a superset across the chunk,
+# so dropping the pair check would silently match an interface on the wrong
+# device.
+from dcim.models import Device
+from dcim.models import DeviceRole
+from dcim.models import DeviceType
+from dcim.models import Interface
+from dcim.models import Manufacturer
+from dcim.models import Site
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+
+from forward_netbox.utilities.apply_engine_bulk import _interfaces_by_device_and_name
+
+
+class InterfaceLookupQueryShapeTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        site = Site.objects.create(name="Q Site", slug="q-site")
+        mfr = Manufacturer.objects.create(name="Q Mfr", slug="q-mfr")
+        dtype = DeviceType.objects.create(manufacturer=mfr, model="Q DT", slug="q-dt")
+        role = DeviceRole.objects.create(name="Q Role", slug="q-role")
+        cls.devices = {}
+        for index in range(6):
+            name = f"q-dev-{index}"
+            device = Device.objects.create(
+                name=name, site=site, device_type=dtype, role=role, status="active"
+            )
+            cls.devices[name] = device
+            for port in range(4):
+                Interface.objects.create(
+                    device=device, name=f"Ethernet{port}", type="1000base-t"
+                )
+
+    def _pairs(self):
+        return {(name, f"Ethernet{port}") for name in self.devices for port in range(4)}
+
+    def test_every_requested_pair_is_returned(self):
+        found = _interfaces_by_device_and_name(
+            self._pairs(), devices_by_name=self.devices
+        )
+        self.assertEqual(set(found), self._pairs())
+
+    def test_an_interface_on_the_wrong_device_is_not_returned(self):
+        # Every device here has an `Ethernet0`. Asking for one device's must
+        # not return another's, which is exactly what a superset name filter
+        # would do without the pair check.
+        found = _interfaces_by_device_and_name(
+            {("q-dev-0", "Ethernet0")}, devices_by_name=self.devices
+        )
+        self.assertEqual(set(found), {("q-dev-0", "Ethernet0")})
+        self.assertEqual(found[("q-dev-0", "Ethernet0")].device.name, "q-dev-0")
+
+    def test_a_name_that_does_not_exist_is_simply_absent(self):
+        found = _interfaces_by_device_and_name(
+            {("q-dev-0", "Ethernet99")}, devices_by_name=self.devices
+        )
+        self.assertEqual(found, {})
+
+    def test_a_device_outside_the_resolved_set_is_skipped(self):
+        found = _interfaces_by_device_and_name(
+            {("q-dev-0", "Ethernet0"), ("unknown-dev", "Ethernet0")},
+            devices_by_name=self.devices,
+        )
+        self.assertEqual(set(found), {("q-dev-0", "Ethernet0")})
+
+    def test_the_query_count_scales_with_devices_not_pairs(self):
+        # Twenty-four pairs across six devices, all inside one device chunk.
+        # The old shape issued one query per chunk of 500 PAIRS, each an
+        # OR-tree; this must be a single indexed query.
+        with CaptureQueriesContext(connection) as captured:
+            _interfaces_by_device_and_name(self._pairs(), devices_by_name=self.devices)
+        self.assertEqual(len(captured.captured_queries), 1)
+
+    def test_the_query_filters_on_device_id_rather_than_matching_a_name(self):
+        with CaptureQueriesContext(connection) as captured:
+            _interfaces_by_device_and_name(self._pairs(), devices_by_name=self.devices)
+        sql = captured.captured_queries[0]["sql"]
+        where = sql.split(" WHERE ", 1)[1]
+        # The predicate is what decides whether an index can be used. A device
+        # NAME in it is the old OR-tree shape, which could not be indexed.
+        self.assertIn('"dcim_interface"."device_id" IN', where)
+        self.assertNotIn('"dcim_device"."name"', where)
+        self.assertNotIn(" OR ", where)
+
+    def test_the_result_is_not_sorted_for_a_dict_that_discards_order(self):
+        # NetBox orders Interface by device name then naturalized name under a
+        # collation. Nothing here reads the order, and the sort is charged per
+        # chunk on the full result set.
+        with CaptureQueriesContext(connection) as captured:
+            _interfaces_by_device_and_name(self._pairs(), devices_by_name=self.devices)
+        self.assertNotIn("ORDER BY", captured.captured_queries[0]["sql"])
+
+    def test_no_pairs_asks_nothing(self):
+        with CaptureQueriesContext(connection) as captured:
+            self.assertEqual(
+                _interfaces_by_device_and_name(set(), devices_by_name={}), {}
+            )
+        self.assertEqual(len(captured.captured_queries), 0)

--- a/forward_netbox/utilities/apply_engine_bulk.py
+++ b/forward_netbox/utilities/apply_engine_bulk.py
@@ -23,19 +23,65 @@ def _chunks(items, size=_APPLY_LOOKUP_CHUNK_SIZE):
         yield items[index : index + size]
 
 
-def _device_scoped_name_query(pairs):
-    from django.db.models import Q
+# How many DEVICES one interface lookup covers. Chunking by device rather than
+# by pair is what keeps the query shape indexable; the number only bounds the
+# result size.
+_DEVICE_LOOKUP_CHUNK_SIZE = 200
 
-    grouped_names_by_device = {}
+
+def _interfaces_by_device_and_name(pairs, *, devices_by_name):
+    """Interfaces for `(device name, interface name)` pairs, without an OR-tree.
+
+    The previous form built one `Q(device__name=..., name__in=[...])` branch per
+    device and OR'd up to 500 of them together, joining `dcim_device` by NAME.
+    Postgres cannot use an index for that shape, so every chunk scanned the
+    interface table whole - 360,771 rows on a customer estate, once per chunk,
+    for 247 seconds of SQL inside a single model's comparison.
+
+    Every caller has already resolved the devices by name, so the join was
+    unnecessary as well as expensive. Chunking by DEVICE keeps each query to one
+    indexed `device_id IN (...)` with a name filter, and the exact pair match
+    happens in Python where it costs nothing.
+
+    The name filter is a superset - a name wanted on one device in the chunk is
+    fetched for every device in it - which is why the pair check below is not
+    optional.
+    """
+    from dcim.models import Interface
+
+    names_by_device: dict[str, set] = {}
     for device_name, interface_name in pairs:
-        grouped_names_by_device.setdefault(device_name, set()).add(interface_name)
-    query = Q()
-    for device_name, interface_names in grouped_names_by_device.items():
-        query |= Q(
-            device__name=device_name,
-            name__in=sorted(interface_names),
-        )
-    return query
+        if device_name in devices_by_name:
+            names_by_device.setdefault(device_name, set()).add(interface_name)
+    if not names_by_device:
+        return {}
+
+    found = {}
+    ordered = sorted(names_by_device)
+    for index in range(0, len(ordered), _DEVICE_LOOKUP_CHUNK_SIZE):
+        chunk = ordered[index : index + _DEVICE_LOOKUP_CHUNK_SIZE]
+        device_names_by_id = {devices_by_name[name].pk: name for name in chunk}
+        wanted_names = set()
+        for name in chunk:
+            wanted_names |= names_by_device[name]
+        # `.order_by()` clears NetBox's default Interface ordering, which sorts
+        # by device name and then by the naturalized `_name` under a collation.
+        # The result goes into a dict, so the order is discarded either way -
+        # but the database still pays for the sort on every chunk.
+        for interface in (
+            Interface.objects.select_related("device")
+            .filter(
+                device_id__in=list(device_names_by_id),
+                name__in=sorted(wanted_names),
+            )
+            .order_by()
+        ):
+            device_name = device_names_by_id.get(interface.device_id)
+            if device_name is None:
+                continue
+            if interface.name in names_by_device[device_name]:
+                found[(device_name, interface.name)] = interface
+    return found
 
 
 def _isolate_bulk_objects(
@@ -1048,12 +1094,9 @@ def bulk_orm_apply_macaddress(runner, rows: list[dict[str, Any]], *, preview=Fal
     for batch in _chunks(list(device_names)):
         for device in Device.objects.filter(name__in=batch):
             devices_by_name[device.name] = device
-    interfaces_by_key = {}
-    # Pair chunking avoids a device/interface Cartesian product across batches.
-    for batch in _chunks(list(interface_pairs)):
-        query = _device_scoped_name_query(batch)
-        for interface in Interface.objects.select_related("device").filter(query):
-            interfaces_by_key[(interface.device.name, interface.name)] = interface
+    interfaces_by_key = _interfaces_by_device_and_name(
+        interface_pairs, devices_by_name=devices_by_name
+    )
     macs_by_address = {}
     # Two persisted rows can share a canonical MAC. Last-write-wins would pick
     # one arbitrarily and silently write the customer's assignment to whichever
@@ -2574,12 +2617,9 @@ def bulk_orm_apply_ipaddress(runner, rows: list[dict[str, Any]], *, preview=Fals
     for batch in _chunks(list(device_names)):
         for device in Device.objects.filter(name__in=batch):
             devices_by_name[device.name] = device
-    interfaces_by_key = {}
-    # Pair chunking avoids a device/interface Cartesian product across batches.
-    for batch in _chunks(list(interface_pairs)):
-        query = _device_scoped_name_query(batch)
-        for interface in Interface.objects.select_related("device").filter(query):
-            interfaces_by_key[(interface.device.name, interface.name)] = interface
+    interfaces_by_key = _interfaces_by_device_and_name(
+        interface_pairs, devices_by_name=devices_by_name
+    )
 
     # Pre-ensure VRFs once (the adapter ensures-or-creates per row).
     vrf_by_name = {}


### PR DESCRIPTION
A customer's drift report spent **1010213 ms** over 648353 rows in **246591 queries**, and named its own worst offender: `dcim.macaddress at 297643 ms in 756 queries, 247134 ms of it in SQL`. Four of those minutes were one lookup shape.

## Why it was slow

`bulk_orm_apply_macaddress` resolves every row's interface before it can classify anything. That lookup chunked the `(device name, interface name)` **pairs** 500 at a time and built, per chunk, one `Q(device__name=..., name__in=[...])` branch per device, OR'd together — joining `dcim_device` by **name**.

Postgres cannot use an index for an OR-tree of that shape, so every chunk scanned `dcim_interface` whole: **360,771 rows on that estate, roughly 248 times**.

The join was unnecessary as well as expensive — both call sites resolve `devices_by_name` immediately above and already had the ids.

## The change

Chunk by **device** rather than by pair. Each chunk is one query filtering `device_id IN (...)` with the union of names wanted across those devices — a predicate an index can serve. The exact pair match happens in Python, where it costs nothing. **Query count now scales with devices, not pairs.**

`.order_by()` clears NetBox's default `Interface` ordering (device name, then naturalized `_name` under a collation). The rows go straight into a dict so nothing reads the order, but the database was paying for that sort on every chunk.

Both call sites with this pattern are fixed, so it is not only the MAC path. `sync_primitives` has its own same-named helper that is already id-based and is deliberately untouched.

## Verification

- The test asserts the **predicate**, not the SQL text: `device_id IN` present, no device name, no `OR` — the three properties that decide whether an index can be used. Pinning the whole statement would break on any unrelated NetBox field addition and teach the next reader to delete the test.
- Query count scales with devices: 24 pairs across 6 devices is **one** query.
- Correctness is pinned where the superset name filter could bite — every device in the fixture has an `Ethernet0`, and asking for one device's must return only that one.
- A device outside the resolved set is skipped; an absent name is simply absent; no pairs asks nothing.
- Full Django suite: **2617 tests, OK**. `pre-commit` clean, harness passes.

## Open

- **This does not close the macaddress cost.** It removes the scan; whether the remaining time is the MAC batch lookup, the classification, or something else needs the per-model breakdown from a run that has this fix.
- **246591 queries overall is still the shape to look at next.** Adapter models compare one row at a time, so a model with 12310 rows issues 12310 preview applies. That is a design question, not a bug, and it is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DczGsTTkuwULnpcYX4qui6
