### PR TITLE
feat: netbox-dlm is back on NetBox 4.7

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -8,7 +8,7 @@
 cryptography==50.0.0
 httpx==0.28.1
 netbox-cisco-aci==0.4.0
-netbox-dlm==0.9.1
+netbox-dlm==0.10.0
 netboxlabs-netbox-branching==1.2.0
 netbox-peering-manager==0.3.0
 netbox-routing==0.4.3

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -16,10 +16,13 @@ COPY development/launch-netbox.sh /opt/netbox/launch-netbox.sh
 RUN chmod +x /opt/netbox/launch-netbox.sh
 
 RUN uv pip install --constraint ${CONSTRAINTS} ${PACKAGE}
-# The five optional plugins are NOT installed on NetBox 4.7: every one of them
-# declares `max_version = "4.6.99"`, and NetBox refuses to start with a plugin
-# outside its declared range, so the image would not boot. They return here the
-# moment an upstream raises its ceiling. The 4.6 lane keeps them on 2.9.x.
+# netbox-dlm is the one optional plugin on NetBox 4.7: 0.10.0 raised its
+# ceiling to 4.7.99. The other four - netbox-cisco-aci, netbox-peering-manager,
+# netbox-routing, netbox-validity - still declare `max_version = "4.6.99"`, and
+# NetBox refuses to start with a plugin outside its declared range, so the
+# image would not boot. Each returns here the moment its upstream raises its
+# ceiling. The 4.6 lane keeps all five on 2.9.x.
+RUN uv pip install --constraint ${CONSTRAINTS} netbox-dlm
 RUN uv pip install "watchdog[watchmedo]"
 RUN uv pip install coverage
 

--- a/development/configuration/plugins.py
+++ b/development/configuration/plugins.py
@@ -3,16 +3,18 @@
 # To learn how to build images with your required plugins
 # See https://github.com/netbox-community/netbox-docker/wiki/Using-Netbox-Plugins
 # On NetBox 4.6 this enabled every supported optional integration, so adapter
-# regressions could not hide behind skipped tests. On 4.7 none of them can be
-# enabled: netbox-dlm, netbox-cisco-aci, netbox-peering-manager, netbox-routing
-# and netbox-validity all declare `max_version = "4.6.99"` and NetBox refuses to
-# start with a plugin outside its range.
+# regressions could not hide behind skipped tests. On 4.7 only netbox-dlm can
+# be enabled - 0.10.0 raised its ceiling to 4.7.99 - so the DLM adapter is
+# exercised here again. netbox-cisco-aci, netbox-peering-manager,
+# netbox-routing and netbox-validity still declare `max_version = "4.6.99"` and
+# NetBox refuses to start with a plugin outside its range.
 #
-# The optional-integration tests therefore skip on this runtime rather than
+# Those four integrations' tests therefore skip on this runtime rather than
 # fail. That is a real loss of coverage and is stated as such: the 2.9.x lane on
 # 4.6 remains where those adapters are exercised until an upstream moves.
 PLUGINS = [
     "netbox_branching",
+    "netbox_dlm",
     "forward_netbox",
 ]
 

--- a/development/constraints-upgrade-from.txt
+++ b/development/constraints-upgrade-from.txt
@@ -15,20 +15,20 @@
 # Branching is deliberately absent: the previous release's own metadata pins it,
 # and letting that resolve is the point.
 #
-# `netbox-dlm` diverged here for one release and no longer does. The rule is
-# that this side holds the newest version the FROM release supports: while the
-# FROM release was 2.7.13, which declares `netbox-dlm >=0.4.1,<0.9.0`, pinning
-# 0.9.1 was unsatisfiable rather than merely old, so it was held at 0.8.0. The
-# FROM release is now 2.8.0, which declares `>=0.4.1,<0.10.0` and supports
-# 0.9.1, so the divergence has lapsed and the pin returns to matching
-# `constraints.txt`.
+# `netbox-dlm` is pinned at 0.10.0 here even though the FROM release (3.0.0,
+# `<0.10.0`) never installed it. The usual rule - hold the newest version the
+# FROM release supports - has no answer on NetBox 4.7: 3.0.0 shipped with no
+# optional plugin because none could boot there, and 0.10.0 is the only
+# netbox-dlm that can. The from-side image installs the bare plugin, not the
+# `dlm` extra, so 3.0.0's own cap does not constrain this line. 0.9.1 here
+# would build an image NetBox refuses to start.
 #
 # Re-check this on any release that widens an optional plugin's range: the
 # entry has to move back down the moment the FROM release cannot satisfy it.
 cryptography==50.0.0
 httpx==0.28.1
 netbox-cisco-aci==0.4.0
-netbox-dlm==0.9.1
+netbox-dlm==0.10.0
 netbox-peering-manager==0.3.0
 netbox-routing==0.4.3
 netbox-validity==3.5.2

--- a/docs/03_Plans/active/2026-09-05-netbox-dlm-0-10-0-on-4-7.md
+++ b/docs/03_Plans/active/2026-09-05-netbox-dlm-0-10-0-on-4-7.md
@@ -1,0 +1,100 @@
+# Bring netbox-dlm back on NetBox 4.7
+
+## Goal
+
+Restore the netbox-dlm integration on the 4.7 lane by admitting 0.10.0, the
+first release of any optional plugin to raise its ceiling past 4.6.99, so a
+3.x deployment can run lifecycle sync at all - and run it on the fast paths.
+
+## Why
+
+3.0.0 shipped with no optional plugin because none could boot on 4.7; the
+4.7 runtime plan recorded the values to restore and said regaining one should
+be "a lookup rather than an archaeology exercise". netbox-dlm 0.10.0 shipped
+2026-09-03 declaring `max_version = "4.7.99"`. This is that lookup, made real.
+
+The 4.6 lane admits the same release in its own change; the two lanes differ
+in what else has to move, which is why this is its own plan.
+
+## Constraints
+
+- `VALIDATED_PLUGIN_APPS` is an exact match that fails closed and silently. It
+  must gain `netbox_dlm` in the same change that installs the plugin, or the
+  dev and release images run every sync on the slow paths with no error.
+- Only 0.10.0 is validated here. 0.4.1 through 0.9.1 were validated against
+  4.6 and cannot boot on 4.7; carrying them over would be evidence about a
+  runtime this lane does not run.
+- The from-side of the upgrade leg shares the Dockerfile and `plugins.py`
+  with the to-side, so it must install a netbox-dlm that boots on 4.7. That
+  is 0.10.0, and it is satisfiable because the from-side installs the bare
+  plugin rather than the `dlm` extra, so 3.0.0's own `<0.10.0` cap does not
+  reach it.
+- The other four integrations stay out. Each still declares `4.6.99`.
+
+## Approach
+
+Follow the restore recipe the 4.7 runtime plan wrote down, in one change:
+
+1. Install the plugin in the image and enable it in the dev `PLUGINS` list,
+   for both sides of the upgrade leg.
+2. Put `netbox_dlm` into `VALIDATED_PLUGIN_APPS` and `0.10.0` - only - into
+   `VALIDATED_OPTIONAL_DISTRIBUTIONS`. Every gate derives from those two.
+3. Move the pins: `constraints.txt`, the from-side constraints, `pyproject`,
+   the lock, both SBOM declarations, both registry version fields.
+4. Rewrite the tests that encoded "no optional plugin on 4.7" so they encode
+   "exactly netbox-dlm 0.10.0 on 4.7", in both directions of the exact match.
+5. Run the suite on the resulting image and confirm the fast paths are ON.
+
+## Touched Surfaces
+
+- `forward_netbox/utilities/validated_runtime.py` - `netbox_dlm` into the app
+  set, `{"netbox-dlm": {"0.10.0"}}` as the distribution set
+- `development/Dockerfile` - install netbox-dlm under the constraints file
+- `development/configuration/plugins.py` - `netbox_dlm` enabled
+- `constraints.txt`, `development/constraints-upgrade-from.txt` - 0.10.0
+- `pyproject.toml` - range widened to `<0.11.0`; `poetry.lock`
+- `scripts/validate_sbom.py`, `tasks.py` - the SBOM carries netbox-dlm again
+- `forward_netbox/utilities/plugin_integrations/registry.py` - both version
+  fields
+- Tests: `test_optional_plugin_versions.py` (the one-entry set, and both
+  directions of the exact match), `test_plugin_integrations.py`, and the
+  stale "cannot be installed on 4.7" notes in the five DLM-guarded suites,
+  whose skips now stop skipping.
+
+## Validation
+
+- The wheel diff: 0.10.0 differs from 0.9.1 in `netbox_dlm/__init__.py` only
+  (version string, `max_version`). No model, migration, URL or view moved.
+- `test_optional_plugin_versions` pins the set to exactly
+  `{"netbox-dlm": {"0.10.0"}}`, that 0.9.1 fails closed, that `netbox_dlm`
+  missing from PLUGINS fails closed, and that a stranger app fails closed.
+- The full Django suite on the 4.7 image with netbox-dlm 0.10.0 installed and
+  enabled. The DLM adapter tests that skipped on 3.0.0 run again; the skip
+  count is expected to fall and is reported.
+- Each fast path shown ON, not merely not-erroring, on that runtime.
+- `scripts/tests`, `pre-commit --all-files`, `check_harness.py`.
+
+## Rollback
+
+Revert. netbox-dlm leaves the image and the validated set together, which is
+the fail-closed direction; nothing persisted changes.
+
+## Decision Log
+
+- **Validate 0.10.0 only.** The 4.6 versions are recorded, not restored.
+- **From-side pins 0.10.0, not 0.9.1.** The rule "newest version the FROM
+  release supports" has no answer for a FROM release that installed nothing;
+  the constraint that does apply is "a version that boots on 4.7", and the
+  comment in that file now says so.
+- **Both directions of the exact match are tested.** The set gaining an entry
+  means a deployment that has NOT installed netbox-dlm now mismatches too.
+  That is the correct fail-closed reading and it is pinned rather than
+  discovered.
+
+## Open
+
+- A 3.x deployment that does not want lifecycle sync now has to install
+  netbox-dlm anyway to keep the fast paths, because the validated app set is
+  exact. That was already true of every optional plugin on 2.9.x and is how
+  the module is designed; it is recorded here because 3.0.0 briefly made the
+  minimal install the validated one.

--- a/forward_netbox/tests/test_bulk_merge.py
+++ b/forward_netbox/tests/test_bulk_merge.py
@@ -49,10 +49,9 @@ from forward_netbox.utilities.merge import merge_branch
 # via bulk_merge_changes, proving batched writes, bounded framework fallbacks,
 # atomic audit evidence, relationship convergence, and idempotent retries.
 
-# netbox-dlm cannot be installed on NetBox 4.7: it declares a max_version in
-# the 4.6 series and NetBox refuses to start with a plugin outside its range.
-# These skip rather than fail, which IS lost coverage - the 4.6 lane on 2.9.x
-# is where the DLM paths stay exercised until that ceiling moves.
+# netbox-dlm 0.10.0 runs on NetBox 4.7, so these are exercised here again. The
+# guard stays: a runtime without the plugin skips rather than fails, and that
+# is stated as lost coverage, not as a pass.
 DLM_INSTALLED = apps.is_installed("netbox_dlm")
 
 

--- a/forward_netbox/tests/test_dlm_catalogue_conflicts.py
+++ b/forward_netbox/tests/test_dlm_catalogue_conflicts.py
@@ -31,10 +31,9 @@ from forward_netbox.models import ForwardSync
 from forward_netbox.utilities.sync import ForwardSyncRunner
 from forward_netbox.utilities.sync_primitives import UNIQUE_LOOKUP_CACHE_FIELD_SETS
 
-# netbox-dlm cannot be installed on NetBox 4.7: it declares a max_version in
-# the 4.6 series and NetBox refuses to start with a plugin outside its range.
-# These skip rather than fail, which IS lost coverage - the 4.6 lane on 2.9.x
-# is where the DLM paths stay exercised until that ceiling moves.
+# netbox-dlm 0.10.0 runs on NetBox 4.7, so these are exercised here again. The
+# guard stays: a runtime without the plugin skips rather than fails, and that
+# is stated as lost coverage, not as a pass.
 DLM_INSTALLED = apps.is_installed("netbox_dlm")
 
 

--- a/forward_netbox/tests/test_fast_baseline.py
+++ b/forward_netbox/tests/test_fast_baseline.py
@@ -47,9 +47,9 @@ from forward_netbox.utilities.workload_state import PendingWorkloadState
 
 
 # The fast-baseline contracts cover ten models, four of which belong to
-# optional plugins that cannot be installed on NetBox 4.7 - each caps at a
-# max_version in the 4.6 series. Tests that build rows for those models can
-# only run where the plugin exists. Skipping is honest here in a way it would
+# optional plugins. netbox-dlm 0.10.0 installs on NetBox 4.7; netbox-routing
+# still caps at a max_version in the 4.6 series. Tests that build rows for
+# those models can only run where the plugin exists. Skipping is honest here in a way it would
 # not be for the core models: the contract for netbox_routing rows is not
 # WEAKER on 4.7, it is unreachable, because rows for an absent plugin are
 # refused before any contract is consulted.

--- a/forward_netbox/tests/test_optional_plugin_versions.py
+++ b/forward_netbox/tests/test_optional_plugin_versions.py
@@ -44,20 +44,18 @@ from forward_netbox.utilities.version_series import series_matches
 class OptionalDistributionVersionSetTest(SimpleTestCase):
     """The validated optional-distribution sets, whatever they currently hold.
 
-    On NetBox 4.7 they hold nothing. Every optional plugin - netbox-dlm,
-    netbox-cisco-aci, netbox-peering-manager, netbox-routing, netbox-validity -
-    declares a max_version in the 4.6 series, and NetBox refuses to start with a
-    plugin outside its declared range, so none of them can be installed on this
-    runtime at all. Claiming a validated version for a plugin nobody can install
-    would be a claim about a runtime nobody can assemble.
+    On NetBox 4.7 they hold one entry: netbox-dlm 0.10.0, the first release of
+    any optional plugin to raise its ceiling past 4.6.99. netbox-cisco-aci,
+    netbox-peering-manager, netbox-routing and netbox-validity still declare a
+    max_version in the 4.6 series, and NetBox refuses to start with a plugin
+    outside its declared range, so none of them can be installed on this
+    runtime. Claiming a validated version for a plugin nobody can install would
+    be a claim about a runtime nobody can assemble.
 
-    These assertions are therefore about the INVARIANTS rather than the
-    contents, so they keep working in both directions: they hold today with the
-    sets empty, and they hold the day an upstream raises its ceiling and entries
-    come back. The per-version assertions that used to live here (netbox-dlm
-    0.4.1 through 0.9.1) are recorded in
-    `docs/03_Plans/active/2026-09-02-netbox-4.7-runtime.md`, because those
-    versions were validated against 4.6 and none of them is evidence about 4.7.
+    The 4.6 validations of netbox-dlm 0.4.1 through 0.9.1 are deliberately NOT
+    carried over: they were evidence about 4.6, and none of those releases can
+    boot here anyway. They are recorded in
+    `docs/03_Plans/active/2026-09-02-netbox-4.7-runtime.md`.
     """
 
     def test_both_gates_read_the_same_declaration(self):
@@ -68,12 +66,13 @@ class OptionalDistributionVersionSetTest(SimpleTestCase):
             SET_BASED_MERGE_SUPPORTED_OPTIONAL_DISTRIBUTIONS,
         )
 
-    def test_no_distribution_is_validated_on_this_runtime(self):
+    def test_only_netbox_dlm_0_10_0_is_validated_on_this_runtime(self):
         self.assertEqual(
             dict(COPY_SQL_SUPPORTED_OPTIONAL_DISTRIBUTIONS),
-            {},
-            "an optional plugin cannot be installed on NetBox 4.7, so a "
-            "validated version for one is a claim about an unbuildable runtime",
+            {"netbox-dlm": frozenset({"0.10.0"})},
+            "the other four optional plugins cannot be installed on NetBox "
+            "4.7, so a validated version for one is a claim about an "
+            "unbuildable runtime; and no netbox-dlm before 0.10.0 can boot here",
         )
 
     def test_any_entry_that_returns_names_a_real_version(self):
@@ -118,13 +117,12 @@ class FastBaselineRuntimeTupleTest(SimpleTestCase):
             self.assertFalse(series_matches(version, "1.2"), version)
 
     def _decide(self, *, optional_plugins=None, plugin_apps=None, netbox="4.7.0"):
-        """A runtime tuple in the 4.7 shape: no optional plugin can be there.
+        """A runtime tuple in the 4.7 shape.
 
-        The old helper varied a netbox-dlm version, because on 4.6 that was the
-        thing customers changed under us. On 4.7 no optional plugin can be
-        installed at all, so the interesting variable is now whether an
-        UNEXPECTED app is present - which must fail closed exactly as a wrong
-        version did.
+        The default is the validated tuple: forward_netbox, Branching and
+        netbox-dlm 0.10.0. Two things can be varied under it - the netbox-dlm
+        version (the thing customers change under us) and whether an UNEXPECTED
+        app is present - and both must fail closed.
         """
         from forward_netbox.utilities import fast_baseline
 
@@ -132,9 +130,13 @@ class FastBaselineRuntimeTupleTest(SimpleTestCase):
             "netbox": netbox,
             "branching": "1.2.0",
             "forward_netbox": fast_baseline.forward_config.version,
-            "optional_plugins": optional_plugins or {},
+            "optional_plugins": (
+                {"netbox-dlm": "0.10.0"}
+                if optional_plugins is None
+                else optional_plugins
+            ),
             "plugin_apps": sorted(
-                plugin_apps or {"forward_netbox", "netbox_branching"}
+                plugin_apps or {"forward_netbox", "netbox_branching", "netbox_dlm"}
             ),
         }
         with patch.object(
@@ -152,12 +154,21 @@ class FastBaselineRuntimeTupleTest(SimpleTestCase):
             self._decide(netbox="4.7.9").reason_code, "unsupported_runtime_tuple"
         )
 
-    def test_an_optional_plugin_that_cannot_run_here_fails_closed(self):
-        # Nothing validates netbox-dlm on 4.7 - it cannot be installed - so a
-        # runtime reporting one is a runtime this was never checked against.
+    def test_a_netbox_dlm_validated_only_on_4_6_fails_closed(self):
+        # 0.9.1 was validated against 4.6 and cannot boot on 4.7. A runtime
+        # reporting it is one this was never checked against, whatever the
+        # 2.9.x lane says about the same version.
+        decision = self._decide(optional_plugins={"netbox-dlm": "0.9.1"})
+
+        self.assertFalse(decision.enabled)
+        self.assertEqual(decision.reason_code, "unsupported_runtime_tuple")
+
+    def test_netbox_dlm_absent_from_plugins_fails_closed(self):
+        # The set is an exact match in both directions: an app the validated
+        # tuple expects and PLUGINS lacks is as much a mismatch as a stranger.
         decision = self._decide(
-            optional_plugins={"netbox-dlm": "0.9.1"},
-            plugin_apps={"forward_netbox", "netbox_branching", "netbox_dlm"},
+            optional_plugins={},
+            plugin_apps={"forward_netbox", "netbox_branching"},
         )
 
         self.assertFalse(decision.enabled)
@@ -183,7 +194,9 @@ class FastBaselineRuntimeTupleTest(SimpleTestCase):
         ).context
 
         json.dumps(detail)
-        self.assertEqual(detail["expected"]["optional_plugins"], {})
+        self.assertEqual(
+            detail["expected"]["optional_plugins"], {"netbox-dlm": ["0.10.0"]}
+        )
 
 
 class FastBaselineFieldContractTest(SimpleTestCase):

--- a/forward_netbox/tests/test_plugin_integrations.py
+++ b/forward_netbox/tests/test_plugin_integrations.py
@@ -73,7 +73,7 @@ class OptionalPluginIntegrationRegistryTest(TestCase):
                 "netbox-routing": "0.4.3",
                 "netbox-peering-manager": "0.3.0",
                 "netbox-cisco-aci": "0.3.9",
-                "netbox-dlm": "0.9.1",
+                "netbox-dlm": "0.10.0",
                 "netbox-validity": "3.5.2",
             }
             return versions[package_name]
@@ -117,10 +117,10 @@ class OptionalPluginIntegrationRegistryTest(TestCase):
             "netbox-cisco-aci",
         )
         self.assertEqual(summary["aci.netbox_cisco_aci"]["required_version"], "0.4.0")
-        self.assertEqual(summary["lifecycle.netbox_dlm"]["required_version"], "0.9.1")
+        self.assertEqual(summary["lifecycle.netbox_dlm"]["required_version"], "0.10.0")
         self.assertEqual(
             summary["lifecycle.netbox_dlm"]["supported_versions"],
-            ["0.4.1", "0.5.0", "0.6.0", "0.7.0", "0.8.0", "0.9.1"],
+            ["0.4.1", "0.5.0", "0.6.0", "0.7.0", "0.8.0", "0.9.1", "0.10.0"],
         )
 
     def test_dlm_supported_versions_are_available_and_not_dropped(self):
@@ -168,7 +168,7 @@ class OptionalPluginIntegrationRegistryTest(TestCase):
             self.assertEqual(
                 capability["availability_reason"],
                 "Installed plugin version must equal one of: 0.4.1, 0.5.0, 0.6.0, 0.7.0, "
-                "0.8.0, 0.9.1.",
+                "0.8.0, 0.9.1, 0.10.0.",
             )
             fetcher = ForwardQueryFetcher(sync=Mock(), client=Mock(), logger_=Mock())
             self.assertEqual(

--- a/forward_netbox/tests/test_refused_deletes_are_not_staged.py
+++ b/forward_netbox/tests/test_refused_deletes_are_not_staged.py
@@ -41,10 +41,9 @@ from django.test import TestCase
 
 from forward_netbox.utilities.workload_state import _reference_protected_pks
 
-# netbox-dlm cannot be installed on NetBox 4.7: it declares a max_version in
-# the 4.6 series and NetBox refuses to start with a plugin outside its range.
-# These skip rather than fail, which IS lost coverage - the 4.6 lane on 2.9.x
-# is where the DLM paths stay exercised until that ceiling moves.
+# netbox-dlm 0.10.0 runs on NetBox 4.7, so these are exercised here again. The
+# guard stays: a runtime without the plugin skips rather than fails, and that
+# is stated as lost coverage, not as a pass.
 DLM_INSTALLED = apps.is_installed("netbox_dlm")
 
 

--- a/forward_netbox/tests/test_validated_runtime_is_declared_once.py
+++ b/forward_netbox/tests/test_validated_runtime_is_declared_once.py
@@ -114,10 +114,10 @@ class AddingAnIntegrationTakesOneEditTest(SimpleTestCase):
     def test_helpers_name_what_differs(self):
         from forward_netbox.utilities import validated_runtime
 
-        # Removes netbox_branching rather than an optional plugin: on NetBox 4.7
-        # no optional plugin is in the validated set, so dropping one would be a
-        # no-op and the assertion would pass without testing anything. Branching
-        # is always there, and its absence is the case that matters most.
+        # Removes netbox_branching rather than an optional plugin: the optional
+        # set on NetBox 4.7 is one entry, and a test that depended on it would
+        # go vacuous the day that entry moved. Branching is always there, and
+        # its absence is the case that matters most.
         installed = (VALIDATED_PLUGIN_APPS | {"stranger"}) - {"netbox_branching"}
 
         self.assertFalse(validated_runtime.validated_plugin_apps_match(installed))

--- a/forward_netbox/tests/test_workload_state.py
+++ b/forward_netbox/tests/test_workload_state.py
@@ -28,10 +28,9 @@ from forward_netbox.utilities.workload_state import encode_state_entries
 from forward_netbox.utilities.workload_state import promote_workload_states_locked
 from forward_netbox.utilities.workload_state import stage_workload_states
 
-# netbox-dlm cannot be installed on NetBox 4.7: it declares a max_version in
-# the 4.6 series and NetBox refuses to start with a plugin outside its range.
-# These skip rather than fail, which IS lost coverage - the 4.6 lane on 2.9.x
-# is where the DLM paths stay exercised until that ceiling moves.
+# netbox-dlm 0.10.0 runs on NetBox 4.7, so these are exercised here again. The
+# guard stays: a runtime without the plugin skips rather than fails, and that
+# is stated as lost coverage, not as a pass.
 DLM_INSTALLED = apps.is_installed("netbox_dlm")
 
 

--- a/forward_netbox/utilities/plugin_integrations/registry.py
+++ b/forward_netbox/utilities/plugin_integrations/registry.py
@@ -219,7 +219,7 @@ DLM_INTEGRATION = OptionalPluginIntegration(
     ),
     package_name="netbox-dlm",
     adapter_module="forward_netbox.utilities.sync_dlm",
-    required_package_version="0.9.1",
+    required_package_version="0.10.0",
     supported_package_versions=(
         "0.4.1",
         "0.5.0",
@@ -229,6 +229,10 @@ DLM_INTEGRATION = OptionalPluginIntegration(
         # 0.9.0 is skipped on purpose: it shipped with a NoReverseMatch on every
         # one of its view URLs and 0.9.1, half an hour later, is that fix.
         "0.9.1",
+        # 0.10.0 changes nothing but `__init__.py`: its own version, and
+        # `max_version` 4.6.99 -> 4.7.99. It is the only release that installs
+        # on NetBox 4.7.
+        "0.10.0",
     ),
     enabled_by_default=False,
     status="supported",

--- a/forward_netbox/utilities/validated_runtime.py
+++ b/forward_netbox/utilities/validated_runtime.py
@@ -31,12 +31,13 @@ VALIDATED_BRANCHING_SERIES = "1.2"
 
 # Plugin apps as they appear in `settings.PLUGINS`.
 #
-# On NetBox 4.7 this is forward_netbox and Branching, and nothing else. Every
-# optional integration - netbox-dlm 0.9.1, netbox-cisco-aci 0.4.0,
-# netbox-peering-manager 0.3.0, netbox-routing, netbox-validity 3.5.2 -
-# declares `max_version = "4.6.99"`, and NetBox refuses to start with a plugin
-# outside its declared range. They cannot be installed here, so listing them
-# would be a claim about a runtime nobody can assemble.
+# On NetBox 4.7 this is forward_netbox, Branching and netbox-dlm. netbox-dlm
+# 0.10.0 raised its ceiling to 4.7.99 on 2026-09-03 and is the first optional
+# integration back. The other four - netbox-cisco-aci 0.4.0,
+# netbox-peering-manager 0.3.0, netbox-routing 0.4.3, netbox-validity 3.5.2 -
+# still declare `max_version = "4.6.99"`, and NetBox refuses to start with a
+# plugin outside its declared range. They cannot be installed here, so listing
+# them would be a claim about a runtime nobody can assemble.
 #
 # This set is an EXACT match that fails closed and silently: an app present in
 # PLUGINS but absent here disables COPY/SQL, the set-based merge and the fast
@@ -48,19 +49,24 @@ VALIDATED_PLUGIN_APPS = frozenset(
     {
         "forward_netbox",
         "netbox_branching",
+        "netbox_dlm",
     }
 )
 
 # Distribution name -> every version validated against these subsystems, not a
 # single pin. An exact pin meant a customer upgrading one optional plugin
 # silently lost the fast paths, because the whole tuple stopped matching.
-# Empty on 4.7 for the reason above, not because the integrations were
-# removed: their registry, models and sync paths are all still here and still
-# report an absent plugin honestly. The 4.6 versions this set held are kept in
-# the 2.9.x line, and the values to restore are recorded in
+# Only netbox-dlm on 4.7, and only 0.10.0 of it: every earlier release caps at
+# 4.6.99, and the 4.6 validations of 0.4.1 through 0.9.1 are evidence about a
+# different runtime. The four absent integrations are not removed - their
+# registry, models and sync paths are all still here and still report an
+# absent plugin honestly. The 4.6 versions this set held are kept in the 2.9.x
+# line, and the values to restore are recorded in
 # `docs/03_Plans/active/2026-09-02-netbox-4.7-runtime.md` so regaining one is a
 # lookup rather than an archaeology exercise.
-VALIDATED_OPTIONAL_DISTRIBUTIONS: dict[str, frozenset[str]] = {}
+VALIDATED_OPTIONAL_DISTRIBUTIONS: dict[str, frozenset[str]] = {
+    "netbox-dlm": frozenset({"0.10.0"}),
+}
 
 # The distributions whose versions a runtime probe reports. Derived rather than
 # repeated: a name expected but never probed reads as ABSENT and fails the

--- a/poetry.lock
+++ b/poetry.lock
@@ -1573,15 +1573,15 @@ test = ["coverage[toml] (>=7.4)", "pytest (>=8.0)", "pytest-cov (>=4.1)", "pytes
 
 [[package]]
 name = "netbox-dlm"
-version = "0.9.1"
+version = "0.10.0"
 description = "Device/software/hardware lifecycle management plugin for NetBox"
 optional = true
 python-versions = ">=3.12"
 groups = ["main"]
 markers = "python_version >= \"3.12\" and (extra == \"dlm\" or extra == \"integrations\")"
 files = [
-    {file = "netbox_dlm-0.9.1-py3-none-any.whl", hash = "sha256:5104730d03eb2c5836789f037cb0aa7d24f9f8a6cb5fc5e60e18ce84657f7356"},
-    {file = "netbox_dlm-0.9.1.tar.gz", hash = "sha256:67a3782a7e9a15187b1b1963126f76a87458efc578ec99f21aec55718a9d10e1"},
+    {file = "netbox_dlm-0.10.0-py3-none-any.whl", hash = "sha256:de6d72eb663ec8320c371983d8da32d6d5220d0606ec791134699a3f388bef44"},
+    {file = "netbox_dlm-0.10.0.tar.gz", hash = "sha256:6fb4bc060f921921c1aba8f2ab70ac9ddedc1ebb7b630f74d17f5aae2dddfa6b"},
 ]
 
 [package.dependencies]
@@ -2829,4 +2829,4 @@ validity = ["netbox-validity"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "c497a528f378ce8c2240023ebcf0c46607ccc26421fefdde687188a6e86862d3"
+content-hash = "bac10503a7d8b778c59093aa830fb70c8b374b260b18bff6381df0a22e1542c5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ python = ">=3.10,<3.15"
 # `requires-python` to >=3.12. Without the marker poetry has to satisfy this
 # dependency all the way down to our own 3.10 floor and therefore resolves to
 # 0.8.0, pinning us a release behind with no error to read.
-netbox-dlm = {version = ">=0.4.1,<0.10.0", optional = true, python = ">=3.12,<3.15"}
+netbox-dlm = {version = ">=0.4.1,<0.11.0", optional = true, python = ">=3.12,<3.15"}
 netbox-routing = {version = "0.4.3", optional = true, python = ">=3.12,<3.15"}
 netbox-cisco-aci = {version = "0.4.0", optional = true, python = ">=3.12,<3.15"}
 netbox-peering-manager = {version = "0.3.0", optional = true, python = ">=3.12,<3.15"}

--- a/scripts/validate_sbom.py
+++ b/scripts/validate_sbom.py
@@ -11,8 +11,10 @@ REQUIRED_COMPONENTS = {
     "forward-netbox": None,
     "httpx": "0.28.1",
     "netbox": "4.7.0",
-    # The five optional plugins are absent on 4.7: each declares
-    # a max_version in the 4.6 series, so the artifact cannot contain them.
+    # netbox-dlm 0.10.0 is the one optional plugin that runs on 4.7. The other
+    # four each declare a max_version in the 4.6 series, so the artifact cannot
+    # contain them.
+    "netbox-dlm": "0.10.0",
     "netboxlabs-netbox-branching": "1.2.0",
     "pyzipper": "0.4.0",
 }

--- a/tasks.py
+++ b/tasks.py
@@ -1266,11 +1266,13 @@ def artifact_test(context):
             "'requires-python = \">=3.14,<3.15\"' "
             "'dependencies = [' "
             f"'  \"forward-netbox=={version}\",' "
-            # The five optional plugins are NOT listed on NetBox 4.7: each caps
-            # at a max_version in the 4.6 series, so none of them is installed
-            # in the artifact and naming them would put components in the SBOM
-            # that the image does not contain.
-            "']' " "> /tmp/netbox-runtime-pyproject.toml",
+            # netbox-dlm 0.10.0 is the one optional plugin installed on NetBox
+            # 4.7. The other four each cap at a max_version in the 4.6 series,
+            # so none of them is in the artifact and naming them would put
+            # components in the SBOM that the image does not contain.
+            "'  \"netbox-dlm==0.10.0\",' "
+            "']' "
+            "> /tmp/netbox-runtime-pyproject.toml",
             "UV_CACHE_DIR=/tmp/uv-cache uv tool run --isolated "
             f"--from cyclonedx-bom=={CYCLONEDX_BOM_VERSION} "
             "cyclonedx-py environment "


### PR DESCRIPTION
## What

netbox-dlm 0.10.0 (released 2026-09-03) declares `max_version = "4.7.99"` — the first optional plugin to raise its ceiling past 4.6. This brings it back on the 4.7 lane: image, dev `PLUGINS`, SBOM, both registry version fields, and `validated_runtime.py`.

Wheel diff, 0.9.1 → 0.10.0: **`netbox_dlm/__init__.py` only** (version string, `max_version`). No model, migration, URL or view moved.

## Decisions

- **Only 0.10.0 is validated on 4.7.** 0.4.1–0.9.1 were validated against 4.6 and cannot boot here; carrying them over would be evidence about a runtime this lane does not run.
- **The exact match is pinned in both directions.** 0.9.1 fails closed; so does a `PLUGINS` list that lacks `netbox_dlm`. A 3.x deployment that skips DLM now mismatches the validated tuple — that is how the module is designed and it is stated in the plan's `## Open`.
- **From-side pins 0.10.0, not 0.9.1.** The upgrade leg shares the Dockerfile and `plugins.py`, so the from-side must install a DLM that boots on 4.7. Satisfiable because it installs the bare plugin, not the `dlm` extra, so 3.0.0's `<0.10.0` cap does not reach it.

## Evidence

Full Django suite on the 4.7 image with 0.10.0 installed and enabled: **2649 tests, OK, 94 skipped** (3.0.0: 2589 tests, 158 skipped — the five DLM-guarded suites run again). `scripts/tests` 400 passed; pre-commit clean; harness passed.

Plan: `docs/03_Plans/active/2026-09-05-netbox-dlm-0-10-0-on-4-7.md`. Sibling change on the 4.6 lane: `chore/netbox-dlm-0-10-0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DczGsTTkuwULnpcYX4qui6
