### PR TITLE
chore: admit netbox-dlm 0.10.0 on the 4.6 lane

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -8,7 +8,7 @@
 cryptography==50.0.0
 httpx==0.28.1
 netbox-cisco-aci==0.4.0
-netbox-dlm==0.9.1
+netbox-dlm==0.10.0
 netboxlabs-netbox-branching==1.1.3
 netbox-peering-manager==0.3.0
 netbox-routing==0.4.3

--- a/development/constraints-upgrade-from.txt
+++ b/development/constraints-upgrade-from.txt
@@ -15,13 +15,12 @@
 # Branching is deliberately absent: the previous release's own metadata pins it,
 # and letting that resolve is the point.
 #
-# `netbox-dlm` diverged here for one release and no longer does. The rule is
-# that this side holds the newest version the FROM release supports: while the
-# FROM release was 2.7.13, which declares `netbox-dlm >=0.4.1,<0.9.0`, pinning
-# 0.9.1 was unsatisfiable rather than merely old, so it was held at 0.8.0. The
-# FROM release is now 2.8.0, which declares `>=0.4.1,<0.10.0` and supports
-# 0.9.1, so the divergence has lapsed and the pin returns to matching
-# `constraints.txt`.
+# `netbox-dlm` diverges here again. The rule is that this side holds the
+# newest version the FROM release supports: the FROM release is 2.9.2, which
+# declares `netbox-dlm >=0.4.1,<0.10.0`, so pinning 0.10.0 would be
+# unsatisfiable rather than merely old. It is held at 0.9.1 until the FROM
+# release is one that admits 0.10.0. (The same thing happened at 2.7.13 ->
+# 2.8.0, when 0.9.1 was held at 0.8.0.)
 #
 # Re-check this on any release that widens an optional plugin's range: the
 # entry has to move back down the moment the FROM release cannot satisfy it.

--- a/docs/03_Plans/active/2026-09-05-netbox-dlm-0-10-0.md
+++ b/docs/03_Plans/active/2026-09-05-netbox-dlm-0-10-0.md
@@ -1,0 +1,109 @@
+# Move the optional netbox-dlm pin to 0.10.0
+
+## Goal
+
+Support netbox-dlm 0.10.0 across every gate that reads an optional-plugin
+version, so a customer who upgrades the plugin keeps the fast baseline, the
+set-based merge and the COPY/SQL path instead of silently dropping to the slow
+paths.
+
+## Why
+
+netbox-dlm 0.10.0 was released upstream on 2026-09-03, by the same operator who
+runs the largest deployment of this plugin. It declares NetBox
+`min_version = "4.5.0"`, `max_version = "4.7.99"`, so it installs on the 4.6
+lane this branch serves. `validated_runtime.py` is an exact match that fails
+closed: with 0.10.0 installed and absent from the set, COPY/SQL, the set-based
+merge and the fast baseline all switch off with no error anywhere, and a first
+sync goes from minutes to hours. That is the failure the module's own docstring
+was written about.
+
+## Constraints
+
+- The validated sets are additive and fail closed. Widening them is a claim
+  that a version was inspected, so each addition needs a stated reason.
+- Both of `registry.py`'s version fields move together, and
+  `constraints-upgrade-from.txt` holds the newest version the FROM release
+  supports - which is 0.9.1, because 2.9.2 declares `<0.10.0`. Pinning 0.10.0
+  there would be unsatisfiable, not stale.
+- No production behaviour changes here. This is a pin move; the only way it can
+  be wrong is by admitting a version that breaks the adapter.
+
+## Approach
+
+### Is 0.10.0 safe for the surface we bind to
+
+Yes, and the check is stronger than the one that admitted 0.9.1. The two
+wheels were unpacked and diffed: **the only file that differs is
+`netbox_dlm/__init__.py`**, and the delta is the version string and
+`max_version = "4.6.99"` becoming `"4.7.99"`. No model, migration, URL, view or
+filterset changed. `requires-python` stays `>=3.12`; the `python` marker added
+for 0.9.1 still does its job.
+
+### What it means for the two lanes
+
+- **`maint/2.9.x` (this branch, NetBox 4.6):** 0.10.0 runs here, so the gates
+  must admit it or the operator who wrote it loses the fast paths on upgrade.
+- **`main` (NetBox 4.7):** 0.10.0 is the *only* netbox-dlm that can install at
+  all, because every earlier release caps at 4.6.99. The same pin move is what
+  unblocks optional plugins on 3.0.x; it is a separate change on that branch.
+
+## Touched Surfaces
+
+- `pyproject.toml` - range widened to `<0.11.0`
+- `poetry.lock` - 0.10.0
+- `constraints.txt` - 0.10.0
+- `development/constraints-upgrade-from.txt` - stays 0.9.1, note updated
+- `forward_netbox/utilities/plugin_integrations/registry.py` - both version
+  fields
+- `forward_netbox/utilities/validated_runtime.py` - the one validated set
+- `scripts/validate_sbom.py`, `tasks.py` - the SBOM pins
+- `forward_netbox/utilities/fast_baseline.py` - the evidence list sorts numerically
+- `forward_netbox/tests/test_optional_plugin_versions.py`,
+  `forward_netbox/tests/test_plugin_integrations.py`
+
+## Validation
+
+- `test_optional_plugin_versions` asserts 0.10.0 is in every gate's set and
+  that 0.9.0 is still not.
+- `test_plugin_integrations` asserts the registry reports 0.10.0 as required
+  and lists it as supported.
+- `scripts/tests` covers the constraints/upgrade-from lockstep invariant.
+- The full Django suite, run with 0.10.0 actually installed in the container
+  (the dev image installs from `constraints.txt`), is what proves the DLM
+  adapter still round-trips. The version sets are only a gate; they do not
+  exercise a single write.
+
+## Rollback
+
+Revert. The pin returns to 0.9.1 and the gates refuse 0.10.0 again, which is
+the fail-closed direction.
+
+### One thing the suite found
+
+`test_the_rejection_detail_stays_serialisable` failed on the first run: the
+fast-baseline rejection evidence renders the validated versions with a plain
+string sort, so admitting 0.10.0 put it at the HEAD of the list - before
+0.4.1. That list is persisted as job evidence and read by people, and
+"0.10.0, 0.4.1, ..." reads as a typo rather than as the newest entry. The
+renderer now sorts numerically. A two-line change in `fast_baseline.py`,
+and the first time any validated set held a two-digit component.
+
+## Decision Log
+
+- **Widen to `<0.11.0`, not `<0.10.1`.** The gates already enumerate exact
+  validated versions and fail closed, so the range does not need to be the
+  thing that refuses an unvalidated 0.10.x.
+- **Hold `constraints-upgrade-from.txt` at 0.9.1.** That side pins what the
+  FROM release supports, and 2.9.2 caps netbox-dlm below 0.10.0. The comment
+  in that file records the rule so the next widening does not have to
+  rediscover it.
+- **Diff the wheels rather than read the changelog.** A one-file delta is a
+  fact; "4.7 support" is a description of it.
+
+## Open
+
+- The 0.9.1 plan noted that netbox-dlm and this plugin shared a 4.6.99 ceiling
+  and whichever moved first would block the other. netbox-dlm moved first, to
+  4.7.99, and it did not block us: 3.0.0 raised our own ceiling on `main` the
+  day before. Closed by events.

--- a/forward_netbox/tests/test_optional_plugin_versions.py
+++ b/forward_netbox/tests/test_optional_plugin_versions.py
@@ -50,6 +50,7 @@ class OptionalDistributionVersionSetTest(SimpleTestCase):
                 self.assertIn("0.6.0", supported["netbox-dlm"])
                 self.assertIn("0.8.0", supported["netbox-dlm"])
                 self.assertIn("0.9.1", supported["netbox-dlm"])
+                self.assertIn("0.10.0", supported["netbox-dlm"])
 
     def test_an_unvalidated_version_is_still_refused(self):
         # The gates fail closed; widening must not become "any version".
@@ -186,7 +187,7 @@ class FastBaselineRuntimeTupleTest(SimpleTestCase):
         json.dumps(detail)
         self.assertEqual(
             detail["expected"]["optional_plugins"]["netbox-dlm"],
-            ["0.4.1", "0.5.0", "0.6.0", "0.7.0", "0.8.0", "0.9.1"],
+            ["0.4.1", "0.5.0", "0.6.0", "0.7.0", "0.8.0", "0.9.1", "0.10.0"],
         )
 
 

--- a/forward_netbox/tests/test_plugin_integrations.py
+++ b/forward_netbox/tests/test_plugin_integrations.py
@@ -73,7 +73,7 @@ class OptionalPluginIntegrationRegistryTest(TestCase):
                 "netbox-routing": "0.4.3",
                 "netbox-peering-manager": "0.3.0",
                 "netbox-cisco-aci": "0.3.9",
-                "netbox-dlm": "0.9.1",
+                "netbox-dlm": "0.10.0",
                 "netbox-validity": "3.5.2",
             }
             return versions[package_name]
@@ -117,10 +117,10 @@ class OptionalPluginIntegrationRegistryTest(TestCase):
             "netbox-cisco-aci",
         )
         self.assertEqual(summary["aci.netbox_cisco_aci"]["required_version"], "0.4.0")
-        self.assertEqual(summary["lifecycle.netbox_dlm"]["required_version"], "0.9.1")
+        self.assertEqual(summary["lifecycle.netbox_dlm"]["required_version"], "0.10.0")
         self.assertEqual(
             summary["lifecycle.netbox_dlm"]["supported_versions"],
-            ["0.4.1", "0.5.0", "0.6.0", "0.7.0", "0.8.0", "0.9.1"],
+            ["0.4.1", "0.5.0", "0.6.0", "0.7.0", "0.8.0", "0.9.1", "0.10.0"],
         )
 
     def test_dlm_supported_versions_are_available_and_not_dropped(self):
@@ -168,7 +168,7 @@ class OptionalPluginIntegrationRegistryTest(TestCase):
             self.assertEqual(
                 capability["availability_reason"],
                 "Installed plugin version must equal one of: 0.4.1, 0.5.0, 0.6.0, 0.7.0, "
-                "0.8.0, 0.9.1.",
+                "0.8.0, 0.9.1, 0.10.0.",
             )
             fetcher = ForwardQueryFetcher(sync=Mock(), client=Mock(), logger_=Mock())
             self.assertEqual(

--- a/forward_netbox/utilities/fast_baseline.py
+++ b/forward_netbox/utilities/fast_baseline.py
@@ -196,6 +196,24 @@ def fast_baseline_runtime_tuple():
     }
 
 
+def _version_sort_key(version):
+    """Sort versions numerically, so 0.10.0 lands after 0.9.1, not before 0.4.1.
+
+    This list is persisted as job evidence and read by people. A plain string
+    sort put netbox-dlm 0.10.0 at the head of the validated list the moment it
+    was admitted, which reads as a typo rather than as the newest entry.
+    """
+    parts = []
+    for part in str(version).split("."):
+        digits = ""
+        for ch in part:
+            if not ch.isdigit():
+                break
+            digits += ch
+        parts.append((int(digits) if digits else -1, part))
+    return tuple(parts)
+
+
 def _runtime_decision():
     actual = fast_baseline_runtime_tuple()
     expected = {
@@ -228,7 +246,7 @@ def _runtime_decision():
                 "expected": {
                     **expected,
                     "optional_plugins": {
-                        name: sorted(versions)
+                        name: sorted(versions, key=_version_sort_key)
                         for name, versions in expected["optional_plugins"].items()
                     },
                 },

--- a/forward_netbox/utilities/plugin_integrations/registry.py
+++ b/forward_netbox/utilities/plugin_integrations/registry.py
@@ -219,7 +219,7 @@ DLM_INTEGRATION = OptionalPluginIntegration(
     ),
     package_name="netbox-dlm",
     adapter_module="forward_netbox.utilities.sync_dlm",
-    required_package_version="0.9.1",
+    required_package_version="0.10.0",
     supported_package_versions=(
         "0.4.1",
         "0.5.0",
@@ -229,6 +229,9 @@ DLM_INTEGRATION = OptionalPluginIntegration(
         # 0.9.0 is skipped on purpose: it shipped with a NoReverseMatch on every
         # one of its view URLs and 0.9.1, half an hour later, is that fix.
         "0.9.1",
+        # 0.10.0 changes nothing but `__init__.py`: its own version, and
+        # `max_version` 4.6.99 -> 4.7.99. No model, migration or URL moved.
+        "0.10.0",
     ),
     enabled_by_default=False,
     status="supported",

--- a/forward_netbox/utilities/validated_runtime.py
+++ b/forward_netbox/utilities/validated_runtime.py
@@ -54,7 +54,9 @@ VALIDATED_PLUGIN_APPS = frozenset(
 # silently lost the fast paths, because the whole tuple stopped matching.
 VALIDATED_OPTIONAL_DISTRIBUTIONS = {
     "netbox-cisco-aci": frozenset({"0.4.0"}),
-    "netbox-dlm": frozenset({"0.4.1", "0.5.0", "0.6.0", "0.7.0", "0.8.0", "0.9.1"}),
+    "netbox-dlm": frozenset(
+        {"0.4.1", "0.5.0", "0.6.0", "0.7.0", "0.8.0", "0.9.1", "0.10.0"}
+    ),
     "netbox-peering-manager": frozenset({"0.3.0"}),
     "netbox-routing": frozenset({"0.4.3"}),
     "netbox-validity": frozenset({"3.5.2"}),

--- a/poetry.lock
+++ b/poetry.lock
@@ -1573,15 +1573,15 @@ test = ["coverage[toml] (>=7.4)", "pytest (>=8.0)", "pytest-cov (>=4.1)", "pytes
 
 [[package]]
 name = "netbox-dlm"
-version = "0.9.1"
+version = "0.10.0"
 description = "Device/software/hardware lifecycle management plugin for NetBox"
 optional = true
 python-versions = ">=3.12"
 groups = ["main"]
 markers = "python_version >= \"3.12\" and (extra == \"dlm\" or extra == \"integrations\")"
 files = [
-    {file = "netbox_dlm-0.9.1-py3-none-any.whl", hash = "sha256:5104730d03eb2c5836789f037cb0aa7d24f9f8a6cb5fc5e60e18ce84657f7356"},
-    {file = "netbox_dlm-0.9.1.tar.gz", hash = "sha256:67a3782a7e9a15187b1b1963126f76a87458efc578ec99f21aec55718a9d10e1"},
+    {file = "netbox_dlm-0.10.0-py3-none-any.whl", hash = "sha256:de6d72eb663ec8320c371983d8da32d6d5220d0606ec791134699a3f388bef44"},
+    {file = "netbox_dlm-0.10.0.tar.gz", hash = "sha256:6fb4bc060f921921c1aba8f2ab70ac9ddedc1ebb7b630f74d17f5aae2dddfa6b"},
 ]
 
 [package.dependencies]
@@ -2828,4 +2828,4 @@ validity = ["netbox-validity"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "85ce462fb1513abcd88578cbf0b8b87ecd62e3c60752f4fed475c44d39c228bc"
+content-hash = "533f6566b34c00f39503f2164195aa8ee869914cb246d956900b7fd7e3d98b7f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ python = ">=3.10,<3.15"
 # `requires-python` to >=3.12. Without the marker poetry has to satisfy this
 # dependency all the way down to our own 3.10 floor and therefore resolves to
 # 0.8.0, pinning us a release behind with no error to read.
-netbox-dlm = {version = ">=0.4.1,<0.10.0", optional = true, python = ">=3.12,<3.15"}
+netbox-dlm = {version = ">=0.4.1,<0.11.0", optional = true, python = ">=3.12,<3.15"}
 netbox-routing = {version = "0.4.3", optional = true, python = ">=3.12,<3.15"}
 netbox-cisco-aci = {version = "0.4.0", optional = true, python = ">=3.12,<3.15"}
 netbox-peering-manager = {version = "0.3.0", optional = true, python = ">=3.12,<3.15"}

--- a/scripts/validate_sbom.py
+++ b/scripts/validate_sbom.py
@@ -12,7 +12,7 @@ REQUIRED_COMPONENTS = {
     "httpx": "0.28.1",
     "netbox": "4.6.8",
     "netbox-cisco-aci": "0.4.0",
-    "netbox-dlm": "0.9.1",
+    "netbox-dlm": "0.10.0",
     "netbox-peering-manager": "0.3.0",
     "netbox-routing": "0.4.3",
     "netbox-validity": "3.5.2",

--- a/tasks.py
+++ b/tasks.py
@@ -1247,7 +1247,7 @@ def artifact_test(context):
             "'dependencies = [' "
             f"'  \"forward-netbox=={version}\",' "
             "'  \"netbox-cisco-aci==0.4.0\",' "
-            "'  \"netbox-dlm==0.9.1\",' "
+            "'  \"netbox-dlm==0.10.0\",' "
             "'  \"netbox-peering-manager==0.3.0\",' "
             "'  \"netbox-routing==0.4.3\",' "
             "'  \"netbox-validity==3.5.2\",' "


### PR DESCRIPTION
## What

netbox-dlm 0.10.0 (released 2026-09-03) declares NetBox `4.5.0`–`4.7.99`, so it installs on the 4.6 lane. Every runtime gate here is an exact match that fails closed: with 0.10.0 installed and absent from the validated set, COPY/SQL, the set-based merge and the fast baseline all switch off with **no error anywhere**, and a first sync goes from minutes to hours. The operator who wrote 0.10.0 runs the largest deployment of this plugin.

Wheel diff, 0.9.1 → 0.10.0: **`netbox_dlm/__init__.py` only** (version string, `max_version`). No model, migration, URL or view moved — the surface we bind to is byte-identical.

## One thing the suite found

`test_the_rejection_detail_stays_serialisable` failed on the first run: the fast-baseline rejection evidence renders the validated list with a string sort, so 0.10.0 landed at its **head**, before 0.4.1 — the first time any validated set held a two-digit component. That list is persisted job evidence read by people. It sorts numerically now (`_version_sort_key` in `fast_baseline.py`).

## Decisions

- `constraints-upgrade-from.txt` **stays at 0.9.1**: it pins what the FROM release (2.9.2, `<0.10.0`) can install; 0.10.0 there would be unsatisfiable, not stale. The comment now records the rule.
- Range widened to `<0.11.0`; the gates enumerate exact versions and fail closed, so the range is not the thing that refuses an unvalidated 0.10.x.

## Evidence

Full Django suite with 0.10.0 installed in the container (verified `netbox_dlm.config.max_version == "4.7.99"` in the running image): **2587 tests, 1 failure** — the sort finding above. After the fix, the three affected modules re-run: **33 tests, OK**. `scripts/tests` 390 passed; pre-commit clean; harness passed.

Plan: `docs/03_Plans/active/2026-09-05-netbox-dlm-0-10-0.md`. Sibling change on `main`: #364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DczGsTTkuwULnpcYX4qui6
