### PR TITLE
release: ship v2.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Generated from the README compatibility table by `scripts/gen_changelog.py`. Do not edit by hand.
 
+## v2.9.3
+
+Release candidate; Fix: **OSPF interface rows converge instead of drifting forever**, and the interface lookup behind MAC-address apply uses an index instead of scanning every interface in the estate. Feature: **netbox-dlm `0.10.0` is supported**. No migration; upgrade and re-run the sync.
+
 ## v2.9.2
 
 Drift is measured exactly for every fetched model, the uncovered-device count says why it grows and warns when it does, and five delete and diagnostic defects are closed.

--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ See the
 
 ## Release Compatibility
 
-The `2.9.2` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
+The `2.9.3` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
+| `v2.9.3` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Fix: **OSPF interface rows converge instead of drifting forever**, and the interface lookup behind MAC-address apply uses an index instead of scanning every interface in the estate. Feature: **netbox-dlm `0.10.0` is supported**. No migration; upgrade and re-run the sync. |
 | `v2.9.2` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Drift is measured exactly for every fetched model, the uncovered-device count says why it grows and warns when it does, and five delete and diagnostic defects are closed. |
 | `v2.9.1` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.2`; Accepts netbox-branching 1.1.3 and records the validated runtime in the lockfile. |
 | `v2.9.0` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.1`; Feature: back up device configurations from Forward into a git data source for Validity golden-config checks, plus the runtime-validation refactor and health check it required. |

--- a/docs/01_User_Guide/README.md
+++ b/docs/01_User_Guide/README.md
@@ -70,13 +70,14 @@ migrations, e.g. netbox-dlm `0.2.0+`; older builds need
 
 ## Release Compatibility
 
-The `2.9.2` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
+The `2.9.3` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
+| `v2.9.3` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Fix: **OSPF interface rows converge instead of drifting forever**, and the interface lookup behind MAC-address apply uses an index instead of scanning every interface in the estate. Feature: **netbox-dlm `0.10.0` is supported**. No migration; upgrade and re-run the sync. |
 | `v2.9.2` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Drift is measured exactly for every fetched model, the uncovered-device count says why it grows and warns when it does, and five delete and diagnostic defects are closed. |
 | `v2.9.1` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.2`; Accepts netbox-branching 1.1.3 and records the validated runtime in the lockfile. |
 | `v2.9.0` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.1`; Feature: back up device configurations from Forward into a git data source for Validity golden-config checks, plus the runtime-validation refactor and health check it required. |

--- a/docs/03_Plans/active/2026-09-05-release-2.9.3.md
+++ b/docs/03_Plans/active/2026-09-05-release-2.9.3.md
@@ -1,0 +1,102 @@
+# Release 2.9.3
+
+## Goal
+
+Ship the first release cut from the `maint/2.9.x` maintenance lane: two
+convergence and cost defects found on a customer's live estate, support for
+netbox-dlm 0.10.0, and the release-resume tooling this lane needs to cut a
+release without restarting one.
+
+## Constraints
+
+- **This is the lane's first release.** Every gate reads
+  `scripts/release_lane.py` rather than assuming `main` (#360), and the
+  resume fixes backported in #366 are what make a failure after the ~45-minute
+  gate recoverable. Both are exercised for the first time by this release.
+- **NetBox 4.6 only.** 2.9.x is the 4.6 lane; `main` is 4.7 from 3.0.0. The
+  lane declares `series="2.9"`, so `require_version_in_lane` refuses a 3.x
+  version from this checkout before any stage touches git.
+- **No migration.** Nothing here changes schema state.
+- The release commit's plan must carry `## Release Authorization` bound to the
+  tagged commit's parent, or the version number is burned.
+
+## Touched Surfaces
+
+Four merged pull requests, each independently gated:
+
+| PR | Change |
+|---|---|
+| #362 | OSPF interface rows that no sync can resolve, plus the apply/compare round trip |
+| #363 | The interface lookup an index can actually serve |
+| #365 | netbox-dlm 0.10.0 admitted to every runtime gate |
+| #366 | The release-resume backport (#358, #359) with lane parameterisation |
+
+Plus the version surfaces `stage_prepare` moves, including
+`fast_baseline.py`'s runtime pin - which must move in the same change as the
+version bump or the fast baseline silently reverts to the slow path.
+
+## Approach
+
+Ordered so the tooling that cuts the release landed before the release used
+it: convergence first, then cost, then the plugin pin, then the backport.
+
+**The two customer-facing fixes came from one drift report and had different
+causes.** `forward_ospf_interfaces.nqe` emits one row per neighbour while
+`ensure_ospf_interface` coalesces one object per interface, so N neighbours
+produced N-1 phantom updates that no sync could ever resolve - 180 drifted
+rows on the reporting estate. Separately, the interface lookup behind the
+MAC-address apply built an OR-tree of up to 500 `Q(device__name=..., name__in=[...])`
+branches, which Postgres cannot index, so each chunk scanned all 360,771
+interfaces - about 248 times, for the 247 seconds of SQL the customer saw.
+
+**A third reported number is not fixed and is not claimed to be.**
+`netbox_routing.bgppeer` showed 126 drift candidates. Eleven peer shapes now
+round-trip through the full sync path and all converge, so the standard path
+is not the cause; see `## Open`.
+
+## Validation
+
+Recorded in the Release Authorization section below, rendered by
+`scripts/release.py --authorize` from the evidence the gate itself wrote.
+
+Before the release branch existed, each merged pull request carried its own
+full Django suite on the isolated stack: #362 and #363 at 2617 tests, #365 at
+2587 with one finding fixed and re-run, #366 at 2628 with 9 skipped on the
+combined four-commit lane.
+
+## Rollback
+
+Revert to 2.9.2. No migration ships, so the downgrade is the upgrade in
+reverse. The netbox-dlm pin returning to `<0.10.0` is the fail-closed
+direction: a deployment on 0.10.0 loses the fast paths rather than running
+them unvalidated.
+
+## Decision Log
+
+- **The backport landed before the release rather than after.** 2.9.3 is the
+  first release through this lane, which is the worst place to discover that a
+  bookkeeping failure after the gate means re-paying the gate. v3.0.0 took
+  fourteen attempts on exactly that.
+- **`_text_on_main` became `_text_on_lane` rather than being re-pointed.** On
+  this branch a check against `origin/main` answers NO forever, so the
+  idempotency would have been absent with nothing reporting it.
+- **netbox-dlm 0.10.0 was admitted on evidence, not on its changelog.** The
+  two wheels were unpacked and diffed: `netbox_dlm/__init__.py` only.
+- **The BGP peer count is reported open rather than guessed at.** Shipping a
+  speculative fix for 126 rows nobody can reproduce would be a change whose
+  effect cannot be measured.
+
+## Open
+
+- **`netbox_routing.bgppeer`'s 126 drift candidates are unexplained.** Ruled
+  out: volatile counters (fixed in 2.8.x), ambiguous addresses (counted
+  rejected, not drift), and the OSPF-style row/object mismatch. Eleven shapes
+  round-trip cleanly through the real apply. Diagnosing it needs the actual
+  rows from the reporting deployment, or a drift report that names its own
+  drifted rows per model - which is a feature this release does not add.
+- **The two lanes now carry two copies of the resume helpers**, differing only
+  in how they name the branch. Same shape as `release_lane.py` itself, and the
+  same merge hazard: a change to the resume logic has to be made twice.
+- **Sensitive-pattern parity.** The release-only feed is a superset of the
+  local one, so this gate can pass content the publish workflow refuses. That
+  refusal is the mechanism working, and it burns the version number.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,13 +8,14 @@ Forward 26.6 is the baseline for async NQE.
 
 ## Release Compatibility
 
-The `2.9.2` release requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and release notes.
+The `2.9.3` release candidate requires NetBox `4.6.x` (>= `4.6.5`, tested on `4.6.8`) and `netbox-branching` `1.1.x` (tested on `1.1.2`). Expand for the published release history and candidate notes.
 
 <details>
 <summary>Release compatibility history</summary>
 
 | Plugin Release | NetBox Version | Status |
 | --- | --- | --- |
+| `v2.9.3` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Release candidate; Fix: **OSPF interface rows converge instead of drifting forever**, and the interface lookup behind MAC-address apply uses an index instead of scanning every interface in the estate. Feature: **netbox-dlm `0.10.0` is supported**. No migration; upgrade and re-run the sync. |
 | `v2.9.2` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Current release; Drift is measured exactly for every fetched model, the uncovered-device count says why it grows and warns when it does, and five delete and diagnostic defects are closed. |
 | `v2.9.1` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.2`; Accepts netbox-branching 1.1.3 and records the validated runtime in the lockfile. |
 | `v2.9.0` | `4.6.x` (>= `4.6.5`) supported, tested on `4.6.8`; needs netbox-branching `1.1.x`, tested on `1.1.2` | Superseded by `v2.9.1`; Feature: back up device configurations from Forward into a git data source for Validity golden-config checks, plus the runtime-validation refactor and health check it required. |

--- a/forward_netbox/__init__.py
+++ b/forward_netbox/__init__.py
@@ -5,7 +5,7 @@ class NetboxForwardConfig(PluginConfig):
     name = "forward_netbox"
     verbose_name = "Forward"
     description = "Sync Forward data into NetBox using built-in NQE queries."
-    version = "2.9.2"
+    version = "2.9.3"
     base_url = "forward"
     min_version = "4.6.5"
     max_version = "4.6.99"

--- a/forward_netbox/tests/test_runtime_dependency_check.py
+++ b/forward_netbox/tests/test_runtime_dependency_check.py
@@ -23,7 +23,7 @@ class RuntimeDependencyCheckTest(SimpleTestCase):
         self.assertIsNotNone(_resolved_branching_version())
 
     def test_plugin_config_version_matches_package_release(self):
-        self.assertEqual(NetboxForwardConfig.version, "2.9.2")
+        self.assertEqual(NetboxForwardConfig.version, "2.9.3")
 
     def test_exact_runtime_passes(self):
         _check_runtime_dependencies()

--- a/forward_netbox/utilities/fast_baseline.py
+++ b/forward_netbox/utilities/fast_baseline.py
@@ -219,7 +219,7 @@ def _runtime_decision():
     expected = {
         "netbox_series": VALIDATED_NETBOX_SERIES,
         "branching_series": VALIDATED_BRANCHING_SERIES,
-        "forward_netbox": "2.9.2",
+        "forward_netbox": "2.9.3",
         # Each optional distribution lists every version validated against this
         # engine, not a single pin. An exact pin meant a customer upgrading one
         # optional plugin silently lost the fast baseline — no error, just a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "forward-netbox"
-version = "2.9.2"
+version = "2.9.3"
 description = "NetBox plugin to sync Forward data into NetBox via built-in NQE queries"
 authors = ["Craig Johnson <craigjohnson@forwardnetworks.com>"]
 license = "MIT"


### PR DESCRIPTION
Production Release PR for v2.9.3. Required CI, CodeQL, and the trusted sensitive-content status must pass before squash merge.