### PR TITLE
docs: a release plan cannot quote the heading it is about

### DIFF
--- a/docs/03_Plans/active/2026-09-05-release-2.9.3.md
+++ b/docs/03_Plans/active/2026-09-05-release-2.9.3.md
@@ -17,8 +17,9 @@ release without restarting one.
   lane declares `series="2.9"`, so `require_version_in_lane` refuses a 3.x
   version from this checkout before any stage touches git.
 - **No migration.** Nothing here changes schema state.
-- The release commit's plan must carry `## Release Authorization` bound to the
-  tagged commit's parent, or the version number is burned.
+- The release commit's plan must carry a rendered authorization section bound
+  to the tagged commit's parent, or the version number is burned. That heading
+  is deliberately NOT spelled out here; see `## Open`.
 
 ## Touched Surfaces
 
@@ -100,3 +101,9 @@ them unvalidated.
 - **Sensitive-pattern parity.** The release-only feed is a superset of the
   local one, so this gate can pass content the publish workflow refuses. That
   refusal is the mechanism working, and it burns the version number.
+- **`stage_authorize` detects its own section by substring, not by heading.**
+  This plan quoted the heading name in its Constraints and the stage refused
+  to render, reporting that the plan "already carries a Release Authorization"
+  when it carried a sentence about needing one. Harmless here - it fails
+  closed and costs a commit, not a version - but a release plan cannot discuss
+  the section it is about. Matching a heading at line start would fix it.


### PR DESCRIPTION
`stage_authorize` tests `"## Release Authorization" in text` to decide whether a plan already carries its authorization. The 2.9.3 plan quoted that heading in its Constraints — as the rule the release must satisfy — so the stage refused to render, reporting the plan "already carries a Release Authorization" when it carried a sentence about needing one.

The wording moves so 2.9.3 can be authorized. The observation is recorded in the plan's `## Open`: the substring check is the brittle half, and matching a heading at line start would fix it. It fails closed and costs a commit rather than a version number, so this is a note rather than a change to the tooling mid-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DczGsTTkuwULnpcYX4qui6